### PR TITLE
Add event-driven observability: Telemetry and PubSub infrastructure

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -52,7 +52,26 @@ config :tailwind,
 # Configure Elixir's Logger
 config :logger, :default_formatter,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id]
+  metadata: [
+    :request_id,
+    :sprite_id,
+    :from_state,
+    :to_state,
+    :reason,
+    :outcome,
+    :duration_ms,
+    :details,
+    :status,
+    :check_duration_ms,
+    :message,
+    :action,
+    :classification,
+    :capability,
+    :operation,
+    :result,
+    :total,
+    :by_state
+  ]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/lib/lattice/application.ex
+++ b/lib/lattice/application.ex
@@ -5,8 +5,14 @@ defmodule Lattice.Application do
 
   use Application
 
+  alias Lattice.Events.TelemetryHandler
+
   @impl true
   def start(_type, _args) do
+    # Attach Lattice domain telemetry handlers before starting the supervision tree.
+    # This ensures events emitted during startup are captured.
+    TelemetryHandler.attach()
+
     children = [
       LatticeWeb.Telemetry,
       {DNSCluster, query: Application.get_env(:lattice, :dns_cluster_query) || :ignore},

--- a/lib/lattice/events.ex
+++ b/lib/lattice/events.ex
@@ -1,0 +1,215 @@
+defmodule Lattice.Events do
+  @moduledoc """
+  Event infrastructure for Lattice: PubSub broadcasting, topic conventions,
+  and Telemetry integration.
+
+  Events are the source of truth in Lattice. State changes emit Telemetry
+  events (for metrics and logging) and PubSub broadcasts (for real-time
+  fan-out to LiveView processes). The UI is a projection of the event stream.
+
+  ## Topic Conventions
+
+  - `"sprites:<sprite_id>"` — per-sprite events (state changes, health, logs)
+  - `"sprites:fleet"` — fleet-wide notifications and summary updates
+  - `"sprites:approvals"` — human-in-the-loop approval requests
+
+  ## Usage
+
+  Broadcasting an event:
+
+      {:ok, event} = Lattice.Events.StateChange.new("sprite-001", :hibernating, :waking)
+      Lattice.Events.broadcast_state_change(event)
+
+  Subscribing from a LiveView:
+
+      def mount(_params, _session, socket) do
+        if connected?(socket) do
+          Lattice.Events.subscribe_sprite("sprite-001")
+          Lattice.Events.subscribe_fleet()
+        end
+        {:ok, socket}
+      end
+
+  Handling events in LiveView:
+
+      def handle_info(%Lattice.Events.StateChange{} = event, socket) do
+        # Update assigns based on the event
+        {:noreply, assign(socket, :state, event.to_state)}
+      end
+  """
+
+  alias Lattice.Events.ApprovalNeeded
+  alias Lattice.Events.HealthUpdate
+  alias Lattice.Events.ReconciliationResult
+  alias Lattice.Events.StateChange
+
+  # ── Topic Helpers ──────────────────────────────────────────────────
+
+  @doc "Returns the PubSub topic for a specific Sprite."
+  @spec sprite_topic(String.t()) :: String.t()
+  def sprite_topic(sprite_id) when is_binary(sprite_id) do
+    "sprites:#{sprite_id}"
+  end
+
+  @doc "Returns the PubSub topic for fleet-wide events."
+  @spec fleet_topic() :: String.t()
+  def fleet_topic, do: "sprites:fleet"
+
+  @doc "Returns the PubSub topic for approval events."
+  @spec approvals_topic() :: String.t()
+  def approvals_topic, do: "sprites:approvals"
+
+  # ── Subscribe ──────────────────────────────────────────────────────
+
+  @doc "Subscribe the calling process to events for a specific Sprite."
+  @spec subscribe_sprite(String.t()) :: :ok | {:error, term()}
+  def subscribe_sprite(sprite_id) do
+    Phoenix.PubSub.subscribe(pubsub(), sprite_topic(sprite_id))
+  end
+
+  @doc "Subscribe the calling process to fleet-wide events."
+  @spec subscribe_fleet() :: :ok | {:error, term()}
+  def subscribe_fleet do
+    Phoenix.PubSub.subscribe(pubsub(), fleet_topic())
+  end
+
+  @doc "Subscribe the calling process to approval events."
+  @spec subscribe_approvals() :: :ok | {:error, term()}
+  def subscribe_approvals do
+    Phoenix.PubSub.subscribe(pubsub(), approvals_topic())
+  end
+
+  # ── Broadcast ──────────────────────────────────────────────────────
+
+  @doc """
+  Broadcast a Sprite state change event.
+
+  Emits a Telemetry event and broadcasts to both the per-sprite topic and
+  the fleet topic.
+  """
+  @spec broadcast_state_change(StateChange.t()) :: :ok | {:error, term()}
+  def broadcast_state_change(%StateChange{} = event) do
+    emit_telemetry([:lattice, :sprite, :state_change], event)
+    broadcast_to_sprite(event.sprite_id, event)
+    broadcast_to_fleet(event)
+  end
+
+  @doc """
+  Broadcast a reconciliation result event.
+
+  Emits a Telemetry event and broadcasts to both the per-sprite topic and
+  the fleet topic.
+  """
+  @spec broadcast_reconciliation_result(ReconciliationResult.t()) :: :ok | {:error, term()}
+  def broadcast_reconciliation_result(%ReconciliationResult{} = event) do
+    emit_telemetry([:lattice, :sprite, :reconciliation], event)
+    broadcast_to_sprite(event.sprite_id, event)
+    broadcast_to_fleet(event)
+  end
+
+  @doc """
+  Broadcast a health update event.
+
+  Emits a Telemetry event and broadcasts to the per-sprite topic and
+  the fleet topic.
+  """
+  @spec broadcast_health_update(HealthUpdate.t()) :: :ok | {:error, term()}
+  def broadcast_health_update(%HealthUpdate{} = event) do
+    emit_telemetry([:lattice, :sprite, :health_update], event)
+    broadcast_to_sprite(event.sprite_id, event)
+    broadcast_to_fleet(event)
+  end
+
+  @doc """
+  Broadcast an approval needed event.
+
+  Emits a Telemetry event and broadcasts to the per-sprite topic, the
+  fleet topic, and the approvals topic.
+  """
+  @spec broadcast_approval_needed(ApprovalNeeded.t()) :: :ok | {:error, term()}
+  def broadcast_approval_needed(%ApprovalNeeded{} = event) do
+    emit_telemetry([:lattice, :sprite, :approval_needed], event)
+    broadcast_to_sprite(event.sprite_id, event)
+    broadcast_to_fleet(event)
+    broadcast_to_approvals(event)
+  end
+
+  # ── Telemetry ──────────────────────────────────────────────────────
+
+  @doc """
+  Emit a capability call telemetry event.
+
+  Used by capability modules to instrument API call latency and outcome.
+
+  ## Examples
+
+      Lattice.Events.emit_capability_call(:sprites, :list_sprites, 150, :ok)
+      Lattice.Events.emit_capability_call(:github, :create_issue, 500, {:error, :timeout})
+
+  """
+  @spec emit_capability_call(atom(), atom(), non_neg_integer(), :ok | {:error, term()}) :: :ok
+  def emit_capability_call(capability, operation, duration_ms, result) do
+    :telemetry.execute(
+      [:lattice, :capability, :call],
+      %{duration_ms: duration_ms},
+      %{
+        capability: capability,
+        operation: operation,
+        result: result,
+        timestamp: DateTime.utc_now()
+      }
+    )
+  end
+
+  @doc """
+  Emit a fleet summary telemetry event.
+
+  Used periodically to report aggregate fleet statistics.
+
+  ## Examples
+
+      Lattice.Events.emit_fleet_summary(%{
+        total: 10,
+        by_state: %{ready: 5, busy: 3, hibernating: 2}
+      })
+
+  """
+  @spec emit_fleet_summary(map()) :: :ok
+  def emit_fleet_summary(summary) when is_map(summary) do
+    :telemetry.execute(
+      [:lattice, :fleet, :summary],
+      %{total: Map.get(summary, :total, 0)},
+      %{
+        by_state: Map.get(summary, :by_state, %{}),
+        timestamp: DateTime.utc_now()
+      }
+    )
+  end
+
+  # ── Private ────────────────────────────────────────────────────────
+
+  defp emit_telemetry(event_name, %{sprite_id: sprite_id} = event) do
+    :telemetry.execute(
+      event_name,
+      %{system_time: System.system_time()},
+      %{
+        sprite_id: sprite_id,
+        event: event
+      }
+    )
+  end
+
+  defp broadcast_to_sprite(sprite_id, event) do
+    Phoenix.PubSub.broadcast(pubsub(), sprite_topic(sprite_id), event)
+  end
+
+  defp broadcast_to_fleet(event) do
+    Phoenix.PubSub.broadcast(pubsub(), fleet_topic(), event)
+  end
+
+  defp broadcast_to_approvals(event) do
+    Phoenix.PubSub.broadcast(pubsub(), approvals_topic(), event)
+  end
+
+  defp pubsub, do: Lattice.PubSub
+end

--- a/lib/lattice/events/approval_needed.ex
+++ b/lib/lattice/events/approval_needed.ex
@@ -1,0 +1,54 @@
+defmodule Lattice.Events.ApprovalNeeded do
+  @moduledoc """
+  Event emitted when a Sprite action requires human-in-the-loop approval.
+
+  When the safety classifier determines an action is dangerous or needs review,
+  this event is broadcast so the dashboard can display it in the approvals queue
+  and a GitHub issue can be created for the approval workflow.
+  """
+
+  @type t :: %__MODULE__{
+          sprite_id: String.t(),
+          action: String.t(),
+          classification: :needs_review | :dangerous,
+          context: map(),
+          timestamp: DateTime.t()
+        }
+
+  @enforce_keys [:sprite_id, :action, :classification, :timestamp]
+  defstruct [:sprite_id, :action, :classification, :timestamp, context: %{}]
+
+  @valid_classifications [:needs_review, :dangerous]
+
+  @doc """
+  Creates a new ApprovalNeeded event.
+
+  ## Examples
+
+      iex> Lattice.Events.ApprovalNeeded.new("sprite-001", "deploy to prod", :dangerous)
+      {:ok, %Lattice.Events.ApprovalNeeded{sprite_id: "sprite-001", action: "deploy to prod", classification: :dangerous, ...}}
+
+  """
+  @spec new(String.t(), String.t(), atom(), keyword()) :: {:ok, t()} | {:error, term()}
+  def new(sprite_id, action, classification, opts \\ [])
+
+  def new(sprite_id, action, classification, opts)
+      when classification in @valid_classifications do
+    {:ok,
+     %__MODULE__{
+       sprite_id: sprite_id,
+       action: action,
+       classification: classification,
+       context: Keyword.get(opts, :context, %{}),
+       timestamp: Keyword.get(opts, :timestamp, DateTime.utc_now())
+     }}
+  end
+
+  def new(_sprite_id, _action, classification, _opts) do
+    {:error, {:invalid_classification, classification}}
+  end
+
+  @doc "Returns the list of valid approval classifications."
+  @spec valid_classifications() :: [atom()]
+  def valid_classifications, do: @valid_classifications
+end

--- a/lib/lattice/events/health_update.ex
+++ b/lib/lattice/events/health_update.ex
@@ -1,0 +1,53 @@
+defmodule Lattice.Events.HealthUpdate do
+  @moduledoc """
+  Event emitted when a Sprite health check completes.
+
+  Health checks are periodic probes that verify a Sprite is responsive and
+  functioning correctly. Results flow through the event system to update
+  the dashboard in real time.
+  """
+
+  @type t :: %__MODULE__{
+          sprite_id: String.t(),
+          status: :healthy | :degraded | :unhealthy,
+          check_duration_ms: non_neg_integer(),
+          message: String.t() | nil,
+          timestamp: DateTime.t()
+        }
+
+  @enforce_keys [:sprite_id, :status, :check_duration_ms, :timestamp]
+  defstruct [:sprite_id, :status, :check_duration_ms, :message, :timestamp]
+
+  @valid_statuses [:healthy, :degraded, :unhealthy]
+
+  @doc """
+  Creates a new HealthUpdate event.
+
+  ## Examples
+
+      iex> Lattice.Events.HealthUpdate.new("sprite-001", :healthy, 15)
+      {:ok, %Lattice.Events.HealthUpdate{sprite_id: "sprite-001", status: :healthy, check_duration_ms: 15, ...}}
+
+  """
+  @spec new(String.t(), atom(), non_neg_integer(), keyword()) :: {:ok, t()} | {:error, term()}
+  def new(sprite_id, status, check_duration_ms, opts \\ [])
+
+  def new(sprite_id, status, check_duration_ms, opts) when status in @valid_statuses do
+    {:ok,
+     %__MODULE__{
+       sprite_id: sprite_id,
+       status: status,
+       check_duration_ms: check_duration_ms,
+       message: Keyword.get(opts, :message),
+       timestamp: Keyword.get(opts, :timestamp, DateTime.utc_now())
+     }}
+  end
+
+  def new(_sprite_id, status, _check_duration_ms, _opts) do
+    {:error, {:invalid_status, status}}
+  end
+
+  @doc "Returns the list of valid health statuses."
+  @spec valid_statuses() :: [atom()]
+  def valid_statuses, do: @valid_statuses
+end

--- a/lib/lattice/events/reconciliation_result.ex
+++ b/lib/lattice/events/reconciliation_result.ex
@@ -1,0 +1,52 @@
+defmodule Lattice.Events.ReconciliationResult do
+  @moduledoc """
+  Event emitted after a Sprite reconciliation cycle completes.
+
+  Reconciliation compares desired state with actual state and takes corrective
+  action. Each cycle produces a result event with its outcome and timing.
+  """
+
+  @type t :: %__MODULE__{
+          sprite_id: String.t(),
+          outcome: :success | :failure | :no_change,
+          duration_ms: non_neg_integer(),
+          details: String.t() | nil,
+          timestamp: DateTime.t()
+        }
+
+  @enforce_keys [:sprite_id, :outcome, :duration_ms, :timestamp]
+  defstruct [:sprite_id, :outcome, :duration_ms, :details, :timestamp]
+
+  @valid_outcomes [:success, :failure, :no_change]
+
+  @doc """
+  Creates a new ReconciliationResult event.
+
+  ## Examples
+
+      iex> Lattice.Events.ReconciliationResult.new("sprite-001", :success, 42)
+      {:ok, %Lattice.Events.ReconciliationResult{sprite_id: "sprite-001", outcome: :success, duration_ms: 42, ...}}
+
+  """
+  @spec new(String.t(), atom(), non_neg_integer(), keyword()) :: {:ok, t()} | {:error, term()}
+  def new(sprite_id, outcome, duration_ms, opts \\ [])
+
+  def new(sprite_id, outcome, duration_ms, opts) when outcome in @valid_outcomes do
+    {:ok,
+     %__MODULE__{
+       sprite_id: sprite_id,
+       outcome: outcome,
+       duration_ms: duration_ms,
+       details: Keyword.get(opts, :details),
+       timestamp: Keyword.get(opts, :timestamp, DateTime.utc_now())
+     }}
+  end
+
+  def new(_sprite_id, outcome, _duration_ms, _opts) do
+    {:error, {:invalid_outcome, outcome}}
+  end
+
+  @doc "Returns the list of valid reconciliation outcomes."
+  @spec valid_outcomes() :: [atom()]
+  def valid_outcomes, do: @valid_outcomes
+end

--- a/lib/lattice/events/state_change.ex
+++ b/lib/lattice/events/state_change.ex
@@ -1,0 +1,56 @@
+defmodule Lattice.Events.StateChange do
+  @moduledoc """
+  Event emitted when a Sprite transitions between states.
+
+  The Sprite lifecycle follows:
+  `hibernating -> waking -> ready -> busy -> error`
+
+  Each transition produces a `StateChange` event that flows through both
+  Telemetry (for metrics/logging) and PubSub (for real-time fan-out to
+  LiveView processes).
+  """
+
+  @type t :: %__MODULE__{
+          sprite_id: String.t(),
+          from_state: atom(),
+          to_state: atom(),
+          reason: String.t() | nil,
+          timestamp: DateTime.t()
+        }
+
+  @enforce_keys [:sprite_id, :from_state, :to_state, :timestamp]
+  defstruct [:sprite_id, :from_state, :to_state, :reason, :timestamp]
+
+  @valid_states [:hibernating, :waking, :ready, :busy, :error]
+
+  @doc """
+  Creates a new StateChange event.
+
+  ## Examples
+
+      iex> Lattice.Events.StateChange.new("sprite-001", :hibernating, :waking)
+      {:ok, %Lattice.Events.StateChange{sprite_id: "sprite-001", from_state: :hibernating, to_state: :waking, ...}}
+
+  """
+  @spec new(String.t(), atom(), atom(), keyword()) :: {:ok, t()} | {:error, term()}
+  def new(sprite_id, from_state, to_state, opts \\ []) do
+    with :ok <- validate_state(from_state),
+         :ok <- validate_state(to_state) do
+      {:ok,
+       %__MODULE__{
+         sprite_id: sprite_id,
+         from_state: from_state,
+         to_state: to_state,
+         reason: Keyword.get(opts, :reason),
+         timestamp: Keyword.get(opts, :timestamp, DateTime.utc_now())
+       }}
+    end
+  end
+
+  @doc "Returns the list of valid Sprite states."
+  @spec valid_states() :: [atom()]
+  def valid_states, do: @valid_states
+
+  defp validate_state(state) when state in @valid_states, do: :ok
+  defp validate_state(state), do: {:error, {:invalid_state, state}}
+end

--- a/lib/lattice/events/telemetry_handler.ex
+++ b/lib/lattice/events/telemetry_handler.ex
@@ -1,0 +1,176 @@
+defmodule Lattice.Events.TelemetryHandler do
+  @moduledoc """
+  Telemetry handler that logs Lattice domain events via `:logger`.
+
+  Attaches to the Lattice telemetry event namespace and produces structured
+  log output. This is the default observability layer — additional handlers
+  (metrics exporters, StatsD, etc.) can be attached independently.
+
+  ## Event Namespace
+
+  All Lattice domain events live under the `[:lattice, ...]` namespace:
+
+  - `[:lattice, :sprite, :state_change]` — Sprite state transitions
+  - `[:lattice, :sprite, :reconciliation]` — Reconciliation cycle results
+  - `[:lattice, :sprite, :health_update]` — Health check results
+  - `[:lattice, :sprite, :approval_needed]` — Actions requiring approval
+  - `[:lattice, :capability, :call]` — Capability module API calls
+  - `[:lattice, :fleet, :summary]` — Fleet-level aggregate metrics
+
+  ## Attaching
+
+  Called from `Lattice.Application.start/2`:
+
+      Lattice.Events.TelemetryHandler.attach()
+
+  """
+
+  require Logger
+
+  @handler_id "lattice-events-logger"
+
+  @events [
+    [:lattice, :sprite, :state_change],
+    [:lattice, :sprite, :reconciliation],
+    [:lattice, :sprite, :health_update],
+    [:lattice, :sprite, :approval_needed],
+    [:lattice, :capability, :call],
+    [:lattice, :fleet, :summary]
+  ]
+
+  @doc """
+  Attach the logger handler to all Lattice telemetry events.
+
+  Returns `:ok`. Safe to call multiple times — duplicates are ignored by
+  `:telemetry.attach_many/4` when the handler ID matches.
+  """
+  @spec attach() :: :ok | {:error, :already_exists}
+  def attach do
+    :telemetry.attach_many(
+      @handler_id,
+      @events,
+      &handle_event/4,
+      :no_config
+    )
+  end
+
+  @doc """
+  Detach the logger handler. Useful in tests to avoid noisy log output.
+  """
+  @spec detach() :: :ok | {:error, :not_found}
+  def detach do
+    :telemetry.detach(@handler_id)
+  end
+
+  @doc "Returns the list of telemetry events this handler covers."
+  @spec events() :: [list(atom())]
+  def events, do: @events
+
+  @doc "Returns the handler ID used for attachment."
+  @spec handler_id() :: String.t()
+  def handler_id, do: @handler_id
+
+  # ── Handler Callbacks ──────────────────────────────────────────────
+
+  @doc false
+  def handle_event(
+        [:lattice, :sprite, :state_change],
+        _measurements,
+        %{sprite_id: sprite_id, event: event},
+        _config
+      ) do
+    Logger.info(
+      "Sprite state change",
+      sprite_id: sprite_id,
+      from_state: event.from_state,
+      to_state: event.to_state,
+      reason: event.reason
+    )
+  end
+
+  def handle_event(
+        [:lattice, :sprite, :reconciliation],
+        _measurements,
+        %{sprite_id: sprite_id, event: event},
+        _config
+      ) do
+    log_level = if event.outcome == :failure, do: :warning, else: :info
+
+    Logger.log(
+      log_level,
+      "Sprite reconciliation #{event.outcome}",
+      sprite_id: sprite_id,
+      outcome: event.outcome,
+      duration_ms: event.duration_ms,
+      details: event.details
+    )
+  end
+
+  def handle_event(
+        [:lattice, :sprite, :health_update],
+        _measurements,
+        %{sprite_id: sprite_id, event: event},
+        _config
+      ) do
+    log_level =
+      case event.status do
+        :healthy -> :info
+        :degraded -> :warning
+        :unhealthy -> :error
+      end
+
+    Logger.log(
+      log_level,
+      "Sprite health: #{event.status}",
+      sprite_id: sprite_id,
+      status: event.status,
+      check_duration_ms: event.check_duration_ms,
+      message: event.message
+    )
+  end
+
+  def handle_event(
+        [:lattice, :sprite, :approval_needed],
+        _measurements,
+        %{sprite_id: sprite_id, event: event},
+        _config
+      ) do
+    Logger.warning(
+      "Approval needed for #{event.classification} action",
+      sprite_id: sprite_id,
+      action: event.action,
+      classification: event.classification
+    )
+  end
+
+  def handle_event(
+        [:lattice, :capability, :call],
+        %{duration_ms: duration_ms},
+        %{capability: capability, operation: operation, result: result},
+        _config
+      ) do
+    log_level = if result == :ok, do: :info, else: :warning
+
+    Logger.log(
+      log_level,
+      "Capability call #{capability}.#{operation}",
+      capability: capability,
+      operation: operation,
+      duration_ms: duration_ms,
+      result: inspect(result)
+    )
+  end
+
+  def handle_event(
+        [:lattice, :fleet, :summary],
+        %{total: total},
+        %{by_state: by_state},
+        _config
+      ) do
+    Logger.info(
+      "Fleet summary: #{total} sprites",
+      total: total,
+      by_state: inspect(by_state)
+    )
+  end
+end

--- a/lib/lattice_web/telemetry.ex
+++ b/lib/lattice_web/telemetry.ex
@@ -56,7 +56,14 @@ defmodule LatticeWeb.Telemetry do
       summary("vm.memory.total", unit: {:byte, :kilobyte}),
       summary("vm.total_run_queue_lengths.total"),
       summary("vm.total_run_queue_lengths.cpu"),
-      summary("vm.total_run_queue_lengths.io")
+      summary("vm.total_run_queue_lengths.io"),
+
+      # Lattice Domain Metrics
+      summary("lattice.capability.call.duration_ms",
+        tags: [:capability, :operation],
+        unit: :millisecond
+      ),
+      sum("lattice.fleet.summary.total")
     ]
   end
 

--- a/test/lattice/events/approval_needed_test.exs
+++ b/test/lattice/events/approval_needed_test.exs
@@ -1,0 +1,52 @@
+defmodule Lattice.Events.ApprovalNeededTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Events.ApprovalNeeded
+
+  describe "new/4" do
+    test "creates an approval needed event with required fields" do
+      assert {:ok, event} = ApprovalNeeded.new("sprite-001", "deploy to prod", :dangerous)
+
+      assert event.sprite_id == "sprite-001"
+      assert event.action == "deploy to prod"
+      assert event.classification == :dangerous
+      assert event.context == %{}
+      assert %DateTime{} = event.timestamp
+    end
+
+    test "accepts optional context" do
+      context = %{branch: "main", commit: "abc123"}
+
+      assert {:ok, event} =
+               ApprovalNeeded.new("sprite-001", "force push", :dangerous, context: context)
+
+      assert event.context == context
+    end
+
+    test "accepts optional timestamp" do
+      ts = ~U[2026-01-15 10:00:00Z]
+
+      assert {:ok, event} =
+               ApprovalNeeded.new("sprite-001", "delete file", :needs_review, timestamp: ts)
+
+      assert event.timestamp == ts
+    end
+
+    test "accepts all valid classifications" do
+      for classification <- [:needs_review, :dangerous] do
+        assert {:ok, _event} = ApprovalNeeded.new("sprite-001", "action", classification)
+      end
+    end
+
+    test "rejects invalid classification" do
+      assert {:error, {:invalid_classification, :safe}} =
+               ApprovalNeeded.new("sprite-001", "action", :safe)
+    end
+
+    test "returns valid classifications through valid_classifications/0" do
+      assert ApprovalNeeded.valid_classifications() == [:needs_review, :dangerous]
+    end
+  end
+end

--- a/test/lattice/events/health_update_test.exs
+++ b/test/lattice/events/health_update_test.exs
@@ -1,0 +1,47 @@
+defmodule Lattice.Events.HealthUpdateTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Events.HealthUpdate
+
+  describe "new/4" do
+    test "creates a health update with required fields" do
+      assert {:ok, event} = HealthUpdate.new("sprite-001", :healthy, 15)
+
+      assert event.sprite_id == "sprite-001"
+      assert event.status == :healthy
+      assert event.check_duration_ms == 15
+      assert event.message == nil
+      assert %DateTime{} = event.timestamp
+    end
+
+    test "accepts optional message" do
+      assert {:ok, event} =
+               HealthUpdate.new("sprite-001", :degraded, 200, message: "high latency")
+
+      assert event.message == "high latency"
+    end
+
+    test "accepts optional timestamp" do
+      ts = ~U[2026-01-15 10:00:00Z]
+      assert {:ok, event} = HealthUpdate.new("sprite-001", :unhealthy, 5000, timestamp: ts)
+      assert event.timestamp == ts
+    end
+
+    test "accepts all valid statuses" do
+      for status <- [:healthy, :degraded, :unhealthy] do
+        assert {:ok, _event} = HealthUpdate.new("sprite-001", status, 10)
+      end
+    end
+
+    test "rejects invalid status" do
+      assert {:error, {:invalid_status, :unknown}} =
+               HealthUpdate.new("sprite-001", :unknown, 10)
+    end
+
+    test "returns valid statuses through valid_statuses/0" do
+      assert HealthUpdate.valid_statuses() == [:healthy, :degraded, :unhealthy]
+    end
+  end
+end

--- a/test/lattice/events/reconciliation_result_test.exs
+++ b/test/lattice/events/reconciliation_result_test.exs
@@ -1,0 +1,50 @@
+defmodule Lattice.Events.ReconciliationResultTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Events.ReconciliationResult
+
+  describe "new/4" do
+    test "creates a reconciliation result with required fields" do
+      assert {:ok, event} = ReconciliationResult.new("sprite-001", :success, 42)
+
+      assert event.sprite_id == "sprite-001"
+      assert event.outcome == :success
+      assert event.duration_ms == 42
+      assert event.details == nil
+      assert %DateTime{} = event.timestamp
+    end
+
+    test "accepts optional details" do
+      assert {:ok, event} =
+               ReconciliationResult.new("sprite-001", :failure, 100, details: "API timeout")
+
+      assert event.details == "API timeout"
+    end
+
+    test "accepts optional timestamp" do
+      ts = ~U[2026-01-15 10:00:00Z]
+
+      assert {:ok, event} =
+               ReconciliationResult.new("sprite-001", :no_change, 5, timestamp: ts)
+
+      assert event.timestamp == ts
+    end
+
+    test "accepts all valid outcomes" do
+      for outcome <- [:success, :failure, :no_change] do
+        assert {:ok, _event} = ReconciliationResult.new("sprite-001", outcome, 10)
+      end
+    end
+
+    test "rejects invalid outcome" do
+      assert {:error, {:invalid_outcome, :partial}} =
+               ReconciliationResult.new("sprite-001", :partial, 10)
+    end
+
+    test "returns valid outcomes through valid_outcomes/0" do
+      assert ReconciliationResult.valid_outcomes() == [:success, :failure, :no_change]
+    end
+  end
+end

--- a/test/lattice/events/state_change_test.exs
+++ b/test/lattice/events/state_change_test.exs
@@ -1,0 +1,54 @@
+defmodule Lattice.Events.StateChangeTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Events.StateChange
+
+  describe "new/4" do
+    test "creates a state change event with required fields" do
+      assert {:ok, event} = StateChange.new("sprite-001", :hibernating, :waking)
+
+      assert event.sprite_id == "sprite-001"
+      assert event.from_state == :hibernating
+      assert event.to_state == :waking
+      assert event.reason == nil
+      assert %DateTime{} = event.timestamp
+    end
+
+    test "accepts an optional reason" do
+      assert {:ok, event} =
+               StateChange.new("sprite-001", :ready, :error, reason: "connection lost")
+
+      assert event.reason == "connection lost"
+    end
+
+    test "accepts an optional timestamp" do
+      ts = ~U[2026-01-15 10:00:00Z]
+      assert {:ok, event} = StateChange.new("sprite-001", :busy, :ready, timestamp: ts)
+      assert event.timestamp == ts
+    end
+
+    test "rejects invalid from_state" do
+      assert {:error, {:invalid_state, :nonexistent}} =
+               StateChange.new("sprite-001", :nonexistent, :waking)
+    end
+
+    test "rejects invalid to_state" do
+      assert {:error, {:invalid_state, :bogus}} =
+               StateChange.new("sprite-001", :hibernating, :bogus)
+    end
+
+    test "returns all valid states through valid_states/0" do
+      assert StateChange.valid_states() == [:hibernating, :waking, :ready, :busy, :error]
+    end
+  end
+
+  describe "struct" do
+    test "enforces required keys" do
+      assert_raise ArgumentError, fn ->
+        struct!(StateChange, %{sprite_id: "sprite-001"})
+      end
+    end
+  end
+end

--- a/test/lattice/events/telemetry_handler_test.exs
+++ b/test/lattice/events/telemetry_handler_test.exs
@@ -1,0 +1,201 @@
+defmodule Lattice.Events.TelemetryHandlerTest do
+  use ExUnit.Case
+
+  require Logger
+
+  @moduletag :unit
+
+  alias Lattice.Events.ApprovalNeeded
+  alias Lattice.Events.HealthUpdate
+  alias Lattice.Events.ReconciliationResult
+  alias Lattice.Events.StateChange
+  alias Lattice.Events.TelemetryHandler
+
+  describe "attach/0 and detach/0" do
+    test "attach registers the handler and detach removes it" do
+      # Detach first in case application startup already attached it
+      TelemetryHandler.detach()
+
+      # Verify we can attach
+      assert :ok = TelemetryHandler.attach()
+
+      # Attaching again returns already_exists
+      assert {:error, :already_exists} = TelemetryHandler.attach()
+
+      # Detach succeeds
+      assert :ok = TelemetryHandler.detach()
+
+      # Re-attach for other tests / application use
+      TelemetryHandler.attach()
+    end
+  end
+
+  describe "events/0" do
+    test "returns all Lattice telemetry event names" do
+      events = TelemetryHandler.events()
+
+      assert [:lattice, :sprite, :state_change] in events
+      assert [:lattice, :sprite, :reconciliation] in events
+      assert [:lattice, :sprite, :health_update] in events
+      assert [:lattice, :sprite, :approval_needed] in events
+      assert [:lattice, :capability, :call] in events
+      assert [:lattice, :fleet, :summary] in events
+      assert length(events) == 6
+    end
+  end
+
+  describe "handler_id/0" do
+    test "returns the handler ID string" do
+      assert is_binary(TelemetryHandler.handler_id())
+    end
+  end
+
+  describe "handle_event/4 (integration — log output)" do
+    import ExUnit.CaptureLog
+
+    setup do
+      # Ensure the handler is attached
+      TelemetryHandler.detach()
+      TelemetryHandler.attach()
+
+      # Lower the log level so we can capture info-level messages
+      previous_level = Logger.level()
+      Logger.configure(level: :debug)
+      on_exit(fn -> Logger.configure(level: previous_level) end)
+
+      :ok
+    end
+
+    test "logs state change events" do
+      {:ok, event} =
+        StateChange.new("sprite-log-1", :hibernating, :waking, reason: "scheduled wake")
+
+      log =
+        capture_log(fn ->
+          :telemetry.execute(
+            [:lattice, :sprite, :state_change],
+            %{system_time: System.system_time()},
+            %{sprite_id: "sprite-log-1", event: event}
+          )
+        end)
+
+      assert log =~ "Sprite state change"
+    end
+
+    test "logs reconciliation success at info level" do
+      {:ok, event} = ReconciliationResult.new("sprite-log-2", :success, 42)
+
+      log =
+        capture_log(fn ->
+          :telemetry.execute(
+            [:lattice, :sprite, :reconciliation],
+            %{system_time: System.system_time()},
+            %{sprite_id: "sprite-log-2", event: event}
+          )
+        end)
+
+      assert log =~ "reconciliation success"
+    end
+
+    test "logs reconciliation failure at warning level" do
+      {:ok, event} =
+        ReconciliationResult.new("sprite-log-3", :failure, 100, details: "API down")
+
+      log =
+        capture_log(fn ->
+          :telemetry.execute(
+            [:lattice, :sprite, :reconciliation],
+            %{system_time: System.system_time()},
+            %{sprite_id: "sprite-log-3", event: event}
+          )
+        end)
+
+      assert log =~ "reconciliation failure"
+    end
+
+    test "logs unhealthy health updates at error level" do
+      {:ok, event} =
+        HealthUpdate.new("sprite-log-4", :unhealthy, 5000, message: "unreachable")
+
+      log =
+        capture_log(fn ->
+          :telemetry.execute(
+            [:lattice, :sprite, :health_update],
+            %{system_time: System.system_time()},
+            %{sprite_id: "sprite-log-4", event: event}
+          )
+        end)
+
+      assert log =~ "health: unhealthy"
+    end
+
+    test "logs approval needed events at warning level" do
+      {:ok, event} =
+        ApprovalNeeded.new("sprite-log-5", "force push", :dangerous)
+
+      log =
+        capture_log(fn ->
+          :telemetry.execute(
+            [:lattice, :sprite, :approval_needed],
+            %{system_time: System.system_time()},
+            %{sprite_id: "sprite-log-5", event: event}
+          )
+        end)
+
+      assert log =~ "Approval needed"
+      assert log =~ "dangerous"
+    end
+
+    test "logs successful capability calls at info level" do
+      log =
+        capture_log(fn ->
+          :telemetry.execute(
+            [:lattice, :capability, :call],
+            %{duration_ms: 150},
+            %{
+              capability: :sprites,
+              operation: :list_sprites,
+              result: :ok,
+              timestamp: DateTime.utc_now()
+            }
+          )
+        end)
+
+      assert log =~ "Capability call sprites.list_sprites"
+    end
+
+    test "logs failed capability calls at warning level" do
+      log =
+        capture_log(fn ->
+          :telemetry.execute(
+            [:lattice, :capability, :call],
+            %{duration_ms: 500},
+            %{
+              capability: :github,
+              operation: :create_issue,
+              result: {:error, :timeout},
+              timestamp: DateTime.utc_now()
+            }
+          )
+        end)
+
+      assert log =~ "Capability call github.create_issue"
+    end
+
+    test "logs fleet summary events" do
+      log =
+        capture_log(fn ->
+          :telemetry.execute(
+            [:lattice, :fleet, :summary],
+            %{total: 10},
+            %{
+              by_state: %{ready: 5, busy: 3, hibernating: 2},
+              timestamp: DateTime.utc_now()
+            }
+          )
+        end)
+
+      assert log =~ "Fleet summary: 10 sprites"
+    end
+  end
+end

--- a/test/lattice/events_test.exs
+++ b/test/lattice/events_test.exs
@@ -1,0 +1,240 @@
+defmodule Lattice.EventsTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Events
+  alias Lattice.Events.ApprovalNeeded
+  alias Lattice.Events.HealthUpdate
+  alias Lattice.Events.ReconciliationResult
+  alias Lattice.Events.StateChange
+
+  # ── Topic Helpers ──────────────────────────────────────────────────
+
+  describe "topic helpers" do
+    test "sprite_topic/1 returns the per-sprite topic" do
+      assert Events.sprite_topic("sprite-001") == "sprites:sprite-001"
+    end
+
+    test "fleet_topic/0 returns the fleet topic" do
+      assert Events.fleet_topic() == "sprites:fleet"
+    end
+
+    test "approvals_topic/0 returns the approvals topic" do
+      assert Events.approvals_topic() == "sprites:approvals"
+    end
+  end
+
+  # ── PubSub Subscribe + Broadcast ───────────────────────────────────
+
+  describe "subscribe_sprite/1 and broadcast_state_change/1" do
+    test "delivers state change events to sprite subscribers" do
+      :ok = Events.subscribe_sprite("sprite-pub-1")
+
+      {:ok, event} = StateChange.new("sprite-pub-1", :hibernating, :waking)
+      :ok = Events.broadcast_state_change(event)
+
+      assert_receive %StateChange{sprite_id: "sprite-pub-1", to_state: :waking}
+    end
+
+    test "delivers state change events to fleet subscribers" do
+      :ok = Events.subscribe_fleet()
+
+      {:ok, event} = StateChange.new("sprite-fleet-1", :ready, :busy)
+      :ok = Events.broadcast_state_change(event)
+
+      assert_receive %StateChange{sprite_id: "sprite-fleet-1", to_state: :busy}
+    end
+  end
+
+  describe "broadcast_reconciliation_result/1" do
+    test "delivers reconciliation events to sprite subscribers" do
+      :ok = Events.subscribe_sprite("sprite-recon-1")
+
+      {:ok, event} = ReconciliationResult.new("sprite-recon-1", :success, 42)
+      :ok = Events.broadcast_reconciliation_result(event)
+
+      assert_receive %ReconciliationResult{sprite_id: "sprite-recon-1", outcome: :success}
+    end
+
+    test "delivers reconciliation events to fleet subscribers" do
+      :ok = Events.subscribe_fleet()
+
+      {:ok, event} = ReconciliationResult.new("sprite-recon-2", :failure, 100)
+      :ok = Events.broadcast_reconciliation_result(event)
+
+      assert_receive %ReconciliationResult{sprite_id: "sprite-recon-2", outcome: :failure}
+    end
+  end
+
+  describe "broadcast_health_update/1" do
+    test "delivers health events to sprite subscribers" do
+      :ok = Events.subscribe_sprite("sprite-health-1")
+
+      {:ok, event} = HealthUpdate.new("sprite-health-1", :healthy, 15)
+      :ok = Events.broadcast_health_update(event)
+
+      assert_receive %HealthUpdate{sprite_id: "sprite-health-1", status: :healthy}
+    end
+
+    test "delivers health events to fleet subscribers" do
+      :ok = Events.subscribe_fleet()
+
+      {:ok, event} = HealthUpdate.new("sprite-health-2", :degraded, 200)
+      :ok = Events.broadcast_health_update(event)
+
+      assert_receive %HealthUpdate{sprite_id: "sprite-health-2", status: :degraded}
+    end
+  end
+
+  describe "broadcast_approval_needed/1" do
+    test "delivers approval events to sprite subscribers" do
+      :ok = Events.subscribe_sprite("sprite-approval-1")
+
+      {:ok, event} = ApprovalNeeded.new("sprite-approval-1", "deploy", :dangerous)
+      :ok = Events.broadcast_approval_needed(event)
+
+      assert_receive %ApprovalNeeded{sprite_id: "sprite-approval-1", action: "deploy"}
+    end
+
+    test "delivers approval events to fleet subscribers" do
+      :ok = Events.subscribe_fleet()
+
+      {:ok, event} = ApprovalNeeded.new("sprite-approval-2", "delete", :needs_review)
+      :ok = Events.broadcast_approval_needed(event)
+
+      assert_receive %ApprovalNeeded{sprite_id: "sprite-approval-2", action: "delete"}
+    end
+
+    test "delivers approval events to approvals subscribers" do
+      :ok = Events.subscribe_approvals()
+
+      {:ok, event} = ApprovalNeeded.new("sprite-approval-3", "force push", :dangerous)
+      :ok = Events.broadcast_approval_needed(event)
+
+      assert_receive %ApprovalNeeded{sprite_id: "sprite-approval-3", action: "force push"}
+    end
+  end
+
+  # ── Telemetry Emissions ────────────────────────────────────────────
+
+  describe "telemetry events" do
+    setup do
+      test_pid = self()
+      ref = make_ref()
+
+      handler_id = "test-#{inspect(ref)}"
+
+      events = [
+        [:lattice, :sprite, :state_change],
+        [:lattice, :sprite, :reconciliation],
+        [:lattice, :sprite, :health_update],
+        [:lattice, :sprite, :approval_needed],
+        [:lattice, :capability, :call],
+        [:lattice, :fleet, :summary]
+      ]
+
+      :telemetry.attach_many(
+        handler_id,
+        events,
+        fn event_name, measurements, metadata, _config ->
+          send(test_pid, {:telemetry, ref, event_name, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      %{ref: ref}
+    end
+
+    test "broadcast_state_change emits telemetry", %{ref: ref} do
+      :ok = Events.subscribe_sprite("sprite-tel-1")
+      {:ok, event} = StateChange.new("sprite-tel-1", :waking, :ready)
+      Events.broadcast_state_change(event)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :sprite, :state_change], measurements,
+                      metadata}
+
+      assert %{system_time: _} = measurements
+      assert metadata.sprite_id == "sprite-tel-1"
+      assert metadata.event == event
+    end
+
+    test "broadcast_reconciliation_result emits telemetry", %{ref: ref} do
+      :ok = Events.subscribe_sprite("sprite-tel-2")
+      {:ok, event} = ReconciliationResult.new("sprite-tel-2", :success, 50)
+      Events.broadcast_reconciliation_result(event)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :sprite, :reconciliation], _measurements,
+                      metadata}
+
+      assert metadata.sprite_id == "sprite-tel-2"
+      assert metadata.event.outcome == :success
+    end
+
+    test "broadcast_health_update emits telemetry", %{ref: ref} do
+      :ok = Events.subscribe_sprite("sprite-tel-3")
+      {:ok, event} = HealthUpdate.new("sprite-tel-3", :unhealthy, 5000)
+      Events.broadcast_health_update(event)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :sprite, :health_update], _measurements,
+                      metadata}
+
+      assert metadata.sprite_id == "sprite-tel-3"
+      assert metadata.event.status == :unhealthy
+    end
+
+    test "broadcast_approval_needed emits telemetry", %{ref: ref} do
+      :ok = Events.subscribe_sprite("sprite-tel-4")
+      {:ok, event} = ApprovalNeeded.new("sprite-tel-4", "rm -rf", :dangerous)
+      Events.broadcast_approval_needed(event)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :sprite, :approval_needed], _measurements,
+                      metadata}
+
+      assert metadata.sprite_id == "sprite-tel-4"
+      assert metadata.event.classification == :dangerous
+    end
+
+    test "emit_capability_call emits telemetry", %{ref: ref} do
+      Events.emit_capability_call(:sprites, :list_sprites, 150, :ok)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :capability, :call], measurements, metadata}
+
+      assert measurements.duration_ms == 150
+      assert metadata.capability == :sprites
+      assert metadata.operation == :list_sprites
+      assert metadata.result == :ok
+    end
+
+    test "emit_capability_call handles error results", %{ref: ref} do
+      Events.emit_capability_call(:github, :create_issue, 500, {:error, :timeout})
+
+      assert_receive {:telemetry, ^ref, [:lattice, :capability, :call], measurements, metadata}
+
+      assert measurements.duration_ms == 500
+      assert metadata.capability == :github
+      assert metadata.result == {:error, :timeout}
+    end
+
+    test "emit_fleet_summary emits telemetry", %{ref: ref} do
+      summary = %{total: 10, by_state: %{ready: 5, busy: 3, hibernating: 2}}
+      Events.emit_fleet_summary(summary)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :fleet, :summary], measurements, metadata}
+
+      assert measurements.total == 10
+      assert metadata.by_state == %{ready: 5, busy: 3, hibernating: 2}
+    end
+
+    test "emit_fleet_summary handles empty summary", %{ref: ref} do
+      Events.emit_fleet_summary(%{})
+
+      assert_receive {:telemetry, ^ref, [:lattice, :fleet, :summary], measurements, metadata}
+
+      assert measurements.total == 0
+      assert metadata.by_state == %{}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implement `Lattice.Events` module with PubSub topic conventions (`sprites:<id>`, `sprites:fleet`, `sprites:approvals`), subscribe/broadcast helpers, and Telemetry emission functions
- Define four event structs — `StateChange`, `ReconciliationResult`, `HealthUpdate`, `ApprovalNeeded` — each with validation, factory functions, and enforced keys
- Create `Lattice.Events.TelemetryHandler` with log-level-aware handlers for all six event types under the `[:lattice, ...]` namespace (state changes, reconciliation, health, approvals, capability calls, fleet summaries)
- Attach telemetry handler in `Application.start/2` before the supervision tree boots, register domain metrics in `LatticeWeb.Telemetry`, and configure Logger metadata keys for structured output

## Design Decisions

- **Telemetry for instrumentation, PubSub for fan-out.** Both are emitted on every broadcast — Telemetry for metrics/logging, PubSub for real-time delivery to LiveView processes. Separate concerns, same trigger.
- **Structs for all event types** per CLAUDE.md: domain types use structs, not bare maps. Each struct enforces required keys and validates enum fields at construction time.
- **Broadcast to multiple topics** — each sprite event goes to both the per-sprite topic and the fleet topic; approval events additionally go to the approvals topic. This enables LiveView to subscribe at the granularity it needs.
- **Handler logs at appropriate levels** — info for success, warning for failures/degraded, error for unhealthy. No silent state changes.

## Test Plan

- [x] Unit tests for all four event structs (valid construction, invalid state/outcome/status/classification rejection, enforce_keys)
- [x] Integration tests for PubSub subscribe + broadcast across all event types and all topic combinations
- [x] Integration tests verifying Telemetry events are emitted with correct measurements and metadata
- [x] Integration tests for TelemetryHandler log output via `capture_log`
- [x] 103 tests passing, `mix credo --strict` clean, `mix compile --warnings-as-errors` clean

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)