### PR TITLE
Add Sprite GenServer with state model and reconciliation loop

### DIFF
--- a/lib/lattice/sprites/sprite.ex
+++ b/lib/lattice/sprites/sprite.ex
@@ -1,0 +1,315 @@
+defmodule Lattice.Sprites.Sprite do
+  @moduledoc """
+  GenServer representing a single Sprite process.
+
+  Each Sprite gets its own GenServer that:
+
+  - Owns the Sprite's internal state (`%Lattice.Sprites.State{}`)
+  - Runs a periodic reconciliation loop comparing desired vs. observed state
+  - Emits Telemetry events and PubSub broadcasts on state transitions
+  - Implements exponential backoff on reconciliation failures
+  - Resets backoff counters on successful reconciliation
+
+  ## Starting a Sprite
+
+      Lattice.Sprites.Sprite.start_link(sprite_id: "sprite-001", desired_state: :ready)
+
+  ## Querying State
+
+      {:ok, state} = Lattice.Sprites.Sprite.get_state(pid)
+
+  ## Changing Desired State
+
+      :ok = Lattice.Sprites.Sprite.set_desired_state(pid, :ready)
+
+  ## Reconciliation
+
+  The reconciliation loop runs on a timer (default: 5 seconds). Each cycle:
+
+  1. Compares `observed_state` to `desired_state`
+  2. If they differ, calls the appropriate capability to drive the transition
+  3. Emits a `ReconciliationResult` event with the outcome
+  4. On success, resets the backoff; on failure, applies exponential backoff
+
+  Reconciliation uses stub capabilities — no real API calls are made until
+  the real Sprites API integration in Step 2.
+  """
+
+  use GenServer
+
+  alias Lattice.Events
+  alias Lattice.Events.ReconciliationResult
+  alias Lattice.Events.StateChange
+  alias Lattice.Sprites.State
+
+  @default_reconcile_interval_ms 5_000
+
+  # ── Public API ──────────────────────────────────────────────────────
+
+  @doc """
+  Start a Sprite GenServer process.
+
+  ## Options
+
+  - `:sprite_id` (required) -- unique identifier for this Sprite
+  - `:desired_state` -- initial desired state (default: `:hibernating`)
+  - `:observed_state` -- initial observed state (default: `:hibernating`)
+  - `:reconcile_interval_ms` -- reconciliation loop interval (default: 5000)
+  - `:base_backoff_ms` -- base backoff for retries (default: 1000)
+  - `:max_backoff_ms` -- max backoff cap (default: 60000)
+  - `:name` -- GenServer name registration (optional)
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    sprite_id = Keyword.fetch!(opts, :sprite_id)
+    name = Keyword.get(opts, :name)
+
+    gen_opts = if name, do: [name: name], else: []
+    GenServer.start_link(__MODULE__, {sprite_id, opts}, gen_opts)
+  end
+
+  @doc """
+  Get the current state of a Sprite.
+
+  Returns `{:ok, %State{}}` with the current internal state.
+  """
+  @spec get_state(GenServer.server()) :: {:ok, State.t()}
+  def get_state(server) do
+    GenServer.call(server, :get_state)
+  end
+
+  @doc """
+  Set the desired state for a Sprite.
+
+  Triggers reconciliation on the next cycle. Returns `:ok` on success or
+  `{:error, reason}` if the desired state is invalid.
+  """
+  @spec set_desired_state(GenServer.server(), State.lifecycle()) :: :ok | {:error, term()}
+  def set_desired_state(server, desired_state) do
+    GenServer.call(server, {:set_desired_state, desired_state})
+  end
+
+  @doc """
+  Trigger an immediate reconciliation cycle.
+
+  Useful for testing or when an operator wants to force a reconciliation
+  without waiting for the next scheduled cycle.
+  """
+  @spec reconcile_now(GenServer.server()) :: :ok
+  def reconcile_now(server) do
+    GenServer.cast(server, :reconcile_now)
+  end
+
+  # ── GenServer Callbacks ─────────────────────────────────────────────
+
+  @impl true
+  def init({sprite_id, opts}) do
+    state_opts = [
+      desired_state: Keyword.get(opts, :desired_state, :hibernating),
+      observed_state: Keyword.get(opts, :observed_state, :hibernating),
+      base_backoff_ms: Keyword.get(opts, :base_backoff_ms, 1_000),
+      max_backoff_ms: Keyword.get(opts, :max_backoff_ms, 60_000)
+    ]
+
+    reconcile_interval = Keyword.get(opts, :reconcile_interval_ms, @default_reconcile_interval_ms)
+
+    case State.new(sprite_id, state_opts) do
+      {:ok, state} ->
+        schedule_reconcile(reconcile_interval)
+        {:ok, {state, reconcile_interval}}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  end
+
+  @impl true
+  def handle_call(:get_state, _from, {state, _interval} = server_state) do
+    {:reply, {:ok, state}, server_state}
+  end
+
+  def handle_call({:set_desired_state, desired}, _from, {state, interval}) do
+    case State.set_desired(state, desired) do
+      {:ok, new_state} ->
+        {:reply, :ok, {new_state, interval}}
+
+      {:error, _reason} = error ->
+        {:reply, error, {state, interval}}
+    end
+  end
+
+  @impl true
+  def handle_cast(:reconcile_now, {state, interval}) do
+    {new_state, _outcome} = do_reconcile(state)
+    schedule_reconcile(interval)
+    {:noreply, {new_state, interval}}
+  end
+
+  @impl true
+  def handle_info(:reconcile, {state, interval}) do
+    {new_state, _outcome} = do_reconcile(state)
+    next_interval = reconcile_delay(new_state, interval)
+    schedule_reconcile(next_interval)
+    {:noreply, {new_state, interval}}
+  end
+
+  # ── Reconciliation Logic ────────────────────────────────────────────
+
+  defp do_reconcile(%State{} = state) do
+    start_time = System.monotonic_time(:millisecond)
+
+    if State.needs_reconciliation?(state) do
+      reconcile_transition(state, start_time)
+    else
+      emit_reconciliation_result(state, :no_change, 0)
+      {state, :no_change}
+    end
+  end
+
+  defp reconcile_transition(state, start_time) do
+    case attempt_transition(state) do
+      {:ok, new_observed} ->
+        duration = System.monotonic_time(:millisecond) - start_time
+        old_observed = state.observed_state
+
+        {:ok, new_state} = State.transition(state, new_observed)
+        new_state = State.reset_backoff(new_state)
+
+        emit_state_change(state.sprite_id, old_observed, new_observed, "reconciliation")
+        emit_reconciliation_result(state, :success, duration, "transitioned to #{new_observed}")
+
+        {new_state, :success}
+
+      {:error, reason} ->
+        duration = System.monotonic_time(:millisecond) - start_time
+        new_state = State.record_failure(state)
+
+        # Transition to error state if not already there
+        new_state = maybe_transition_to_error(new_state, state.observed_state)
+
+        emit_reconciliation_result(
+          state,
+          :failure,
+          duration,
+          "reconciliation failed: #{inspect(reason)}"
+        )
+
+        {new_state, :failure}
+    end
+  end
+
+  defp maybe_transition_to_error(%State{} = state, previous_observed) do
+    if previous_observed != :error do
+      case State.transition(state, :error) do
+        {:ok, error_state} ->
+          emit_state_change(
+            state.sprite_id,
+            previous_observed,
+            :error,
+            "reconciliation failure"
+          )
+
+          error_state
+
+        {:error, _} ->
+          state
+      end
+    else
+      state
+    end
+  end
+
+  # Determine what transition to attempt based on current and desired state.
+  # Uses stub capabilities — returns synthetic results.
+  defp attempt_transition(%State{observed_state: :hibernating, desired_state: desired})
+       when desired in [:waking, :ready, :busy] do
+    case sprites_capability().wake("synthetic") do
+      {:ok, _} -> {:ok, :waking}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp attempt_transition(%State{observed_state: :waking, desired_state: desired})
+       when desired in [:ready, :busy] do
+    # Simulate the waking -> ready transition completing
+    case sprites_capability().get_sprite("synthetic") do
+      {:ok, _} -> {:ok, :ready}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp attempt_transition(%State{observed_state: :ready, desired_state: :busy}) do
+    case sprites_capability().exec("synthetic", "start-task") do
+      {:ok, _} -> {:ok, :busy}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp attempt_transition(%State{observed_state: :ready, desired_state: :hibernating}) do
+    case sprites_capability().sleep("synthetic") do
+      {:ok, _} -> {:ok, :hibernating}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp attempt_transition(%State{observed_state: :busy, desired_state: :ready}) do
+    # Busy -> ready happens when the task completes
+    case sprites_capability().get_sprite("synthetic") do
+      {:ok, _} -> {:ok, :ready}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp attempt_transition(%State{observed_state: :busy, desired_state: :hibernating}) do
+    case sprites_capability().sleep("synthetic") do
+      {:ok, _} -> {:ok, :ready}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp attempt_transition(%State{observed_state: :error, desired_state: desired})
+       when desired in [:hibernating, :waking, :ready] do
+    # Attempt recovery from error state
+    case sprites_capability().wake("synthetic") do
+      {:ok, _} -> {:ok, :waking}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp attempt_transition(%State{observed_state: observed, desired_state: desired}) do
+    {:error, {:no_transition_path, from: observed, to: desired}}
+  end
+
+  # ── Event Emission ──────────────────────────────────────────────────
+
+  defp emit_state_change(sprite_id, from, to, reason) do
+    case StateChange.new(sprite_id, from, to, reason: reason) do
+      {:ok, event} -> Events.broadcast_state_change(event)
+      {:error, _} -> :ok
+    end
+  end
+
+  defp emit_reconciliation_result(state, outcome, duration_ms, details \\ nil) do
+    opts = if details, do: [details: details], else: []
+
+    case ReconciliationResult.new(state.sprite_id, outcome, duration_ms, opts) do
+      {:ok, event} -> Events.broadcast_reconciliation_result(event)
+      {:error, _} -> :ok
+    end
+  end
+
+  # ── Scheduling ──────────────────────────────────────────────────────
+
+  defp schedule_reconcile(interval_ms) do
+    Process.send_after(self(), :reconcile, interval_ms)
+  end
+
+  defp reconcile_delay(%State{failure_count: 0}, interval), do: interval
+  defp reconcile_delay(%State{backoff_ms: backoff}, _interval), do: backoff
+
+  # ── Capability Access ───────────────────────────────────────────────
+
+  defp sprites_capability do
+    Application.get_env(:lattice, :capabilities)[:sprites]
+  end
+end

--- a/lib/lattice/sprites/state.ex
+++ b/lib/lattice/sprites/state.ex
@@ -1,0 +1,217 @@
+defmodule Lattice.Sprites.State do
+  @moduledoc """
+  Internal state struct for a Sprite GenServer process.
+
+  Each Sprite GenServer holds a `%State{}` that tracks:
+
+  - **Identity** -- `sprite_id` is the unique identifier for this Sprite
+  - **Lifecycle** -- `observed_state` is the current state from the API;
+    `desired_state` is what the operator wants
+  - **Health** -- `health` summarizes the last health check result
+  - **Backoff** -- exponential backoff parameters for retry after failure
+  - **Failure tracking** -- `failure_count` tracks consecutive failures
+  - **Log cursor** -- `log_cursor` tracks the last-read log position
+
+  ## Lifecycle States
+
+  A Sprite moves through these states:
+
+      hibernating -> waking -> ready -> busy -> error
+
+  The `observed_state` reflects the actual state reported by the Sprites API.
+  The `desired_state` is the target set by the operator. The reconciliation
+  loop works to bring `observed_state` in line with `desired_state`.
+  """
+
+  @type lifecycle :: :hibernating | :waking | :ready | :busy | :error
+
+  @type t :: %__MODULE__{
+          sprite_id: String.t(),
+          observed_state: lifecycle(),
+          desired_state: lifecycle(),
+          health: :healthy | :degraded | :unhealthy | :unknown,
+          backoff_ms: non_neg_integer(),
+          max_backoff_ms: non_neg_integer(),
+          base_backoff_ms: non_neg_integer(),
+          failure_count: non_neg_integer(),
+          log_cursor: String.t() | nil,
+          started_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  @enforce_keys [:sprite_id, :started_at, :updated_at]
+  defstruct [
+    :sprite_id,
+    :log_cursor,
+    :started_at,
+    :updated_at,
+    observed_state: :hibernating,
+    desired_state: :hibernating,
+    health: :unknown,
+    backoff_ms: 1_000,
+    max_backoff_ms: 60_000,
+    base_backoff_ms: 1_000,
+    failure_count: 0
+  ]
+
+  @valid_lifecycle_states [:hibernating, :waking, :ready, :busy, :error]
+
+  @doc """
+  Creates a new State struct for a Sprite.
+
+  ## Options
+
+  - `:desired_state` -- initial desired state (default: `:hibernating`)
+  - `:observed_state` -- initial observed state (default: `:hibernating`)
+  - `:base_backoff_ms` -- base backoff interval in ms (default: 1000)
+  - `:max_backoff_ms` -- maximum backoff interval in ms (default: 60000)
+
+  ## Examples
+
+      iex> {:ok, state} = Lattice.Sprites.State.new("sprite-001")
+      iex> state.sprite_id
+      "sprite-001"
+      iex> state.observed_state
+      :hibernating
+
+  """
+  @spec new(String.t(), keyword()) :: {:ok, t()} | {:error, term()}
+  def new(sprite_id, opts \\ []) when is_binary(sprite_id) do
+    desired = Keyword.get(opts, :desired_state, :hibernating)
+    observed = Keyword.get(opts, :observed_state, :hibernating)
+    base_backoff = Keyword.get(opts, :base_backoff_ms, 1_000)
+    max_backoff = Keyword.get(opts, :max_backoff_ms, 60_000)
+
+    with :ok <- validate_lifecycle(desired),
+         :ok <- validate_lifecycle(observed) do
+      now = DateTime.utc_now()
+
+      {:ok,
+       %__MODULE__{
+         sprite_id: sprite_id,
+         observed_state: observed,
+         desired_state: desired,
+         base_backoff_ms: base_backoff,
+         backoff_ms: base_backoff,
+         max_backoff_ms: max_backoff,
+         started_at: now,
+         updated_at: now
+       }}
+    end
+  end
+
+  @doc """
+  Transition the observed state, updating the timestamp.
+
+  Returns `{:ok, updated_state}` if the new state is valid, or
+  `{:error, {:invalid_lifecycle, state}}` if it is not.
+
+  ## Examples
+
+      iex> {:ok, state} = Lattice.Sprites.State.new("sprite-001")
+      iex> {:ok, state} = Lattice.Sprites.State.transition(state, :waking)
+      iex> state.observed_state
+      :waking
+
+  """
+  @spec transition(t(), lifecycle()) :: {:ok, t()} | {:error, term()}
+  def transition(%__MODULE__{} = state, new_observed) do
+    with :ok <- validate_lifecycle(new_observed) do
+      {:ok, %{state | observed_state: new_observed, updated_at: DateTime.utc_now()}}
+    end
+  end
+
+  @doc """
+  Set the desired state, updating the timestamp.
+
+  Returns `{:ok, updated_state}` if the new state is valid, or
+  `{:error, {:invalid_lifecycle, state}}` if it is not.
+
+  ## Examples
+
+      iex> {:ok, state} = Lattice.Sprites.State.new("sprite-001")
+      iex> {:ok, state} = Lattice.Sprites.State.set_desired(state, :ready)
+      iex> state.desired_state
+      :ready
+
+  """
+  @spec set_desired(t(), lifecycle()) :: {:ok, t()} | {:error, term()}
+  def set_desired(%__MODULE__{} = state, new_desired) do
+    with :ok <- validate_lifecycle(new_desired) do
+      {:ok, %{state | desired_state: new_desired, updated_at: DateTime.utc_now()}}
+    end
+  end
+
+  @doc """
+  Record a failure, incrementing the counter and computing the next backoff.
+
+  Uses exponential backoff: `min(base * 2^failures, max_backoff)`.
+
+  ## Examples
+
+      iex> {:ok, state} = Lattice.Sprites.State.new("sprite-001", base_backoff_ms: 100, max_backoff_ms: 1000)
+      iex> state = Lattice.Sprites.State.record_failure(state)
+      iex> state.failure_count
+      1
+      iex> state.backoff_ms
+      200
+
+  """
+  @spec record_failure(t()) :: t()
+  def record_failure(%__MODULE__{} = state) do
+    new_count = state.failure_count + 1
+    new_backoff = compute_backoff(state.base_backoff_ms, new_count, state.max_backoff_ms)
+
+    %{state | failure_count: new_count, backoff_ms: new_backoff, updated_at: DateTime.utc_now()}
+  end
+
+  @doc """
+  Reset failure tracking after a successful operation.
+
+  Resets `failure_count` to 0 and `backoff_ms` to `base_backoff_ms`.
+
+  ## Examples
+
+      iex> {:ok, state} = Lattice.Sprites.State.new("sprite-001", base_backoff_ms: 100)
+      iex> state = Lattice.Sprites.State.record_failure(state)
+      iex> state = Lattice.Sprites.State.reset_backoff(state)
+      iex> state.failure_count
+      0
+      iex> state.backoff_ms
+      100
+
+  """
+  @spec reset_backoff(t()) :: t()
+  def reset_backoff(%__MODULE__{} = state) do
+    %{state | failure_count: 0, backoff_ms: state.base_backoff_ms, updated_at: DateTime.utc_now()}
+  end
+
+  @doc """
+  Returns true if the observed state differs from the desired state.
+
+  ## Examples
+
+      iex> {:ok, state} = Lattice.Sprites.State.new("sprite-001", desired_state: :ready)
+      iex> Lattice.Sprites.State.needs_reconciliation?(state)
+      true
+
+  """
+  @spec needs_reconciliation?(t()) :: boolean()
+  def needs_reconciliation?(%__MODULE__{observed_state: same, desired_state: same}), do: false
+  def needs_reconciliation?(%__MODULE__{}), do: true
+
+  @doc "Returns the list of valid lifecycle states."
+  @spec valid_lifecycle_states() :: [lifecycle()]
+  def valid_lifecycle_states, do: @valid_lifecycle_states
+
+  # ── Private ────────────────────────────────────────────────────────
+
+  defp validate_lifecycle(state) when state in @valid_lifecycle_states, do: :ok
+  defp validate_lifecycle(state), do: {:error, {:invalid_lifecycle, state}}
+
+  defp compute_backoff(base, failure_count, max) do
+    # Exponential backoff: base * 2^(failures - 1), capped at max
+    backoff = base * Integer.pow(2, failure_count - 1)
+    min(backoff, max)
+  end
+end

--- a/test/lattice/sprites/sprite_test.exs
+++ b/test/lattice/sprites/sprite_test.exs
@@ -1,0 +1,461 @@
+defmodule Lattice.Sprites.SpriteTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  import Mox
+
+  alias Lattice.Events
+  alias Lattice.Events.ReconciliationResult
+  alias Lattice.Events.StateChange
+  alias Lattice.Sprites.Sprite
+  alias Lattice.Sprites.State
+
+  # Mox requires verify_on_exit! for each test.
+  # set_mox_global allows stubs to be called from any process (the GenServer).
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  # Use a very long reconcile interval so tests control timing
+  @long_interval 60_000
+
+  # ── Helpers ─────────────────────────────────────────────────────────
+
+  defp start_sprite(opts \\ []) do
+    sprite_id =
+      Keyword.get(opts, :sprite_id, "sprite-test-#{System.unique_integer([:positive])}")
+
+    defaults = [
+      sprite_id: sprite_id,
+      reconcile_interval_ms: @long_interval,
+      base_backoff_ms: Keyword.get(opts, :base_backoff_ms, 100),
+      max_backoff_ms: Keyword.get(opts, :max_backoff_ms, 1_000)
+    ]
+
+    merged = Keyword.merge(defaults, opts)
+    {:ok, pid} = Sprite.start_link(merged)
+    {pid, sprite_id}
+  end
+
+  # ── Start & Init ────────────────────────────────────────────────────
+
+  describe "start_link/1" do
+    test "starts a Sprite GenServer" do
+      {pid, _id} = start_sprite()
+      assert Process.alive?(pid)
+    end
+
+    test "requires sprite_id option" do
+      assert_raise KeyError, ~r/sprite_id/, fn ->
+        Sprite.start_link(reconcile_interval_ms: @long_interval)
+      end
+    end
+
+    test "accepts a name option" do
+      name = :"sprite-named-#{System.unique_integer([:positive])}"
+
+      {:ok, pid} =
+        Sprite.start_link(
+          sprite_id: "named-sprite",
+          name: name,
+          reconcile_interval_ms: @long_interval
+        )
+
+      assert Process.alive?(pid)
+      assert GenServer.whereis(name) == pid
+    end
+
+    test "initializes with default hibernating state" do
+      {pid, _id} = start_sprite()
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.observed_state == :hibernating
+      assert state.desired_state == :hibernating
+    end
+
+    test "initializes with custom desired state" do
+      {pid, _id} = start_sprite(desired_state: :ready)
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.desired_state == :ready
+    end
+
+    test "initializes with custom observed state" do
+      {pid, _id} = start_sprite(observed_state: :ready)
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.observed_state == :ready
+    end
+  end
+
+  # ── get_state ───────────────────────────────────────────────────────
+
+  describe "get_state/1" do
+    test "returns the current state struct" do
+      {pid, sprite_id} = start_sprite()
+      {:ok, state} = Sprite.get_state(pid)
+
+      assert %State{} = state
+      assert state.sprite_id == sprite_id
+    end
+  end
+
+  # ── set_desired_state ───────────────────────────────────────────────
+
+  describe "set_desired_state/2" do
+    test "updates the desired state" do
+      {pid, _id} = start_sprite()
+      assert :ok = Sprite.set_desired_state(pid, :ready)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.desired_state == :ready
+    end
+
+    test "rejects invalid desired state" do
+      {pid, _id} = start_sprite()
+      assert {:error, {:invalid_lifecycle, :bogus}} = Sprite.set_desired_state(pid, :bogus)
+    end
+
+    test "preserves state on error" do
+      {pid, _id} = start_sprite()
+      Sprite.set_desired_state(pid, :bogus)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.desired_state == :hibernating
+    end
+  end
+
+  # ── Reconciliation: No Change ───────────────────────────────────────
+
+  describe "reconciliation with no change needed" do
+    test "emits no_change reconciliation result when states match" do
+      {pid, sprite_id} = start_sprite()
+
+      :ok = Events.subscribe_sprite(sprite_id)
+      :ok = Events.subscribe_fleet()
+
+      # Trigger reconciliation
+      Sprite.reconcile_now(pid)
+
+      # Should get a no_change result
+      assert_receive %ReconciliationResult{
+                       sprite_id: ^sprite_id,
+                       outcome: :no_change
+                     },
+                     1_000
+    end
+  end
+
+  # ── Reconciliation: Successful Transition ───────────────────────────
+
+  describe "reconciliation with transition" do
+    test "transitions hibernating -> waking when desired is ready" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:wake, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+
+      {pid, sprite_id} = start_sprite(desired_state: :ready)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      # First reconcile: hibernating -> waking
+      Sprite.reconcile_now(pid)
+
+      assert_receive %StateChange{
+                       sprite_id: ^sprite_id,
+                       from_state: :hibernating,
+                       to_state: :waking
+                     },
+                     1_000
+
+      assert_receive %ReconciliationResult{
+                       sprite_id: ^sprite_id,
+                       outcome: :success
+                     },
+                     1_000
+    end
+
+    test "transitions waking -> ready on next reconciliation" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+
+      {pid, sprite_id} = start_sprite(observed_state: :waking, desired_state: :ready)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive %StateChange{
+                       sprite_id: ^sprite_id,
+                       from_state: :waking,
+                       to_state: :ready
+                     },
+                     1_000
+    end
+
+    test "transitions ready -> busy" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:exec, fn _id, _cmd -> {:ok, %{exit_code: 0}} end)
+
+      {pid, sprite_id} = start_sprite(observed_state: :ready, desired_state: :busy)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive %StateChange{
+                       sprite_id: ^sprite_id,
+                       from_state: :ready,
+                       to_state: :busy
+                     },
+                     1_000
+    end
+
+    test "transitions ready -> hibernating" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:sleep, fn _id -> {:ok, %{id: "synthetic", status: "sleeping"}} end)
+
+      {pid, sprite_id} = start_sprite(observed_state: :ready, desired_state: :hibernating)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive %StateChange{
+                       sprite_id: ^sprite_id,
+                       from_state: :ready,
+                       to_state: :hibernating
+                     },
+                     1_000
+    end
+
+    test "resets backoff on successful reconciliation" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:wake, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+
+      {pid, _id} = start_sprite(desired_state: :waking)
+
+      Sprite.reconcile_now(pid)
+
+      # Allow time for async processing
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.failure_count == 0
+    end
+  end
+
+  # ── Reconciliation: Failure & Backoff ───────────────────────────────
+
+  describe "reconciliation failure and backoff" do
+    test "increments failure count on reconciliation failure" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:wake, fn _id -> {:error, :api_timeout} end)
+
+      {pid, _id} = start_sprite(desired_state: :waking)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.failure_count == 1
+    end
+
+    test "transitions to error state on failure" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:wake, fn _id -> {:error, :api_timeout} end)
+
+      {pid, sprite_id} = start_sprite(desired_state: :waking)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      # Should receive a state change to error
+      assert_receive %StateChange{
+                       sprite_id: ^sprite_id,
+                       from_state: :hibernating,
+                       to_state: :error
+                     },
+                     1_000
+
+      # And a failure reconciliation result
+      assert_receive %ReconciliationResult{
+                       sprite_id: ^sprite_id,
+                       outcome: :failure
+                     },
+                     1_000
+    end
+
+    test "accumulates failures with exponential backoff" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:wake, fn _id -> {:error, :api_timeout} end)
+
+      {pid, _id} =
+        start_sprite(desired_state: :waking, base_backoff_ms: 100, max_backoff_ms: 10_000)
+
+      # First failure
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.failure_count == 1
+      assert state.backoff_ms == 100
+
+      # Second failure (now in error state, trying to recover)
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.failure_count == 2
+      assert state.backoff_ms == 200
+    end
+
+    test "caps backoff at max" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:wake, fn _id -> {:error, :api_timeout} end)
+
+      {pid, _id} =
+        start_sprite(desired_state: :waking, base_backoff_ms: 100, max_backoff_ms: 200)
+
+      # Accumulate many failures
+      for _ <- 1..10 do
+        Sprite.reconcile_now(pid)
+        Process.sleep(20)
+      end
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.backoff_ms <= 200
+    end
+
+    test "recovery from error state resets backoff" do
+      # First, cause a failure
+      Lattice.Capabilities.MockSprites
+      |> stub(:wake, fn _id -> {:error, :timeout} end)
+
+      {pid, _id} = start_sprite(desired_state: :ready)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.observed_state == :error
+      assert state.failure_count > 0
+
+      # Now succeed on next attempt
+      Lattice.Capabilities.MockSprites
+      |> stub(:wake, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.observed_state == :waking
+      assert state.failure_count == 0
+      assert state.backoff_ms == 100
+    end
+  end
+
+  # ── PubSub Broadcasting ────────────────────────────────────────────
+
+  describe "PubSub broadcasting" do
+    test "broadcasts state changes to fleet topic" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:wake, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+
+      {pid, sprite_id} = start_sprite(desired_state: :waking)
+
+      :ok = Events.subscribe_fleet()
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive %StateChange{sprite_id: ^sprite_id}, 1_000
+    end
+
+    test "broadcasts reconciliation results to fleet topic" do
+      {pid, sprite_id} = start_sprite()
+
+      :ok = Events.subscribe_fleet()
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive %ReconciliationResult{sprite_id: ^sprite_id}, 1_000
+    end
+
+    test "broadcasts to per-sprite topic" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:wake, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+
+      {pid, sprite_id} = start_sprite(desired_state: :waking)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive %StateChange{sprite_id: ^sprite_id}, 1_000
+      assert_receive %ReconciliationResult{sprite_id: ^sprite_id}, 1_000
+    end
+  end
+
+  # ── Telemetry Events ───────────────────────────────────────────────
+
+  describe "telemetry events" do
+    setup do
+      test_pid = self()
+      ref = make_ref()
+      handler_id = "sprite-test-#{inspect(ref)}"
+
+      events = [
+        [:lattice, :sprite, :state_change],
+        [:lattice, :sprite, :reconciliation]
+      ]
+
+      :telemetry.attach_many(
+        handler_id,
+        events,
+        fn event_name, measurements, metadata, _config ->
+          send(test_pid, {:telemetry, ref, event_name, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      %{ref: ref}
+    end
+
+    test "emits telemetry on state change", %{ref: ref} do
+      Lattice.Capabilities.MockSprites
+      |> stub(:wake, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+
+      {pid, sprite_id} = start_sprite(desired_state: :waking)
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :sprite, :state_change], _measurements,
+                      %{sprite_id: ^sprite_id}},
+                     1_000
+    end
+
+    test "emits telemetry on reconciliation", %{ref: ref} do
+      {pid, sprite_id} = start_sprite()
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :sprite, :reconciliation], _measurements,
+                      %{sprite_id: ^sprite_id}},
+                     1_000
+    end
+  end
+
+  # ── Periodic Reconciliation ─────────────────────────────────────────
+
+  describe "periodic reconciliation" do
+    test "runs reconciliation on schedule" do
+      {pid, sprite_id} = start_sprite(reconcile_interval_ms: 50)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      # Wait for at least one reconciliation cycle
+      assert_receive %ReconciliationResult{sprite_id: ^sprite_id}, 500
+
+      # Verify process is still alive
+      assert Process.alive?(pid)
+    end
+  end
+end

--- a/test/lattice/sprites/state_test.exs
+++ b/test/lattice/sprites/state_test.exs
@@ -1,0 +1,200 @@
+defmodule Lattice.Sprites.StateTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Sprites.State
+
+  # ── Construction ────────────────────────────────────────────────────
+
+  describe "new/2" do
+    test "creates a state with defaults" do
+      assert {:ok, state} = State.new("sprite-001")
+
+      assert state.sprite_id == "sprite-001"
+      assert state.observed_state == :hibernating
+      assert state.desired_state == :hibernating
+      assert state.health == :unknown
+      assert state.failure_count == 0
+      assert state.backoff_ms == 1_000
+      assert state.base_backoff_ms == 1_000
+      assert state.max_backoff_ms == 60_000
+      assert state.log_cursor == nil
+      assert %DateTime{} = state.started_at
+      assert %DateTime{} = state.updated_at
+    end
+
+    test "accepts custom desired_state" do
+      assert {:ok, state} = State.new("sprite-001", desired_state: :ready)
+      assert state.desired_state == :ready
+    end
+
+    test "accepts custom observed_state" do
+      assert {:ok, state} = State.new("sprite-001", observed_state: :busy)
+      assert state.observed_state == :busy
+    end
+
+    test "accepts custom backoff parameters" do
+      assert {:ok, state} =
+               State.new("sprite-001", base_backoff_ms: 500, max_backoff_ms: 30_000)
+
+      assert state.base_backoff_ms == 500
+      assert state.backoff_ms == 500
+      assert state.max_backoff_ms == 30_000
+    end
+
+    test "rejects invalid desired_state" do
+      assert {:error, {:invalid_lifecycle, :invalid}} =
+               State.new("sprite-001", desired_state: :invalid)
+    end
+
+    test "rejects invalid observed_state" do
+      assert {:error, {:invalid_lifecycle, :bogus}} =
+               State.new("sprite-001", observed_state: :bogus)
+    end
+  end
+
+  # ── Transitions ─────────────────────────────────────────────────────
+
+  describe "transition/2" do
+    test "updates observed state" do
+      {:ok, state} = State.new("sprite-001")
+      assert {:ok, new_state} = State.transition(state, :waking)
+      assert new_state.observed_state == :waking
+    end
+
+    test "updates timestamp" do
+      {:ok, state} = State.new("sprite-001")
+      {:ok, new_state} = State.transition(state, :waking)
+      assert DateTime.compare(new_state.updated_at, state.updated_at) in [:gt, :eq]
+    end
+
+    test "rejects invalid state" do
+      {:ok, state} = State.new("sprite-001")
+      assert {:error, {:invalid_lifecycle, :flying}} = State.transition(state, :flying)
+    end
+
+    test "allows all valid lifecycle states" do
+      {:ok, state} = State.new("sprite-001")
+
+      for lifecycle <- State.valid_lifecycle_states() do
+        assert {:ok, %State{observed_state: ^lifecycle}} = State.transition(state, lifecycle)
+      end
+    end
+  end
+
+  # ── Set Desired ─────────────────────────────────────────────────────
+
+  describe "set_desired/2" do
+    test "updates desired state" do
+      {:ok, state} = State.new("sprite-001")
+      assert {:ok, new_state} = State.set_desired(state, :ready)
+      assert new_state.desired_state == :ready
+    end
+
+    test "updates timestamp" do
+      {:ok, state} = State.new("sprite-001")
+      {:ok, new_state} = State.set_desired(state, :ready)
+      assert DateTime.compare(new_state.updated_at, state.updated_at) in [:gt, :eq]
+    end
+
+    test "rejects invalid state" do
+      {:ok, state} = State.new("sprite-001")
+      assert {:error, {:invalid_lifecycle, :nope}} = State.set_desired(state, :nope)
+    end
+  end
+
+  # ── Backoff & Failure Tracking ──────────────────────────────────────
+
+  describe "record_failure/1" do
+    test "increments failure count" do
+      {:ok, state} = State.new("sprite-001")
+      state = State.record_failure(state)
+      assert state.failure_count == 1
+    end
+
+    test "applies exponential backoff" do
+      {:ok, state} = State.new("sprite-001", base_backoff_ms: 100, max_backoff_ms: 10_000)
+
+      state = State.record_failure(state)
+      # 100 * 2^0 = 100
+      assert state.backoff_ms == 100
+
+      state = State.record_failure(state)
+      # 100 * 2^1 = 200
+      assert state.backoff_ms == 200
+
+      state = State.record_failure(state)
+      # 100 * 2^2 = 400
+      assert state.backoff_ms == 400
+
+      state = State.record_failure(state)
+      # 100 * 2^3 = 800
+      assert state.backoff_ms == 800
+    end
+
+    test "caps backoff at max" do
+      {:ok, state} = State.new("sprite-001", base_backoff_ms: 100, max_backoff_ms: 500)
+
+      state =
+        Enum.reduce(1..10, state, fn _, acc -> State.record_failure(acc) end)
+
+      assert state.backoff_ms == 500
+    end
+
+    test "tracks consecutive failures" do
+      {:ok, state} = State.new("sprite-001")
+
+      state =
+        Enum.reduce(1..5, state, fn _, acc -> State.record_failure(acc) end)
+
+      assert state.failure_count == 5
+    end
+  end
+
+  describe "reset_backoff/1" do
+    test "resets failure count to zero" do
+      {:ok, state} = State.new("sprite-001")
+      state = State.record_failure(state)
+      state = State.record_failure(state)
+      state = State.reset_backoff(state)
+      assert state.failure_count == 0
+    end
+
+    test "resets backoff to base value" do
+      {:ok, state} = State.new("sprite-001", base_backoff_ms: 200)
+      state = State.record_failure(state)
+      state = State.record_failure(state)
+      state = State.reset_backoff(state)
+      assert state.backoff_ms == 200
+    end
+  end
+
+  # ── Needs Reconciliation ────────────────────────────────────────────
+
+  describe "needs_reconciliation?/1" do
+    test "returns false when observed matches desired" do
+      {:ok, state} = State.new("sprite-001")
+      refute State.needs_reconciliation?(state)
+    end
+
+    test "returns true when observed differs from desired" do
+      {:ok, state} = State.new("sprite-001", desired_state: :ready)
+      assert State.needs_reconciliation?(state)
+    end
+  end
+
+  # ── Valid States ────────────────────────────────────────────────────
+
+  describe "valid_lifecycle_states/0" do
+    test "returns all lifecycle states" do
+      states = State.valid_lifecycle_states()
+      assert :hibernating in states
+      assert :waking in states
+      assert :ready in states
+      assert :busy in states
+      assert :error in states
+      assert length(states) == 5
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Sprite state struct** (`Lattice.Sprites.State`): Typed struct modeling the Sprite lifecycle (`hibernating -> waking -> ready -> busy -> error`) with exponential backoff parameters, failure counters, and health tracking
- **Sprite GenServer** (`Lattice.Sprites.Sprite`): Process-per-Sprite with periodic reconciliation loop, state transitions via stub capabilities, synthetic event emission through existing Telemetry + PubSub infrastructure, and automatic exponential backoff on failure
- **Comprehensive test suite**: 30+ tests covering state struct operations, GenServer lifecycle, reconciliation transitions, PubSub broadcasting, telemetry emission, backoff/retry behavior, and error recovery

### Design Decisions

- GenServer state is a `{%State{}, reconcile_interval}` tuple per CLAUDE.md conventions
- Reconciliation uses `Process.send_after/3` for periodic scheduling
- Failed reconciliation transitions the Sprite to `:error` state and applies exponential backoff (capped at `max_backoff_ms`)
- Successful reconciliation resets all failure counters and backoff timers
- Uses existing `Lattice.Events.StateChange` and `Lattice.Events.ReconciliationResult` event structs
- Broadcasts to both per-sprite (`sprites:<id>`) and fleet (`sprites:fleet`) PubSub topics
- Tests use Mox with global mode for cross-process mock access

Closes #4

## Test plan

- [x] `mix compile --warnings-as-errors` passes (0 warnings)
- [x] `mix format --check-formatted` passes
- [x] `mix credo --strict` passes (0 issues)
- [x] `mix test` passes (276 tests, 0 failures)
- [ ] Verify state struct creation and validation
- [ ] Verify GenServer start, get_state, set_desired_state
- [ ] Verify reconciliation transitions through lifecycle states
- [ ] Verify PubSub event broadcasting on state changes
- [ ] Verify telemetry event emission
- [ ] Verify exponential backoff on failure and reset on success
- [ ] Verify periodic reconciliation runs on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)