### PR TITLE
Add project foundation: docs, Claude hooks, and dev tooling

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lattice — Claude Code session bootstrap
+# Installs required tooling for Elixir/Phoenix development on Fly.io.
+# Only runs in remote (web/headless) environments where tools aren't pre-installed.
+
+LOG_PREFIX="[lattice:session-start]"
+log() { echo "$LOG_PREFIX $*"; }
+
+# Skip in local environments where the developer has tools installed
+if [ -z "${CLAUDE_REMOTE:-}" ] && [ -z "${CODESPACES:-}" ] && [ -z "${GITPOD_WORKSPACE_ID:-}" ]; then
+  log "Local environment detected — skipping bootstrap"
+  exit 0
+fi
+
+log "Remote environment detected — installing tooling..."
+
+# --- GitHub CLI (gh) ---
+if ! command -v gh &>/dev/null; then
+  log "Installing GitHub CLI..."
+  GH_VERSION="2.74.0"
+  GH_ARCHIVE="gh_${GH_VERSION}_linux_amd64.tar.gz"
+  curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_ARCHIVE}" -o "/tmp/${GH_ARCHIVE}"
+  tar -xzf "/tmp/${GH_ARCHIVE}" -C /tmp
+  cp "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh 2>/dev/null \
+    || sudo cp "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh 2>/dev/null \
+    || { mkdir -p "$HOME/.local/bin" && cp "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" "$HOME/.local/bin/gh" && export PATH="$HOME/.local/bin:$PATH"; }
+  rm -rf "/tmp/${GH_ARCHIVE}" "/tmp/gh_${GH_VERSION}_linux_amd64"
+  log "GitHub CLI $(gh --version | head -1) installed"
+else
+  log "GitHub CLI already installed: $(gh --version | head -1)"
+fi
+
+# --- Erlang/OTP + Elixir via asdf ---
+install_asdf_and_languages() {
+  if ! command -v asdf &>/dev/null; then
+    log "Installing asdf version manager..."
+    git clone https://github.com/asdf-vm/asdf.git "$HOME/.asdf" --branch v0.16.0 2>/dev/null || true
+    # shellcheck disable=SC1091
+    . "$HOME/.asdf/asdf.sh"
+    export PATH="$HOME/.asdf/shims:$HOME/.asdf/bin:$PATH"
+  fi
+
+  if ! asdf plugin list 2>/dev/null | grep -q erlang; then
+    log "Adding asdf erlang plugin..."
+    asdf plugin add erlang https://github.com/asdf-vm/asdf-erlang.git
+  fi
+
+  if ! asdf plugin list 2>/dev/null | grep -q elixir; then
+    log "Adding asdf elixir plugin..."
+    asdf plugin add elixir https://github.com/asdf-vm/asdf-elixir.git
+  fi
+
+  # Install versions from .tool-versions if present, otherwise use defaults
+  local PROJECT_DIR
+  PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+  if [ -f "$PROJECT_DIR/.tool-versions" ]; then
+    log "Installing languages from .tool-versions..."
+    cd "$PROJECT_DIR"
+    asdf install
+  else
+    # Defaults — update these as needed
+    local ERLANG_VERSION="27.2.4"
+    local ELIXIR_VERSION="1.18.3-otp-27"
+
+    log "Installing Erlang/OTP $ERLANG_VERSION (this takes a few minutes)..."
+    # Minimal Erlang build — skip docs, GUI, and optional deps
+    export KERL_CONFIGURE_OPTIONS="--without-javac --without-wx --without-odbc --without-debugger --without-observer --without-et"
+    asdf install erlang "$ERLANG_VERSION" || {
+      log "WARNING: Erlang build failed — you may need build dependencies"
+      log "Try: apt-get install -y build-essential autoconf libncurses-dev libssl-dev"
+      return 1
+    }
+    asdf set --home erlang "$ERLANG_VERSION"
+
+    log "Installing Elixir $ELIXIR_VERSION..."
+    asdf install elixir "$ELIXIR_VERSION"
+    asdf set --home elixir "$ELIXIR_VERSION"
+  fi
+
+  log "Erlang: $(erl -noshell -eval 'io:format(erlang:system_info(otp_release)), halt().' 2>/dev/null || echo 'pending')"
+  log "Elixir: $(elixir --version 2>/dev/null | tail -1 || echo 'pending')"
+}
+
+# Check if Elixir is already available
+if ! command -v elixir &>/dev/null; then
+  # Check for build dependencies first
+  if command -v apt-get &>/dev/null; then
+    log "Installing Erlang/Elixir build dependencies..."
+    (sudo apt-get update -qq && sudo apt-get install -y -qq \
+      build-essential autoconf libncurses-dev libssl-dev libwxgtk-webview3.2-dev \
+      unzip curl 2>&1) | tail -1
+  fi
+  install_asdf_and_languages
+else
+  log "Elixir already installed: $(elixir --version | tail -1)"
+fi
+
+# --- Fly CLI (flyctl) ---
+if ! command -v flyctl &>/dev/null && ! command -v fly &>/dev/null; then
+  log "Installing Fly CLI..."
+  curl -fsSL https://fly.io/install.sh | sh 2>&1 | tail -3
+  export FLYCTL_INSTALL="$HOME/.fly"
+  export PATH="$FLYCTL_INSTALL/bin:$PATH"
+  log "Fly CLI installed: $(flyctl version 2>/dev/null || echo 'installed')"
+else
+  log "Fly CLI already installed: $(flyctl version 2>/dev/null || fly version 2>/dev/null)"
+fi
+
+# --- Hex + Rebar (Elixir package managers) ---
+if command -v mix &>/dev/null; then
+  log "Installing Hex and Rebar..."
+  mix local.hex --force --if-missing 2>/dev/null
+  mix local.rebar --force --if-missing 2>/dev/null
+  log "Hex and Rebar ready"
+fi
+
+# --- Project dependencies ---
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+if [ -f "$PROJECT_DIR/mix.exs" ]; then
+  log "Fetching project dependencies..."
+  cd "$PROJECT_DIR"
+  mix deps.get 2>&1 | tail -3
+  log "Dependencies fetched"
+fi
+
+log "Session bootstrap complete"

--- a/.claude/review-guidelines.md
+++ b/.claude/review-guidelines.md
@@ -1,0 +1,44 @@
+# Code Review Guidelines — Lattice
+
+Use these guidelines when reviewing PRs (automated or manual).
+
+## Highest Priority: Vertical Slice Completeness
+
+Every PR must be a complete vertical slice. Check:
+
+- [ ] Feature works end-to-end (not just backend or just frontend)
+- [ ] Tests cover the new behavior
+- [ ] No manual steps required post-merge
+- [ ] LiveView updates in real-time (no polling patterns)
+- [ ] Telemetry events emitted for state changes
+
+## Architecture
+
+- **Capabilities are behaviours.** External system access must go through a behaviour module, never direct API calls in business logic.
+- **GenServer state is a struct.** No bare maps for Sprite or Fleet state.
+- **Events flow through PubSub.** LiveView subscribes in `mount`, never polls.
+- **Safety is enforced.** Actions touching external systems must be classified and gated.
+- **Contexts own business logic.** Controllers and LiveViews delegate — they don't compute.
+
+## Code Conventions
+
+- Elixir formatter applied (`mix format`)
+- No compiler warnings (`--warnings-as-errors`)
+- Credo clean (`mix credo --strict`)
+- Pattern matching in function heads preferred over `if`/`case` in body
+- Pipe chains read clearly top-to-bottom
+- Domain types use structs, not bare maps
+
+## Testing
+
+- Test public module APIs, not internal functions
+- Use Mox for capability behaviour mocks
+- Tag tests: `@tag :unit`, `@tag :integration`
+- No tests that depend on external services without mocking
+
+## What to Flag
+
+- **Bug:** Incorrect behavior, race conditions, missing error handling at system boundaries
+- **Security:** Unsanitized input, missing auth checks, secrets in code
+- **Design:** Violates capability boundary, polling instead of PubSub, business logic in LiveView
+- **Style:** Formatting, naming, unnecessary complexity

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Elixir/Mix
+/_build/
+/deps/
+/.fetch
+erl_crash.dump
+*.ez
+
+# Phoenix
+/priv/static/assets/
+
+# Database
+*.db
+*.db-journal
+/priv/*.db
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+\#*\#
+
+# Test
+/cover/
+
+# Dialyzer
+/priv/plts/
+
+# Fly.io
+.fly/
+
+# Node (Phoenix asset pipeline)
+/assets/node_modules/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "flyio": {
+      "command": "flyctl",
+      "args": ["mcp", "server"]
+    }
+  }
+}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 27.2.4
+elixir 1.18.3-otp-27

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md — Lattice
+
+Guidelines for AI agents working on this repository.
+
+## Required Reading
+
+1. [PHILOSOPHY.md](PHILOSOPHY.md) — design principles and product thinking
+2. [CLAUDE.md](CLAUDE.md) — architecture, conventions, and commands
+
+## Project Overview
+
+Lattice is an Elixir/Phoenix control plane for managing AI coding agents (Sprites). It uses OTP processes (GenServer per Sprite), LiveView for real-time dashboards, and capability behaviours for safe, bounded access to external systems.
+
+## Build & Test Commands
+
+```bash
+mix setup                         # Bootstrap project
+mix test                          # Run all tests
+mix test --only unit              # Unit tests only
+mix format --check-formatted      # Check formatting
+mix credo --strict                # Static analysis
+mix compile --warnings-as-errors  # Strict compilation
+```
+
+## Coding Style
+
+- Elixir with standard library conventions
+- 2-space indentation (Elixir default)
+- `mix format` enforced
+- Pattern matching over conditionals
+- Structs for domain types
+- Behaviours for external dependencies
+
+## Testing
+
+- ExUnit with Mox for behaviour mocking
+- Tests colocated in `test/` mirroring `lib/` structure
+- `@tag :unit` and `@tag :integration` for categorization
+
+## Commits & PRs
+
+- Imperative mood: "Add fleet dashboard", not "Added fleet dashboard"
+- Each PR is a complete vertical slice
+- Small, focused PRs preferred

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,189 @@
+# CLAUDE.md — Lattice
+
+> Required reading before any work: this file, then PHILOSOPHY.md.
+
+## What is Lattice
+
+Lattice is an **Elixir/Phoenix control plane for managing AI coding agents ("Sprites")**. It provides:
+
+- **LiveView dashboard** — real-time ops pane for fleet visibility (the "NOC glass")
+- **Sprite-per-process model** — each Sprite is a GenServer managed by a Fleet Manager
+- **Capability modules** — bounded interfaces to external systems (GitHub, Fly.io, Sprites API)
+- **GitHub human-in-the-loop** — issue-based approval workflows for risky Sprite actions
+- **Event-driven observability** — Telemetry + PubSub, LiveView renders projections (never polls)
+- **Safety guardrails** — action classification, gating, audit logging
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                  Phoenix/LiveView                │
+│         (Fleet Dashboard, Sprite Detail,         │
+│          Incidents, Approvals Queue)             │
+├─────────────────────────────────────────────────┤
+│                  Fleet Manager                   │
+│         (DynamicSupervisor, Registry)            │
+├──────────┬──────────┬──────────┬────────────────┤
+│ Sprite 1 │ Sprite 2 │ Sprite N │  (GenServers)  │
+├──────────┴──────────┴──────────┴────────────────┤
+│              Capability Modules                  │
+│   GitHubCapability │ FlyCapability │ SpritesAPI  │
+├─────────────────────────────────────────────────┤
+│         Telemetry + PubSub (Event Bus)           │
+├─────────────────────────────────────────────────┤
+│              Safety & Guardrails                 │
+│     (Action Classification, Gating, Audit)       │
+└─────────────────────────────────────────────────┘
+```
+
+### Key Mental Models
+
+- **Sprites are processes.** Each Sprite gets a GenServer that owns its state, reads its logs, and reconciles desired vs. actual.
+- **Events are truth.** State changes emit Telemetry events. PubSub broadcasts them. LiveView subscribes and renders. No polling.
+- **Capabilities are behaviours.** Each external system (GitHub, Fly, Sprites API) gets a behaviour module. This enables clean mocking, testing, and future swapping.
+- **Safety is first-class.** Every action is classified (safe/needs-review/dangerous), gated, and audit-logged.
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | Elixir 1.18+ / OTP 27+ |
+| Web | Phoenix 1.7+ / LiveView 1.0+ |
+| Process model | GenServer, DynamicSupervisor, Registry |
+| Events | :telemetry + Phoenix.PubSub |
+| Persistence | ETS initially, PostgreSQL later |
+| Auth | Clerk (deferred — stubbed initially) |
+| Deployment | Fly.io + Fly Scheduled Machines |
+| CI | GitHub Actions |
+
+## Project Structure (target)
+
+```
+lattice/
+├── .claude/                    # Claude Code hooks & config
+│   ├── hooks/session-start.sh  # Remote session bootstrap
+│   └── settings.json           # Hook configuration
+├── .github/workflows/          # CI/CD
+├── lib/
+│   ├── lattice/
+│   │   ├── sprites/
+│   │   │   ├── sprite.ex           # Sprite GenServer
+│   │   │   ├── fleet_manager.ex    # DynamicSupervisor + Registry
+│   │   │   └── state.ex            # Sprite state struct
+│   │   ├── capabilities/
+│   │   │   ├── capability.ex       # Behaviour definition
+│   │   │   ├── github.ex           # GitHub HITL
+│   │   │   ├── fly.ex              # Fly.io management
+│   │   │   └── sprites_api.ex      # Sprites API client
+│   │   ├── safety/
+│   │   │   ├── classifier.ex       # Action classification
+│   │   │   ├── gate.ex             # Approval gating
+│   │   │   └── audit.ex            # Audit logging
+│   │   ├── events.ex               # Telemetry + PubSub helpers
+│   │   └── application.ex          # OTP application
+│   ├── lattice_web/
+│   │   ├── live/
+│   │   │   ├── fleet_live.ex       # Fleet dashboard
+│   │   │   ├── sprite_live.ex      # Sprite detail
+│   │   │   ├── incidents_live.ex   # Incidents view
+│   │   │   └── approvals_live.ex   # Approval queue
+│   │   ├── controllers/
+│   │   │   └── api/                # REST API
+│   │   └── router.ex
+│   └── lattice_web.ex
+├── test/
+├── config/
+├── CLAUDE.md                   # You are here
+├── PHILOSOPHY.md               # Design principles
+├── README.md                   # Project overview
+├── mix.exs
+├── fly.toml
+└── Dockerfile
+```
+
+## Commands
+
+```bash
+# Development
+mix setup              # Install deps, create db, run migrations
+mix phx.server         # Start dev server (localhost:4000)
+iex -S mix phx.server  # Start with IEx shell attached
+
+# Testing
+mix test               # Run all tests
+mix test --only unit   # Run unit tests only
+mix test path/to/test  # Run specific test file
+
+# Quality
+mix format             # Format code
+mix format --check-formatted  # Check formatting (CI)
+mix credo --strict     # Static analysis
+mix dialyzer           # Type checking (slow first run)
+
+# Build
+mix compile --warnings-as-errors  # Compile with strict warnings
+```
+
+## Coding Conventions
+
+### Elixir Style
+
+- **Pattern match eagerly.** Use pattern matching in function heads, not `if/case` inside the body.
+- **Let it crash.** Supervisors handle failures. Don't wrap everything in `try/rescue`.
+- **Pipe clearly.** `|>` chains should read top-to-bottom. If a pipe chain gets unclear, extract a named function.
+- **Structs for domain types.** `%Sprite{}`, `%Action{}`, `%AuditEntry{}` — not bare maps.
+- **Contexts over controllers.** Business logic lives in context modules, never in controllers or LiveView.
+
+### Phoenix/LiveView
+
+- **LiveView handles display, not logic.** `handle_event` should delegate to contexts.
+- **PubSub, not polling.** Subscribe to topics in `mount/3`, render from assigns.
+- **Functional components** for reusable UI pieces. LiveComponents only when they need their own lifecycle.
+- **HEEX templates** colocated with their LiveView modules.
+
+### OTP
+
+- **GenServer state should be a struct.** Define a `%State{}` struct in the module.
+- **Handle_info for PubSub messages.** Keep `handle_call` for sync queries, `handle_cast` for fire-and-forget.
+- **Timeouts and `:continue`** for periodic work. Not `Process.send_after` loops unless needed.
+
+### Testing
+
+- **Test the behaviour, not the implementation.** Test public APIs of modules.
+- **Use behaviours for external deps.** Mock at the behaviour boundary with Mox.
+- **ExUnit tags** for test categorization: `@tag :unit`, `@tag :integration`.
+- **Factories over fixtures.** Use ExMachina or simple factory functions.
+
+### Commits & PRs
+
+- **Vertical slices only.** Each PR delivers one complete, working feature top-to-bottom.
+- **Imperative commit messages.** "Add fleet dashboard", not "Added fleet dashboard".
+- **Small PRs.** If it's hard to review, it's too big.
+
+## Instance Configuration
+
+Each Lattice deployment binds to specific external resources:
+
+```elixir
+# config/runtime.exs
+config :lattice, :instance,
+  name: System.get_env("LATTICE_INSTANCE_NAME", "lattice-dev"),
+  environment: config_env()
+
+config :lattice, :resources,
+  github_repo: System.get_env("GITHUB_REPO"),
+  fly_org: System.get_env("FLY_ORG"),
+  fly_app: System.get_env("FLY_APP"),
+  sprites_api_base: System.get_env("SPRITES_API_BASE")
+```
+
+## Issue Tracker
+
+Active issues are in [github.com/plattegruber/lattice/issues](https://github.com/plattegruber/lattice/issues).
+
+Phases:
+1. **Foundation** — capability architecture, event infrastructure, safety framework, CI
+2. **Step 1** — scaffold, sprite processes, fleet manager, LiveView dashboard
+3. **Step 2** — real Sprites API integration, reconciliation, Phoenix API
+4. **Step 3** — GitHub HITL workflow, approvals queue
+5. **Step 4** — Fly deployment, Scheduled Machines

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -1,0 +1,77 @@
+# Philosophy — Lattice
+
+This document captures the design principles and product thinking behind Lattice. Read this before writing code.
+
+## What We're Building
+
+A **control plane for AI coding agents**. Not an AI framework. Not a chatbot. An operations tool that lets a human operator manage a fleet of Sprites — the way a NOC engineer manages a fleet of servers.
+
+The operator sees what each Sprite is doing, can intervene when needed, and trusts that unsafe actions will be caught before they execute.
+
+## Core Principles
+
+### 1. Walking Skeleton First
+
+Build the thinnest possible vertical slice that works end-to-end before adding depth. A Sprite process that emits synthetic events, rendered in a LiveView dashboard, is more valuable than a perfect API client with no UI.
+
+### 2. Observable by Default
+
+Every state change emits a Telemetry event. Every event flows through PubSub. LiveView subscribes and renders. There is no hidden state — if it happened, you can see it.
+
+This is the "NOC glass" mental model: the dashboard should tell you what's happening right now without clicking into anything.
+
+### 3. Safe Boundaries
+
+Full computer access is the magic of Sprites. Safety is non-negotiable.
+
+- Every action is **classified** (safe / needs-review / dangerous)
+- Dangerous actions are **gated** until a human approves via GitHub
+- Every action, approved or not, is **audit-logged**
+- Capabilities are **behaviour modules** — bounded interfaces, not open shell access
+
+### 4. Processes, Not Services
+
+OTP is the runtime. Each Sprite is a GenServer. The Fleet Manager is a DynamicSupervisor. State lives in processes, supervised by the BEAM.
+
+We don't need Kubernetes, message queues, or microservices. We need `GenServer.start_link/3`.
+
+### 5. Events Are Truth
+
+State changes are communicated via Telemetry events and PubSub broadcasts. LiveView renders projections of event streams. The database (when we add one) is a projection too.
+
+This means:
+- No polling. Ever.
+- No "refresh the page to see changes."
+- The dashboard is always live.
+
+### 6. GitHub as Human Substrate
+
+GitHub issues are the approval interface for human-in-the-loop workflows. Not Slack. Not email. Not a custom UI.
+
+Why GitHub:
+- Operators already live there
+- Issues have comments, labels, assignees — a natural approval workflow
+- Everything is versioned and auditable
+- Sprites can read and write issues via API
+
+### 7. Minimal Persistence Early
+
+ETS and process state first. PostgreSQL later, only when we need it. Don't add a database until the pain of not having one is concrete.
+
+### 8. Vertical PRs Only
+
+Every change ships as a complete vertical slice. No "backend PR" followed by "frontend PR." Each PR should boot, work, and be testable on its own.
+
+## What We're Not Building
+
+- **An AI framework.** We don't run models. Sprites run themselves. We observe and manage them.
+- **A chatbot interface.** The operator uses a dashboard, not a chat window.
+- **Multi-tenant SaaS.** Each Lattice instance manages one fleet. Multi-instance is fine; multi-tenant is not a goal.
+- **A CI/CD system.** We trigger and observe. We don't replace GitHub Actions or Fly deployments.
+
+## Design Taste
+
+- **Boring technology.** Phoenix, LiveView, GenServer, PostgreSQL. No novel infrastructure.
+- **Small surface area.** Fewer features, well-built. Resist the urge to add configuration options.
+- **Show, don't tell.** The dashboard should make state obvious. Minimize text explanations; maximize real-time visibility.
+- **Fail loudly.** Crashes are fine — supervisors restart things. Silent failures are not fine.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Lattice
+
+A Phoenix/LiveView control plane for managing AI coding agents (Sprites).
+
+Lattice gives you a real-time operations dashboard for your fleet of Sprites — with human-in-the-loop safety via GitHub, capability-bounded access to external systems, and deployment on Fly.io.
+
+## Architecture
+
+```
+Phoenix/LiveView (ops dashboard)
+        │
+   Fleet Manager (DynamicSupervisor)
+        │
+   ┌────┼────┐
+Sprite Sprite Sprite  (GenServers — one per agent)
+   │    │    │
+   Capability Modules  (GitHub, Fly, Sprites API)
+        │
+   Telemetry + PubSub  (event-driven observability)
+        │
+   Safety & Guardrails  (classify → gate → audit)
+```
+
+**Key ideas:**
+
+- Each Sprite is an OTP process (GenServer) that reconciles desired vs. actual state
+- LiveView renders event projections — never polls
+- Capabilities are behaviour modules — mockable, testable, swappable
+- Every action is classified, gated, and audit-logged
+- GitHub issues serve as the human-in-the-loop approval substrate
+
+## Getting Started
+
+```bash
+# Prerequisites: Erlang/OTP 27+, Elixir 1.18+
+mix setup
+mix phx.server
+# Visit http://localhost:4000
+```
+
+## Development
+
+```bash
+mix test                          # Run tests
+mix format --check-formatted      # Check formatting
+mix credo --strict                # Static analysis
+mix compile --warnings-as-errors  # Strict compilation
+```
+
+See [CLAUDE.md](CLAUDE.md) for detailed conventions and [PHILOSOPHY.md](PHILOSOPHY.md) for design principles.
+
+## Deployment
+
+Deployed on [Fly.io](https://fly.io). See issue tracker for deployment setup status.
+
+## License
+
+Private.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,86 @@
+# Recommended Claude Code Skills & Plugins
+
+Plugins and MCP servers to install for working on Lattice.
+
+## Tier 1 — Install These
+
+### Elixir Plugin (`georgeguimaraes/claude-code-elixir`)
+
+Purpose-built Elixir development plugin with thinking skills for Elixir, Phoenix, Ecto, and OTP patterns. Includes auto-format and credo hooks.
+
+```bash
+claude plugin marketplace add georgeguimaraes/claude-code-elixir
+```
+
+Includes:
+- `elixir-thinking` — core language patterns
+- `phoenix-thinking` — Phoenix/LiveView patterns
+- `otp-thinking` — GenServer, Supervisor, concurrency patterns
+- Auto-hooks: `mix format` on save, `mix compile --warnings-as-errors`, `mix credo`
+
+### Fly.io MCP Server
+
+Already configured in `.mcp.json`. Requires `flyctl` installed and authenticated.
+
+Gives Claude direct access to manage Fly apps, machines, logs, certs, and orgs.
+
+```bash
+flyctl auth login  # One-time setup
+```
+
+### Claude Code GitHub Action
+
+Enables `@claude` mentions in PRs for automated code review.
+
+```bash
+# Inside Claude Code:
+/install-github-app
+```
+
+Or configure manually — see [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action).
+
+## Tier 2 — Install When Needed
+
+### Code Review Plugin
+
+Language-agnostic code review workflows from Anthropic's official plugin directory.
+
+```bash
+claude plugin install code-review@claude-plugin-directory
+```
+
+### PR Review Toolkit
+
+Multi-agent PR review with confidence scoring.
+
+```bash
+claude plugin install pr-review-toolkit@claude-plugin-directory
+```
+
+### GitHub MCP Server
+
+Structured access to repos, PRs, issues, Actions, and code search. Richer than the `gh` CLI for some workflows.
+
+Add to `.mcp.json`:
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github@latest"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<your-token>"
+      }
+    }
+  }
+}
+```
+
+## Tier 3 — Nice to Have
+
+| Plugin | Use Case |
+|--------|----------|
+| `elixir-architect` (`maxim-ist/elixir-architect`) | Architecture docs and ADR generation |
+| `commit-commands` | Structured commit workflows |
+| `feature-dev` | Feature development workflow |
+| `playwright` | Browser-based LiveView E2E testing |


### PR DESCRIPTION
## Summary

- **CLAUDE.md** + **PHILOSOPHY.md** — project architecture, conventions, and design principles for Claude sessions
- **Session-start hook** — bootstraps remote environments with gh, Erlang/Elixir (asdf), flyctl, Hex, and Rebar
- **.mcp.json** — Fly.io MCP server config for direct Fly access from Claude
- **.tool-versions** — pins Erlang 27.2.4 + Elixir 1.18.3-otp-27
- **SKILLS.md** — tiered plugin/MCP recommendations (Elixir plugin, GitHub Action, etc.)
- **AGENTS.md**, **README.md**, **.gitignore**, review guidelines — standard repo scaffolding

## Test plan

- [ ] Verify session-start hook runs cleanly in a remote Claude Code session (installs gh, Erlang/Elixir, flyctl)
- [ ] Verify hook is skipped in local environments
- [ ] Confirm `.mcp.json` activates flyctl MCP server when flyctl is authenticated
- [ ] Review CLAUDE.md and PHILOSOPHY.md for accuracy against issue tracker

https://claude.ai/code/session_01JYeh8v8HarQapxwHtbSBBt