### PR TITLE
Add auth boundary and operator identity (Clerk)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,6 +17,9 @@ config :lattice, :capabilities,
   fly: Lattice.Capabilities.Fly.Stub,
   secret_store: Lattice.Capabilities.SecretStore.Env
 
+# Auth provider — stub for dev, Clerk for production
+config :lattice, :auth, provider: Lattice.Auth.Stub
+
 # Safety guardrails — action gating and approval requirements
 config :lattice, :guardrails,
   allow_controlled: true,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -34,6 +34,11 @@ config :lattice, :resources,
   fly_app: System.get_env("FLY_APP"),
   sprites_api_base: System.get_env("SPRITES_API_BASE")
 
+# Auth provider: use Clerk when secret key is configured, otherwise stub
+if System.get_env("CLERK_SECRET_KEY") do
+  config :lattice, :auth, provider: Lattice.Auth.Clerk
+end
+
 if config_env() == :prod do
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/config/test.exs
+++ b/config/test.exs
@@ -29,3 +29,6 @@ config :lattice, :capabilities,
   github: Lattice.Capabilities.MockGitHub,
   fly: Lattice.Capabilities.MockFly,
   secret_store: Lattice.Capabilities.MockSecretStore
+
+# Use stub auth provider in tests (returns a hardcoded dev operator)
+config :lattice, :auth, provider: Lattice.Auth.Stub

--- a/lib/lattice/auth.ex
+++ b/lib/lattice/auth.ex
@@ -1,0 +1,65 @@
+defmodule Lattice.Auth do
+  @moduledoc """
+  Behaviour for authenticating operators.
+
+  Follows the same pattern as capability modules: a behaviour defines the
+  contract, configuration selects the active implementation, and proxy
+  functions delegate to the configured module.
+
+  ## Implementations
+
+  - `Lattice.Auth.Stub` -- returns a hardcoded dev operator (for local dev
+    and tests when Clerk keys are not configured)
+  - `Lattice.Auth.Clerk` -- verifies Clerk JWTs via JWKS and maps Clerk
+    users to Operator structs
+
+  ## Configuration
+
+  In `config/config.exs`:
+
+      config :lattice, :auth,
+        provider: Lattice.Auth.Stub
+
+  In `config/runtime.exs` (when Clerk keys are present):
+
+      config :lattice, :auth,
+        provider: Lattice.Auth.Clerk
+
+  ## Usage
+
+      case Lattice.Auth.verify_token(token) do
+        {:ok, %Operator{}} -> # authenticated
+        {:error, reason} -> # denied
+      end
+  """
+
+  alias Lattice.Auth.Operator
+
+  @doc """
+  Verify a session token and return the authenticated Operator.
+
+  The token format depends on the implementation:
+  - Stub: any string (ignored, returns hardcoded operator)
+  - Clerk: a Clerk session JWT
+  """
+  @callback verify_token(String.t()) :: {:ok, Operator.t()} | {:error, term()}
+
+  @doc """
+  Verify a session token using the configured auth provider.
+  """
+  @spec verify_token(String.t()) :: {:ok, Operator.t()} | {:error, term()}
+  def verify_token(token), do: impl().verify_token(token)
+
+  @doc """
+  Returns the configured auth provider module.
+  """
+  @spec provider() :: module()
+  def provider, do: impl()
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp impl do
+    Application.get_env(:lattice, :auth, [])
+    |> Keyword.get(:provider, Lattice.Auth.Stub)
+  end
+end

--- a/lib/lattice/auth/clerk.ex
+++ b/lib/lattice/auth/clerk.ex
@@ -1,0 +1,264 @@
+defmodule Lattice.Auth.Clerk do
+  @moduledoc """
+  Clerk auth provider that verifies session JWTs.
+
+  Clerk issues RS256-signed JWTs for authenticated sessions. This module
+  verifies those tokens using Clerk's JWKS (JSON Web Key Set) endpoint,
+  then maps the Clerk user to a Lattice Operator struct.
+
+  ## How It Works
+
+  1. Decode the JWT header to confirm RS256 algorithm and extract the `kid`
+  2. Fetch the JWKS from Clerk's Backend API (cached in ETS)
+  3. Find the matching public key by `kid`
+  4. Verify the RSA signature using Erlang's `:public_key` module
+  5. Validate claims (`exp`, `nbf`)
+  6. Fetch user details from Clerk's API to build the Operator struct
+
+  ## Configuration
+
+  Required environment variables (read at runtime):
+  - `CLERK_SECRET_KEY` -- Clerk secret key for API calls
+
+  ## Role Mapping
+
+  Clerk user metadata can contain a `lattice_role` field in `public_metadata`.
+  If not present, defaults to `:operator`.
+  """
+
+  @behaviour Lattice.Auth
+
+  alias Lattice.Auth.Operator
+
+  require Logger
+
+  @jwks_ets_table :lattice_clerk_jwks
+  @jwks_cache_ttl_ms :timer.minutes(60)
+
+  # ── Public API ─────────────────────────────────────────────────────
+
+  @impl true
+  def verify_token(token) when is_binary(token) do
+    with {:ok, header, payload} <- decode_jwt(token),
+         :ok <- validate_algorithm(header),
+         kid = Map.get(header, "kid"),
+         {:ok, jwk} <- fetch_jwk(kid),
+         {:ok, public_key} <- jwk_to_public_key(jwk),
+         :ok <- verify_signature(token, public_key),
+         :ok <- validate_claims(payload) do
+      build_operator(payload)
+    end
+  end
+
+  def verify_token(_token), do: {:error, :invalid_token}
+
+  # ── JWT Decoding ───────────────────────────────────────────────────
+
+  defp decode_jwt(token) do
+    case String.split(token, ".") do
+      [header_b64, payload_b64, _signature] ->
+        with {:ok, header_json} <- Base.url_decode64(header_b64, padding: false),
+             {:ok, header} <- Jason.decode(header_json),
+             {:ok, payload_json} <- Base.url_decode64(payload_b64, padding: false),
+             {:ok, payload} <- Jason.decode(payload_json) do
+          {:ok, header, payload}
+        else
+          _ -> {:error, :malformed_token}
+        end
+
+      _ ->
+        {:error, :malformed_token}
+    end
+  end
+
+  defp validate_algorithm(%{"alg" => "RS256"}), do: :ok
+  defp validate_algorithm(_), do: {:error, :unsupported_algorithm}
+
+  # ── JWKS Fetching ──────────────────────────────────────────────────
+
+  defp fetch_jwk(kid) do
+    case get_cached_jwks() do
+      {:ok, keys} ->
+        find_key(keys, kid)
+
+      :miss ->
+        case fetch_and_cache_jwks() do
+          {:ok, keys} -> find_key(keys, kid)
+          {:error, _} = error -> error
+        end
+    end
+  end
+
+  defp find_key(keys, kid) do
+    case Enum.find(keys, fn key -> Map.get(key, "kid") == kid end) do
+      nil -> {:error, :key_not_found}
+      key -> {:ok, key}
+    end
+  end
+
+  defp get_cached_jwks do
+    ensure_ets_table()
+
+    case :ets.lookup(@jwks_ets_table, :jwks) do
+      [{:jwks, keys, cached_at}] ->
+        if System.monotonic_time(:millisecond) - cached_at < @jwks_cache_ttl_ms do
+          {:ok, keys}
+        else
+          :miss
+        end
+
+      [] ->
+        :miss
+    end
+  end
+
+  defp fetch_and_cache_jwks do
+    secret_key = clerk_secret_key()
+
+    if is_nil(secret_key) or secret_key == "" do
+      {:error, :clerk_secret_key_not_configured}
+    else
+      fetch_jwks_from_clerk(secret_key)
+    end
+  end
+
+  defp fetch_jwks_from_clerk(secret_key) do
+    jwks_url = "https://api.clerk.com/v1/jwks"
+
+    headers = [
+      {~c"authorization", ~c"Bearer #{secret_key}"},
+      {~c"accept", ~c"application/json"}
+    ]
+
+    case :httpc.request(:get, {String.to_charlist(jwks_url), headers}, [], []) do
+      {:ok, {{_, 200, _}, _headers, body}} ->
+        parse_and_cache_jwks(body)
+
+      {:ok, {{_, status, _}, _headers, _body}} ->
+        Logger.warning("Clerk JWKS fetch failed with status #{status}")
+        {:error, {:jwks_fetch_failed, status}}
+
+      {:error, reason} ->
+        Logger.warning("Clerk JWKS fetch error: #{inspect(reason)}")
+        {:error, {:jwks_fetch_error, reason}}
+    end
+  end
+
+  defp parse_and_cache_jwks(body) do
+    case Jason.decode(to_string(body)) do
+      {:ok, %{"keys" => keys}} ->
+        ensure_ets_table()
+        :ets.insert(@jwks_ets_table, {:jwks, keys, System.monotonic_time(:millisecond)})
+        {:ok, keys}
+
+      _ ->
+        {:error, :invalid_jwks_response}
+    end
+  end
+
+  defp ensure_ets_table do
+    case :ets.whereis(@jwks_ets_table) do
+      :undefined ->
+        :ets.new(@jwks_ets_table, [:set, :public, :named_table])
+
+      _ ->
+        :ok
+    end
+  end
+
+  # ── RSA Signature Verification ─────────────────────────────────────
+
+  defp jwk_to_public_key(%{"kty" => "RSA", "n" => n_b64, "e" => e_b64}) do
+    with {:ok, n_bytes} <- Base.url_decode64(n_b64, padding: false),
+         {:ok, e_bytes} <- Base.url_decode64(e_b64, padding: false) do
+      n = :crypto.bytes_to_integer(n_bytes)
+      e = :crypto.bytes_to_integer(e_bytes)
+      {:ok, {:RSAPublicKey, n, e}}
+    else
+      _ -> {:error, :invalid_jwk}
+    end
+  end
+
+  defp jwk_to_public_key(_), do: {:error, :unsupported_key_type}
+
+  defp verify_signature(token, public_key) do
+    [header_b64, payload_b64, signature_b64] = String.split(token, ".")
+    signing_input = "#{header_b64}.#{payload_b64}"
+
+    case Base.url_decode64(signature_b64, padding: false) do
+      {:ok, signature} ->
+        if :public_key.verify(signing_input, :sha256, signature, public_key) do
+          :ok
+        else
+          {:error, :invalid_signature}
+        end
+
+      _ ->
+        {:error, :malformed_signature}
+    end
+  end
+
+  # ── Claim Validation ───────────────────────────────────────────────
+
+  defp validate_claims(payload) do
+    now = System.system_time(:second)
+
+    with :ok <- validate_exp(payload, now) do
+      validate_nbf(payload, now)
+    end
+  end
+
+  defp validate_exp(%{"exp" => exp}, now) when is_integer(exp) do
+    if now < exp, do: :ok, else: {:error, :token_expired}
+  end
+
+  defp validate_exp(_, _), do: {:error, :missing_exp_claim}
+
+  defp validate_nbf(%{"nbf" => nbf}, now) when is_integer(nbf) do
+    # Allow 30 seconds of clock skew
+    if now >= nbf - 30, do: :ok, else: {:error, :token_not_yet_valid}
+  end
+
+  # nbf is optional
+  defp validate_nbf(_, _), do: :ok
+
+  # ── Operator Building ──────────────────────────────────────────────
+
+  defp build_operator(payload) do
+    user_id = Map.get(payload, "sub", "unknown")
+
+    # Clerk JWT claims may include user metadata
+    # The full name can come from session claims or we fall back to the user ID
+    name = extract_name(payload)
+    role = extract_role(payload)
+
+    Operator.new(user_id, name, role)
+  end
+
+  defp extract_name(payload) do
+    # Clerk session JWTs may include custom claims via JWT templates
+    # Fall back to subject ID if no name is available
+    case payload do
+      %{"name" => name} when is_binary(name) and name != "" -> name
+      %{"first_name" => first, "last_name" => last} -> "#{first} #{last}" |> String.trim()
+      %{"sub" => sub} -> sub
+      _ -> "Unknown Operator"
+    end
+  end
+
+  defp extract_role(payload) do
+    # Check for a custom lattice_role claim in public metadata
+    case get_in(payload, ["public_metadata", "lattice_role"]) do
+      "admin" -> :admin
+      "viewer" -> :viewer
+      "operator" -> :operator
+      _ -> :operator
+    end
+  end
+
+  # ── Config ─────────────────────────────────────────────────────────
+
+  defp clerk_secret_key do
+    System.get_env("CLERK_SECRET_KEY")
+  end
+end

--- a/lib/lattice/auth/operator.ex
+++ b/lib/lattice/auth/operator.ex
@@ -1,0 +1,89 @@
+defmodule Lattice.Auth.Operator do
+  @moduledoc """
+  Represents an authenticated human operator.
+
+  Every request (API or LiveView) carries an Operator struct that identifies
+  who is performing the action. This identity flows through to audit logs,
+  telemetry metadata, and safety gating decisions.
+
+  ## Roles
+
+  - `:viewer` -- read-only access, can observe but not trigger actions
+  - `:operator` -- can trigger actions (wake/sleep sprites, approve, etc.)
+  - `:admin` -- full access, including configuration changes
+
+  ## Fields
+
+  - `id` -- unique identifier (Clerk user ID or stub ID)
+  - `name` -- display name for logs and dashboard
+  - `role` -- one of `:viewer`, `:operator`, `:admin`
+  """
+
+  @type role :: :viewer | :operator | :admin
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          name: String.t(),
+          role: role()
+        }
+
+  @enforce_keys [:id, :name, :role]
+  defstruct [:id, :name, :role]
+
+  @valid_roles [:viewer, :operator, :admin]
+
+  @doc """
+  Create a new Operator struct.
+
+  Returns `{:ok, operator}` if the role is valid, or
+  `{:error, {:invalid_role, role}}` otherwise.
+
+  ## Examples
+
+      iex> Lattice.Auth.Operator.new("user_123", "Ada Lovelace", :operator)
+      {:ok, %Lattice.Auth.Operator{id: "user_123", name: "Ada Lovelace", role: :operator}}
+
+      iex> Lattice.Auth.Operator.new("user_123", "Ada", :superadmin)
+      {:error, {:invalid_role, :superadmin}}
+
+  """
+  @spec new(String.t(), String.t(), role()) :: {:ok, t()} | {:error, term()}
+  def new(id, name, role) when role in @valid_roles do
+    {:ok, %__MODULE__{id: id, name: name, role: role}}
+  end
+
+  def new(_id, _name, role) do
+    {:error, {:invalid_role, role}}
+  end
+
+  @doc """
+  Returns true if the operator has at least the given role level.
+
+  Role hierarchy: `:admin` > `:operator` > `:viewer`.
+
+  ## Examples
+
+      iex> op = %Lattice.Auth.Operator{id: "1", name: "Ada", role: :admin}
+      iex> Lattice.Auth.Operator.has_role?(op, :operator)
+      true
+
+      iex> op = %Lattice.Auth.Operator{id: "1", name: "Ada", role: :viewer}
+      iex> Lattice.Auth.Operator.has_role?(op, :operator)
+      false
+
+  """
+  @spec has_role?(t(), role()) :: boolean()
+  def has_role?(%__MODULE__{role: actual_role}, required_role) do
+    role_level(actual_role) >= role_level(required_role)
+  end
+
+  @doc "Returns the list of valid roles."
+  @spec valid_roles() :: [role()]
+  def valid_roles, do: @valid_roles
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp role_level(:viewer), do: 0
+  defp role_level(:operator), do: 1
+  defp role_level(:admin), do: 2
+end

--- a/lib/lattice/auth/stub.ex
+++ b/lib/lattice/auth/stub.ex
@@ -1,0 +1,37 @@
+defmodule Lattice.Auth.Stub do
+  @moduledoc """
+  Stub auth provider for development and testing.
+
+  Returns a hardcoded operator for any token. The operator identity is
+  read from application config, falling back to sensible defaults.
+
+  ## Configuration
+
+      config :lattice, :auth,
+        provider: Lattice.Auth.Stub,
+        stub_operator: %{
+          id: "dev-operator",
+          name: "Dev Operator",
+          role: :admin
+        }
+
+  If no stub_operator config is present, defaults to an admin operator
+  named "Dev Operator".
+  """
+
+  @behaviour Lattice.Auth
+
+  alias Lattice.Auth.Operator
+
+  @impl true
+  def verify_token(_token) do
+    config = Application.get_env(:lattice, :auth, [])
+    stub_config = Keyword.get(config, :stub_operator, %{})
+
+    id = Map.get(stub_config, :id, "dev-operator")
+    name = Map.get(stub_config, :name, "Dev Operator")
+    role = Map.get(stub_config, :role, :admin)
+
+    Operator.new(id, name, role)
+  end
+end

--- a/lib/lattice/events/telemetry_handler.ex
+++ b/lib/lattice/events/telemetry_handler.ex
@@ -188,9 +188,15 @@ defmodule Lattice.Events.TelemetryHandler do
         {:error, _} -> :warning
       end
 
+    operator_info =
+      case entry.operator do
+        %{id: id, name: name} -> "#{name} (#{id})"
+        _ -> "none"
+      end
+
     Logger.log(
       log_level,
-      "Audit: #{entry.capability}.#{entry.operation} [#{entry.classification}] -> #{inspect(entry.result)}",
+      "Audit: #{entry.capability}.#{entry.operation} [#{entry.classification}] -> #{inspect(entry.result)} by #{operator_info}",
       capability: entry.capability,
       operation: entry.operation,
       classification: entry.classification,

--- a/lib/lattice/safety/audit.ex
+++ b/lib/lattice/safety/audit.ex
@@ -37,11 +37,16 @@ defmodule Lattice.Safety.Audit do
   - `actor` -- who initiated (`:system`, `:human`, `:scheduled`)
   - `opts` -- optional keyword list:
     - `:args` -- list of arguments (will be sanitized)
+    - `:operator` -- the authenticated `%Operator{}` who triggered the action
     - `:timestamp` -- override timestamp
 
   ## Examples
 
       Lattice.Safety.Audit.log(:sprites, :wake, :controlled, :ok, :human, args: ["sprite-001"])
+
+      operator = %Lattice.Auth.Operator{id: "user_123", name: "Ada", role: :operator}
+      Lattice.Safety.Audit.log(:sprites, :wake, :controlled, :ok, :human,
+        args: ["sprite-001"], operator: operator)
 
   """
   @spec log(

--- a/lib/lattice_web/hooks/auth_hook.ex
+++ b/lib/lattice_web/hooks/auth_hook.ex
@@ -1,0 +1,83 @@
+defmodule LatticeWeb.Hooks.AuthHook do
+  @moduledoc """
+  LiveView on_mount hook for authenticating operators.
+
+  Reads the session token from the LiveView session (set during the
+  initial HTTP request), verifies it via the configured auth provider,
+  and assigns the resulting Operator to the socket.
+
+  If authentication fails, redirects to the root path.
+
+  ## Usage
+
+  In a LiveView module:
+
+      on_mount {LatticeWeb.Hooks.AuthHook, :default}
+
+  Or in the router for all LiveViews in a scope:
+
+      live_session :authenticated, on_mount: [{LatticeWeb.Hooks.AuthHook, :default}] do
+        live "/fleet", FleetLive
+      end
+
+  ## Role-Based Hooks
+
+  For role-specific access control, use the role atoms:
+
+      on_mount {LatticeWeb.Hooks.AuthHook, :operator}
+      on_mount {LatticeWeb.Hooks.AuthHook, :admin}
+  """
+
+  import Phoenix.LiveView
+  import Phoenix.Component
+
+  alias Lattice.Auth
+  alias Lattice.Auth.Operator
+
+  @doc false
+  def on_mount(:default, _params, session, socket) do
+    authenticate(session, socket)
+  end
+
+  def on_mount(:viewer, _params, session, socket) do
+    with {:cont, socket} <- authenticate(session, socket) do
+      require_role(socket, :viewer)
+    end
+  end
+
+  def on_mount(:operator, _params, session, socket) do
+    with {:cont, socket} <- authenticate(session, socket) do
+      require_role(socket, :operator)
+    end
+  end
+
+  def on_mount(:admin, _params, session, socket) do
+    with {:cont, socket} <- authenticate(session, socket) do
+      require_role(socket, :admin)
+    end
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp authenticate(session, socket) do
+    token = Map.get(session, "auth_token", "stub")
+
+    case Auth.verify_token(token) do
+      {:ok, operator} ->
+        {:cont, assign(socket, :current_operator, operator)}
+
+      {:error, _reason} ->
+        {:halt, redirect(socket, to: "/")}
+    end
+  end
+
+  defp require_role(socket, required_role) do
+    operator = socket.assigns.current_operator
+
+    if Operator.has_role?(operator, required_role) do
+      {:cont, socket}
+    else
+      {:halt, redirect(socket, to: "/")}
+    end
+  end
+end

--- a/lib/lattice_web/plugs/auth.ex
+++ b/lib/lattice_web/plugs/auth.ex
@@ -1,0 +1,68 @@
+defmodule LatticeWeb.Plugs.Auth do
+  @moduledoc """
+  Plug that authenticates API requests and assigns the operator.
+
+  Reads the `Authorization: Bearer <token>` header, verifies the token
+  via the configured auth provider, and assigns the resulting Operator
+  struct to `conn.assigns.current_operator`.
+
+  If authentication fails, responds with 401 Unauthorized.
+
+  ## Usage
+
+  In the router:
+
+      pipeline :authenticated_api do
+        plug :accepts, ["json"]
+        plug LatticeWeb.Plugs.Auth
+      end
+
+  In controllers:
+
+      def index(conn, _params) do
+        operator = conn.assigns.current_operator
+        # ...
+      end
+  """
+
+  import Plug.Conn
+
+  alias Lattice.Auth
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    case extract_token(conn) do
+      {:ok, token} ->
+        case Auth.verify_token(token) do
+          {:ok, operator} ->
+            assign(conn, :current_operator, operator)
+
+          {:error, _reason} ->
+            conn
+            |> put_resp_content_type("application/json")
+            |> send_resp(401, Jason.encode!(%{error: "unauthorized"}))
+            |> halt()
+        end
+
+      :error ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(401, Jason.encode!(%{error: "missing_authorization_header"}))
+        |> halt()
+    end
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp extract_token(conn) do
+    case get_req_header(conn, "authorization") do
+      ["Bearer " <> token] -> {:ok, token}
+      _ -> :error
+    end
+  end
+end

--- a/lib/lattice_web/plugs/require_role.ex
+++ b/lib/lattice_web/plugs/require_role.ex
@@ -1,0 +1,52 @@
+defmodule LatticeWeb.Plugs.RequireRole do
+  @moduledoc """
+  Plug that enforces role-based access control on API routes.
+
+  Must be used after `LatticeWeb.Plugs.Auth`, which sets
+  `conn.assigns.current_operator`. Returns 403 Forbidden if the
+  operator does not have the required role level.
+
+  ## Usage
+
+      pipeline :operator_api do
+        plug LatticeWeb.Plugs.Auth
+        plug LatticeWeb.Plugs.RequireRole, role: :operator
+      end
+  """
+
+  import Plug.Conn
+
+  alias Lattice.Auth.Operator
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts) do
+    role = Keyword.fetch!(opts, :role)
+
+    unless role in Operator.valid_roles() do
+      raise ArgumentError, "invalid role: #{inspect(role)}"
+    end
+
+    role
+  end
+
+  @impl true
+  def call(%{assigns: %{current_operator: operator}} = conn, required_role) do
+    if Operator.has_role?(operator, required_role) do
+      conn
+    else
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(403, Jason.encode!(%{error: "forbidden", required_role: required_role}))
+      |> halt()
+    end
+  end
+
+  def call(conn, _required_role) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(401, Jason.encode!(%{error: "unauthorized"}))
+    |> halt()
+  end
+end

--- a/lib/lattice_web/router.ex
+++ b/lib/lattice_web/router.ex
@@ -14,16 +14,39 @@ defmodule LatticeWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :authenticated_api do
+    plug :accepts, ["json"]
+    plug LatticeWeb.Plugs.Auth
+  end
+
   scope "/", LatticeWeb do
     pipe_through :browser
 
     get "/", PageController, :home
   end
 
+  # Unauthenticated API routes
   scope "/", LatticeWeb do
     pipe_through :api
 
     get "/health", HealthController, :index
+  end
+
+  # Authenticated API routes -- protected by bearer token
+  scope "/api", LatticeWeb do
+    pipe_through :authenticated_api
+
+    # Future API endpoints go here
+  end
+
+  # Authenticated LiveView routes
+  live_session :authenticated,
+    on_mount: [{LatticeWeb.Hooks.AuthHook, :default}] do
+    scope "/", LatticeWeb do
+      pipe_through :browser
+
+      # Future LiveView routes go here
+    end
   end
 
   # Enable LiveDashboard in development

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Lattice.MixProject do
   def application do
     [
       mod: {Lattice.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :inets, :ssl]
     ]
   end
 

--- a/test/lattice/auth/clerk_test.exs
+++ b/test/lattice/auth/clerk_test.exs
@@ -1,0 +1,53 @@
+defmodule Lattice.Auth.ClerkTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Auth.Clerk
+
+  # These tests verify the JWT parsing and validation logic without hitting
+  # Clerk's API. We use malformed and expired tokens to test error paths.
+  # Full integration testing with real Clerk tokens requires a running Clerk
+  # instance and is covered by integration tests.
+
+  describe "verify_token/1 with invalid tokens" do
+    test "rejects non-string token" do
+      assert {:error, :invalid_token} = Clerk.verify_token(123)
+      assert {:error, :invalid_token} = Clerk.verify_token(nil)
+    end
+
+    test "rejects malformed token (not 3 parts)" do
+      assert {:error, :malformed_token} = Clerk.verify_token("not-a-jwt")
+      assert {:error, :malformed_token} = Clerk.verify_token("two.parts")
+    end
+
+    test "rejects token with invalid base64 in header" do
+      assert {:error, :malformed_token} = Clerk.verify_token("!!!.payload.sig")
+    end
+
+    test "rejects token with non-RS256 algorithm" do
+      # Header: {"alg": "HS256", "typ": "JWT"}
+      header = Base.url_encode64(~s({"alg":"HS256","typ":"JWT"}), padding: false)
+      payload = Base.url_encode64(~s({"sub":"user_1","exp":9999999999}), padding: false)
+      token = "#{header}.#{payload}.fake-signature"
+
+      assert {:error, :unsupported_algorithm} = Clerk.verify_token(token)
+    end
+
+    test "rejects token when JWKS fetch fails (no CLERK_SECRET_KEY)" do
+      # Ensure no secret key is set
+      original = System.get_env("CLERK_SECRET_KEY")
+      System.delete_env("CLERK_SECRET_KEY")
+
+      # Header: {"alg": "RS256", "typ": "JWT", "kid": "test-kid"}
+      header = Base.url_encode64(~s({"alg":"RS256","typ":"JWT","kid":"test-kid"}), padding: false)
+      payload = Base.url_encode64(~s({"sub":"user_1","exp":9999999999}), padding: false)
+      token = "#{header}.#{payload}.fake-signature"
+
+      assert {:error, :clerk_secret_key_not_configured} = Clerk.verify_token(token)
+
+      # Restore original env
+      if original, do: System.put_env("CLERK_SECRET_KEY", original)
+    end
+  end
+end

--- a/test/lattice/auth/operator_test.exs
+++ b/test/lattice/auth/operator_test.exs
@@ -1,0 +1,56 @@
+defmodule Lattice.Auth.OperatorTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Auth.Operator
+
+  describe "new/3" do
+    test "creates an operator with valid role" do
+      assert {:ok, %Operator{id: "user_1", name: "Ada", role: :admin}} =
+               Operator.new("user_1", "Ada", :admin)
+    end
+
+    test "accepts all valid roles" do
+      for role <- [:viewer, :operator, :admin] do
+        assert {:ok, %Operator{role: ^role}} = Operator.new("id", "name", role)
+      end
+    end
+
+    test "rejects invalid role" do
+      assert {:error, {:invalid_role, :superadmin}} = Operator.new("id", "name", :superadmin)
+    end
+  end
+
+  describe "has_role?/2" do
+    test "admin has all roles" do
+      {:ok, op} = Operator.new("1", "Ada", :admin)
+
+      assert Operator.has_role?(op, :viewer)
+      assert Operator.has_role?(op, :operator)
+      assert Operator.has_role?(op, :admin)
+    end
+
+    test "operator has viewer and operator roles" do
+      {:ok, op} = Operator.new("1", "Ada", :operator)
+
+      assert Operator.has_role?(op, :viewer)
+      assert Operator.has_role?(op, :operator)
+      refute Operator.has_role?(op, :admin)
+    end
+
+    test "viewer has only viewer role" do
+      {:ok, op} = Operator.new("1", "Ada", :viewer)
+
+      assert Operator.has_role?(op, :viewer)
+      refute Operator.has_role?(op, :operator)
+      refute Operator.has_role?(op, :admin)
+    end
+  end
+
+  describe "valid_roles/0" do
+    test "returns all valid roles" do
+      assert Operator.valid_roles() == [:viewer, :operator, :admin]
+    end
+  end
+end

--- a/test/lattice/auth/stub_test.exs
+++ b/test/lattice/auth/stub_test.exs
@@ -1,0 +1,37 @@
+defmodule Lattice.Auth.StubTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Auth.Operator
+  alias Lattice.Auth.Stub
+
+  describe "verify_token/1" do
+    test "returns a valid operator for any token" do
+      assert {:ok, %Operator{}} = Stub.verify_token("any-token")
+    end
+
+    test "returns default dev operator when no config set" do
+      assert {:ok, %Operator{id: "dev-operator", name: "Dev Operator", role: :admin}} =
+               Stub.verify_token("ignored")
+    end
+
+    test "returns configured stub operator" do
+      original = Application.get_env(:lattice, :auth)
+
+      Application.put_env(:lattice, :auth,
+        provider: Lattice.Auth.Stub,
+        stub_operator: %{id: "custom-1", name: "Custom Op", role: :viewer}
+      )
+
+      assert {:ok, %Operator{id: "custom-1", name: "Custom Op", role: :viewer}} =
+               Stub.verify_token("anything")
+
+      Application.put_env(:lattice, :auth, original)
+    end
+
+    test "accepts nil token" do
+      assert {:ok, %Operator{}} = Stub.verify_token(nil)
+    end
+  end
+end

--- a/test/lattice/auth_test.exs
+++ b/test/lattice/auth_test.exs
@@ -1,0 +1,20 @@
+defmodule Lattice.AuthTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Auth
+  alias Lattice.Auth.Operator
+
+  describe "verify_token/1" do
+    test "delegates to the configured provider (stub in test)" do
+      assert {:ok, %Operator{}} = Auth.verify_token("any-token")
+    end
+  end
+
+  describe "provider/0" do
+    test "returns the configured provider module" do
+      assert Auth.provider() == Lattice.Auth.Stub
+    end
+  end
+end

--- a/test/lattice/safety/audit_operator_test.exs
+++ b/test/lattice/safety/audit_operator_test.exs
@@ -1,0 +1,67 @@
+defmodule Lattice.Safety.AuditOperatorTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Auth.Operator
+  alias Lattice.Safety.Audit
+  alias Lattice.Safety.AuditEntry
+
+  describe "log/6 with operator" do
+    setup do
+      test_pid = self()
+      ref = make_ref()
+      handler_id = "audit-operator-test-#{inspect(ref)}"
+
+      :telemetry.attach(
+        handler_id,
+        [:lattice, :safety, :audit],
+        fn _event_name, _measurements, metadata, _config ->
+          send(test_pid, {:audit_entry, ref, metadata.entry})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      {:ok, operator} = Operator.new("user_123", "Ada Lovelace", :operator)
+      %{ref: ref, operator: operator}
+    end
+
+    test "includes operator in audit entry", %{ref: ref, operator: operator} do
+      Audit.log(:sprites, :wake, :controlled, :ok, :human, operator: operator)
+
+      assert_receive {:audit_entry, ^ref, entry}
+
+      assert %AuditEntry{} = entry
+      assert entry.operator == operator
+      assert entry.operator.id == "user_123"
+      assert entry.operator.name == "Ada Lovelace"
+      assert entry.operator.role == :operator
+    end
+
+    test "operator defaults to nil when not provided", %{ref: ref} do
+      Audit.log(:sprites, :list_sprites, :safe, :ok, :system)
+
+      assert_receive {:audit_entry, ^ref, entry}
+
+      assert entry.operator == nil
+    end
+  end
+
+  describe "AuditEntry.new/6 with operator" do
+    test "accepts operator in opts" do
+      {:ok, operator} = Operator.new("op-1", "Test", :admin)
+
+      {:ok, entry} =
+        AuditEntry.new(:sprites, :wake, :controlled, :ok, :human, operator: operator)
+
+      assert entry.operator == operator
+    end
+
+    test "operator defaults to nil" do
+      {:ok, entry} = AuditEntry.new(:sprites, :wake, :controlled, :ok, :human)
+      assert entry.operator == nil
+    end
+  end
+end

--- a/test/lattice_web/plugs/auth_test.exs
+++ b/test/lattice_web/plugs/auth_test.exs
@@ -1,0 +1,51 @@
+defmodule LatticeWeb.Plugs.AuthTest do
+  use ExUnit.Case
+
+  import Plug.Conn
+  import Plug.Test
+
+  @moduletag :unit
+
+  alias LatticeWeb.Plugs.Auth
+
+  # In test env, the stub provider always succeeds
+
+  describe "call/2 with valid authorization header" do
+    test "assigns current_operator from bearer token" do
+      conn =
+        :get
+        |> conn("/api/test")
+        |> put_req_header("authorization", "Bearer some-token")
+        |> Auth.call(Auth.init([]))
+
+      assert %Lattice.Auth.Operator{} = conn.assigns.current_operator
+      refute conn.halted
+    end
+  end
+
+  describe "call/2 without authorization header" do
+    test "returns 401 with missing_authorization_header error" do
+      conn =
+        :get
+        |> conn("/api/test")
+        |> Auth.call(Auth.init([]))
+
+      assert conn.halted
+      assert conn.status == 401
+      assert Jason.decode!(conn.resp_body) == %{"error" => "missing_authorization_header"}
+    end
+  end
+
+  describe "call/2 with malformed authorization header" do
+    test "returns 401 for non-bearer token" do
+      conn =
+        :get
+        |> conn("/api/test")
+        |> put_req_header("authorization", "Basic user:pass")
+        |> Auth.call(Auth.init([]))
+
+      assert conn.halted
+      assert conn.status == 401
+    end
+  end
+end

--- a/test/lattice_web/plugs/require_role_test.exs
+++ b/test/lattice_web/plugs/require_role_test.exs
@@ -1,0 +1,72 @@
+defmodule LatticeWeb.Plugs.RequireRoleTest do
+  use ExUnit.Case
+
+  import Plug.Test
+
+  @moduletag :unit
+
+  alias Lattice.Auth.Operator
+  alias LatticeWeb.Plugs.RequireRole
+
+  describe "init/1" do
+    test "accepts valid roles" do
+      assert :viewer == RequireRole.init(role: :viewer)
+      assert :operator == RequireRole.init(role: :operator)
+      assert :admin == RequireRole.init(role: :admin)
+    end
+
+    test "raises on invalid role" do
+      assert_raise ArgumentError, fn -> RequireRole.init(role: :superadmin) end
+    end
+
+    test "raises when role is missing" do
+      assert_raise KeyError, fn -> RequireRole.init([]) end
+    end
+  end
+
+  describe "call/2 with sufficient role" do
+    test "passes through when operator has required role" do
+      {:ok, operator} = Operator.new("1", "Ada", :admin)
+
+      conn =
+        :get
+        |> conn("/api/test")
+        |> Plug.Conn.assign(:current_operator, operator)
+        |> RequireRole.call(:operator)
+
+      refute conn.halted
+    end
+  end
+
+  describe "call/2 with insufficient role" do
+    test "returns 403 when operator lacks required role" do
+      {:ok, operator} = Operator.new("1", "Ada", :viewer)
+
+      conn =
+        :get
+        |> conn("/api/test")
+        |> Plug.Conn.assign(:current_operator, operator)
+        |> RequireRole.call(:operator)
+
+      assert conn.halted
+      assert conn.status == 403
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "error" => "forbidden",
+               "required_role" => "operator"
+             }
+    end
+  end
+
+  describe "call/2 without operator" do
+    test "returns 401 when no operator is assigned" do
+      conn =
+        :get
+        |> conn("/api/test")
+        |> RequireRole.call(:viewer)
+
+      assert conn.halted
+      assert conn.status == 401
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implement auth behaviour (`Lattice.Auth`) following the same pattern as capability modules: a behaviour defines the contract, configuration selects the implementation
- Add `Lattice.Auth.Operator` struct with role-based access control (viewer, operator, admin)
- Implement `Lattice.Auth.Stub` provider for dev/test -- returns a hardcoded operator for any token
- Implement `Lattice.Auth.Clerk` provider for production -- verifies Clerk RS256 JWTs via JWKS endpoint using Erlang's native `:public_key` and `:crypto` modules (no external JWT dependencies)
- Add `LatticeWeb.Plugs.Auth` for API bearer token authentication
- Add `LatticeWeb.Plugs.RequireRole` for role-based API access control
- Add `LatticeWeb.Hooks.AuthHook` for LiveView session authentication with role-based variants
- Extend `AuditEntry` with optional `operator` field so audit logs carry the identity of who triggered each action
- Configure `runtime.exs` to auto-select Clerk provider when `CLERK_SECRET_KEY` is present, otherwise fall back to Stub

## Design Decisions

- **No new dependencies**: Clerk JWT (RS256) verification uses Erlang's built-in `:public_key` module and `:httpc` for JWKS fetching. JWKS responses are cached in ETS for 1 hour.
- **Behaviour pattern**: Follows the same capability-style architecture as `Lattice.Capabilities` -- a behaviour module, proxy functions, and swappable implementations.
- **Backward compatible audit**: The `operator` field on `AuditEntry` is optional (defaults to `nil`), so existing audit code continues to work unchanged.

## Test plan

- [x] Operator struct creation and role hierarchy
- [x] Stub provider returns valid operator for any token
- [x] Clerk provider rejects malformed, wrong-algorithm, and unconfigured tokens
- [x] Auth plug requires Bearer token, returns 401 on missing/invalid
- [x] RequireRole plug enforces role hierarchy, returns 403 on insufficient role
- [x] Audit entries carry operator identity when provided
- [x] All 227 tests pass
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean (0 issues)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)