### PR TITLE
Add instance identity and resource binding

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -78,7 +78,13 @@ config :logger, :default_formatter,
     :total,
     :by_state,
     :actor,
-    :args
+    :args,
+    :instance_name,
+    :environment,
+    :github_repo,
+    :fly_org,
+    :fly_app,
+    :sprites_api_base
   ]
 
 # Use Jason for JSON parsing in Phoenix

--- a/lib/lattice/application.ex
+++ b/lib/lattice/application.ex
@@ -6,12 +6,18 @@ defmodule Lattice.Application do
   use Application
 
   alias Lattice.Events.TelemetryHandler
+  alias Lattice.Instance
 
   @impl true
   def start(_type, _args) do
     # Attach Lattice domain telemetry handlers before starting the supervision tree.
     # This ensures events emitted during startup are captured.
     TelemetryHandler.attach()
+
+    # Validate resource bindings and log instance identity at boot.
+    # In prod, missing bindings cause a crash (fail fast).
+    Instance.validate!()
+    Instance.log_boot_info()
 
     children = [
       LatticeWeb.Telemetry,

--- a/lib/lattice/instance.ex
+++ b/lib/lattice/instance.ex
@@ -1,0 +1,274 @@
+defmodule Lattice.Instance do
+  @moduledoc """
+  Instance identity and resource binding for a Lattice deployment.
+
+  Each Lattice instance has a name, an environment, and a set of bound
+  resources (GitHub repo, Fly org/app, Sprites API base URL). This module
+  provides a clean API for reading that configuration, validating it at
+  startup, and logging the boot identity.
+
+  ## Configuration
+
+  Instance config is set in `config/runtime.exs`:
+
+      config :lattice, :instance,
+        name: System.get_env("LATTICE_INSTANCE_NAME", "lattice-dev"),
+        environment: config_env()
+
+      config :lattice, :resources,
+        github_repo: System.get_env("GITHUB_REPO"),
+        fly_org: System.get_env("FLY_ORG"),
+        fly_app: System.get_env("FLY_APP"),
+        sprites_api_base: System.get_env("SPRITES_API_BASE")
+
+  ## Startup Validation
+
+  In production, all resource bindings must be present. Call `validate!/0`
+  from `Application.start/2` to fail fast if required bindings are missing.
+  In dev and test, missing bindings are tolerated.
+
+  ## Cross-Wiring Guard
+
+  Capability modules can call `validate_resource!/2` to verify they are
+  operating against the configured resource, preventing accidental
+  cross-environment operations.
+  """
+
+  require Logger
+
+  @resource_keys [:github_repo, :fly_org, :fly_app, :sprites_api_base]
+
+  # Keys whose values should be partially redacted in logs
+  @secret_patterns ~w(api_base)
+
+  # ── Public API ────────────────────────────────────────────────────
+
+  @doc """
+  Returns the instance name.
+
+  ## Examples
+
+      iex> Lattice.Instance.name()
+      "lattice-dev"
+
+  """
+  @spec name() :: String.t()
+  def name do
+    instance_config()[:name] || "unknown"
+  end
+
+  @doc """
+  Returns the instance environment as an atom.
+
+  ## Examples
+
+      iex> Lattice.Instance.environment()
+      :dev
+
+  """
+  @spec environment() :: atom()
+  def environment do
+    instance_config()[:environment] || :unknown
+  end
+
+  @doc """
+  Returns the full resource binding as a keyword list.
+
+  ## Examples
+
+      Lattice.Instance.resources()
+      #=> [github_repo: "plattegruber/lattice", fly_org: "lattice-org", ...]
+
+  """
+  @spec resources() :: keyword()
+  def resources do
+    Application.get_env(:lattice, :resources, [])
+  end
+
+  @doc """
+  Returns a specific bound resource value.
+
+  ## Examples
+
+      Lattice.Instance.resource(:github_repo)
+      #=> "plattegruber/lattice"
+
+  """
+  @spec resource(atom()) :: String.t() | nil
+  def resource(key) when is_atom(key) do
+    resources()[key]
+  end
+
+  @doc """
+  Returns a map suitable for JSON serialization containing instance identity.
+
+  Includes the instance name, environment, and a sanitized view of bound
+  resources (secrets are partially redacted).
+
+  ## Examples
+
+      Lattice.Instance.identity()
+      #=> %{name: "lattice-dev", environment: :dev, resources: %{github_repo: "plattegruber/lattice", ...}}
+
+  """
+  @spec identity() :: map()
+  def identity do
+    %{
+      name: name(),
+      environment: environment(),
+      resources: sanitized_resources()
+    }
+  end
+
+  @doc """
+  Returns the resource bindings with sensitive values partially redacted.
+
+  Values containing URL-like strings or API endpoints are truncated to show
+  only the host portion. Other values are shown in full.
+  """
+  @spec sanitized_resources() :: map()
+  def sanitized_resources do
+    resources()
+    |> Enum.map(fn {key, value} -> {key, sanitize_value(key, value)} end)
+    |> Map.new()
+  end
+
+  # ── Validation ────────────────────────────────────────────────────
+
+  @doc """
+  Validate that all required resource bindings are present.
+
+  In production, raises if any required binding is missing or blank.
+  In dev/test, logs warnings for missing bindings but does not raise.
+
+  Returns `:ok` on success.
+  """
+  @spec validate!() :: :ok
+  def validate! do
+    missing = missing_resources()
+
+    case {environment(), missing} do
+      {_, []} ->
+        :ok
+
+      {:prod, missing_keys} ->
+        raise """
+        Missing required resource bindings for production: #{inspect(missing_keys)}.
+
+        Set the following environment variables:
+        #{Enum.map_join(missing_keys, "\n", &"  - #{env_var_for(&1)}")}
+        """
+
+      {env, missing_keys} ->
+        Logger.warning(
+          "Missing resource bindings in #{env}: #{inspect(missing_keys)}. " <>
+            "This is acceptable for development but would fail in production."
+        )
+
+        :ok
+    end
+  end
+
+  @doc """
+  Validate that the given resource matches the configured binding.
+
+  Used by capability modules to guard against cross-wiring. Raises
+  `ArgumentError` if the actual resource does not match the configured one.
+
+  ## Examples
+
+      Lattice.Instance.validate_resource!(:github_repo, "plattegruber/lattice")
+      #=> :ok
+
+      Lattice.Instance.validate_resource!(:github_repo, "other-org/other-repo")
+      #=> ** (ArgumentError) ...
+
+  """
+  @spec validate_resource!(atom(), String.t()) :: :ok
+  def validate_resource!(key, actual) when is_atom(key) and is_binary(actual) do
+    case resource(key) do
+      nil ->
+        Logger.warning("No configured binding for #{key}, skipping cross-wire check")
+        :ok
+
+      ^actual ->
+        :ok
+
+      expected ->
+        raise ArgumentError,
+              "Resource cross-wiring detected! " <>
+                "Expected #{key} to be #{inspect(expected)}, " <>
+                "but got #{inspect(actual)}. " <>
+                "Check your environment configuration."
+    end
+  end
+
+  # ── Boot Logging ──────────────────────────────────────────────────
+
+  @doc """
+  Log the full instance identity at boot time.
+
+  Called from `Application.start/2` to make the instance identity visible
+  in the boot log. Secrets are sanitized.
+  """
+  @spec log_boot_info() :: :ok
+  def log_boot_info do
+    sanitized = sanitized_resources()
+
+    Logger.info("Lattice instance starting",
+      instance_name: name(),
+      environment: environment(),
+      github_repo: sanitized[:github_repo],
+      fly_org: sanitized[:fly_org],
+      fly_app: sanitized[:fly_app],
+      sprites_api_base: sanitized[:sprites_api_base]
+    )
+
+    :ok
+  end
+
+  # ── Private ───────────────────────────────────────────────────────
+
+  defp instance_config do
+    Application.get_env(:lattice, :instance, [])
+  end
+
+  defp missing_resources do
+    @resource_keys
+    |> Enum.filter(fn key ->
+      value = resource(key)
+      is_nil(value) or value == ""
+    end)
+  end
+
+  defp env_var_for(:github_repo), do: "GITHUB_REPO"
+  defp env_var_for(:fly_org), do: "FLY_ORG"
+  defp env_var_for(:fly_app), do: "FLY_APP"
+  defp env_var_for(:sprites_api_base), do: "SPRITES_API_BASE"
+
+  defp sanitize_value(_key, nil), do: nil
+  defp sanitize_value(_key, ""), do: ""
+
+  defp sanitize_value(key, value) when is_binary(value) do
+    if secret_key?(key) do
+      redact_url(value)
+    else
+      value
+    end
+  end
+
+  defp secret_key?(key) do
+    key_string = to_string(key)
+    Enum.any?(@secret_patterns, &String.contains?(key_string, &1))
+  end
+
+  defp redact_url(value) do
+    uri = URI.parse(value)
+
+    if uri.scheme && uri.host do
+      "#{uri.scheme}://#{uri.host}/***"
+    else
+      value
+    end
+  end
+end

--- a/lib/lattice_web/components/layouts/root.html.heex
+++ b/lib/lattice_web/components/layouts/root.html.heex
@@ -32,5 +32,16 @@
   </head>
   <body>
     {@inner_content}
+    <footer class="px-4 py-3 text-xs text-center opacity-60 border-t border-base-300">
+      <span>
+        {Lattice.Instance.name()} | {Lattice.Instance.environment()}
+        <%= if repo = Lattice.Instance.resource(:github_repo) do %>
+          | {repo}
+        <% end %>
+        <%= if fly_app = Lattice.Instance.resource(:fly_app) do %>
+          | fly:{fly_app}
+        <% end %>
+      </span>
+    </footer>
   </body>
 </html>

--- a/lib/lattice_web/controllers/health_controller.ex
+++ b/lib/lattice_web/controllers/health_controller.ex
@@ -1,7 +1,13 @@
 defmodule LatticeWeb.HealthController do
   use LatticeWeb, :controller
 
+  alias Lattice.Instance
+
   def index(conn, _params) do
-    json(conn, %{status: "ok", timestamp: DateTime.utc_now()})
+    json(conn, %{
+      status: "ok",
+      timestamp: DateTime.utc_now(),
+      instance: Instance.identity()
+    })
   end
 end

--- a/test/lattice/instance_test.exs
+++ b/test/lattice/instance_test.exs
@@ -1,0 +1,216 @@
+defmodule Lattice.InstanceTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Instance
+
+  # ── Identity ──────────────────────────────────────────────────────
+
+  describe "name/0" do
+    test "returns the configured instance name" do
+      assert is_binary(Instance.name())
+    end
+
+    test "returns default when no config is set" do
+      original = Application.get_env(:lattice, :instance)
+      Application.put_env(:lattice, :instance, [])
+
+      assert Instance.name() == "unknown"
+
+      Application.put_env(:lattice, :instance, original)
+    end
+  end
+
+  describe "environment/0" do
+    test "returns the configured environment as an atom" do
+      assert is_atom(Instance.environment())
+    end
+  end
+
+  describe "resources/0" do
+    test "returns a keyword list of resource bindings" do
+      resources = Instance.resources()
+      assert is_list(resources)
+    end
+  end
+
+  describe "resource/1" do
+    test "returns nil for unconfigured resources" do
+      # In test, resources may not be set
+      result = Instance.resource(:github_repo)
+      assert is_nil(result) or is_binary(result)
+    end
+  end
+
+  describe "identity/0" do
+    test "returns a map with name, environment, and resources" do
+      identity = Instance.identity()
+
+      assert is_map(identity)
+      assert Map.has_key?(identity, :name)
+      assert Map.has_key?(identity, :environment)
+      assert Map.has_key?(identity, :resources)
+      assert is_binary(identity.name)
+      assert is_atom(identity.environment)
+      assert is_map(identity.resources)
+    end
+  end
+
+  # ── Sanitization ──────────────────────────────────────────────────
+
+  describe "sanitized_resources/0" do
+    test "redacts URL-like values for secret keys" do
+      original = Application.get_env(:lattice, :resources)
+
+      Application.put_env(:lattice, :resources,
+        github_repo: "plattegruber/lattice",
+        fly_org: "lattice-org",
+        fly_app: "lattice-app",
+        sprites_api_base: "https://api.sprites.example.com/v1"
+      )
+
+      sanitized = Instance.sanitized_resources()
+
+      # Non-secret keys are shown in full
+      assert sanitized.github_repo == "plattegruber/lattice"
+      assert sanitized.fly_org == "lattice-org"
+      assert sanitized.fly_app == "lattice-app"
+
+      # Secret keys (containing "api_base") are redacted
+      assert sanitized.sprites_api_base == "https://api.sprites.example.com/***"
+
+      Application.put_env(:lattice, :resources, original)
+    end
+
+    test "handles nil values without crashing" do
+      original = Application.get_env(:lattice, :resources)
+
+      Application.put_env(:lattice, :resources,
+        github_repo: nil,
+        fly_org: nil,
+        fly_app: nil,
+        sprites_api_base: nil
+      )
+
+      sanitized = Instance.sanitized_resources()
+      assert sanitized.github_repo == nil
+
+      Application.put_env(:lattice, :resources, original)
+    end
+  end
+
+  # ── Validation ────────────────────────────────────────────────────
+
+  describe "validate!/0" do
+    test "returns :ok in test environment even with missing bindings" do
+      original = Application.get_env(:lattice, :resources)
+
+      Application.put_env(:lattice, :resources,
+        github_repo: nil,
+        fly_org: nil,
+        fly_app: nil,
+        sprites_api_base: nil
+      )
+
+      assert Instance.validate!() == :ok
+
+      Application.put_env(:lattice, :resources, original)
+    end
+
+    test "returns :ok when all bindings are present" do
+      original_resources = Application.get_env(:lattice, :resources)
+
+      Application.put_env(:lattice, :resources,
+        github_repo: "plattegruber/lattice",
+        fly_org: "lattice-org",
+        fly_app: "lattice-app",
+        sprites_api_base: "https://api.example.com"
+      )
+
+      assert Instance.validate!() == :ok
+
+      Application.put_env(:lattice, :resources, original_resources)
+    end
+
+    test "raises in prod when bindings are missing" do
+      original_instance = Application.get_env(:lattice, :instance)
+      original_resources = Application.get_env(:lattice, :resources)
+
+      Application.put_env(:lattice, :instance, name: "prod-test", environment: :prod)
+
+      Application.put_env(:lattice, :resources,
+        github_repo: nil,
+        fly_org: nil,
+        fly_app: nil,
+        sprites_api_base: nil
+      )
+
+      assert_raise RuntimeError, ~r/Missing required resource bindings for production/, fn ->
+        Instance.validate!()
+      end
+
+      Application.put_env(:lattice, :instance, original_instance)
+      Application.put_env(:lattice, :resources, original_resources)
+    end
+  end
+
+  # ── Cross-Wiring Guard ───────────────────────────────────────────
+
+  describe "validate_resource!/2" do
+    test "returns :ok when the resource matches" do
+      original = Application.get_env(:lattice, :resources)
+
+      Application.put_env(:lattice, :resources,
+        github_repo: "plattegruber/lattice",
+        fly_org: "lattice-org",
+        fly_app: "lattice-app",
+        sprites_api_base: "https://api.example.com"
+      )
+
+      assert Instance.validate_resource!(:github_repo, "plattegruber/lattice") == :ok
+
+      Application.put_env(:lattice, :resources, original)
+    end
+
+    test "raises when the resource does not match" do
+      original = Application.get_env(:lattice, :resources)
+
+      Application.put_env(:lattice, :resources,
+        github_repo: "plattegruber/lattice",
+        fly_org: "lattice-org",
+        fly_app: "lattice-app",
+        sprites_api_base: "https://api.example.com"
+      )
+
+      assert_raise ArgumentError, ~r/Resource cross-wiring detected/, fn ->
+        Instance.validate_resource!(:github_repo, "other-org/other-repo")
+      end
+
+      Application.put_env(:lattice, :resources, original)
+    end
+
+    test "returns :ok when the resource is not configured" do
+      original = Application.get_env(:lattice, :resources)
+
+      Application.put_env(:lattice, :resources,
+        github_repo: nil,
+        fly_org: nil,
+        fly_app: nil,
+        sprites_api_base: nil
+      )
+
+      assert Instance.validate_resource!(:github_repo, "any-value") == :ok
+
+      Application.put_env(:lattice, :resources, original)
+    end
+  end
+
+  # ── Boot Logging ──────────────────────────────────────────────────
+
+  describe "log_boot_info/0" do
+    test "returns :ok and does not crash" do
+      assert Instance.log_boot_info() == :ok
+    end
+  end
+end

--- a/test/lattice_web/controllers/health_controller_test.exs
+++ b/test/lattice_web/controllers/health_controller_test.exs
@@ -3,6 +3,25 @@ defmodule LatticeWeb.HealthControllerTest do
 
   test "GET /health returns ok", %{conn: conn} do
     conn = get(conn, "/health")
-    assert json_response(conn, 200)["status"] == "ok"
+    body = json_response(conn, 200)
+
+    assert body["status"] == "ok"
+  end
+
+  test "GET /health includes instance identity", %{conn: conn} do
+    conn = get(conn, "/health")
+    body = json_response(conn, 200)
+
+    assert is_map(body["instance"])
+    assert is_binary(body["instance"]["name"])
+    assert is_binary(body["instance"]["environment"])
+    assert is_map(body["instance"]["resources"])
+  end
+
+  test "GET /health includes timestamp", %{conn: conn} do
+    conn = get(conn, "/health")
+    body = json_response(conn, 200)
+
+    assert is_binary(body["timestamp"])
   end
 end


### PR DESCRIPTION
## Summary

- Add `Lattice.Instance` module that reads `:instance` and `:resources` config, provides a clean API for instance name/environment/resources, validates bindings at startup (fails fast in prod), and guards against cross-wiring
- Update health endpoint (`GET /health`) to include full instance identity in the JSON response (name, environment, sanitized resources)
- Add instance identity footer to the root HTML layout showing instance name, environment, and bound resources
- Add startup validation and boot logging in `Application.start/2`

Closes #17

## Test plan

- [x] `Lattice.Instance` unit tests cover: name/environment accessors, resource lookup, identity map structure, secret sanitization (URL redaction for `api_base` keys), nil handling, prod validation raises on missing bindings, dev/test validation warns but passes, cross-wiring detection raises on mismatch, cross-wiring skips when unconfigured, boot logging returns `:ok`
- [x] `HealthController` tests verify: status "ok", instance identity map with name/environment/resources, timestamp present
- [x] All 196 tests pass
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)