### PR TITLE
Add Fleet Manager: sprite discovery and lifecycle coordination

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,6 +17,9 @@ config :lattice, :capabilities,
   fly: Lattice.Capabilities.Fly.Stub,
   secret_store: Lattice.Capabilities.SecretStore.Env
 
+# Fleet configuration — sprites to discover and manage at boot
+config :lattice, :fleet, sprites: []
+
 # Auth provider — stub for dev, Clerk for production
 config :lattice, :auth, provider: Lattice.Auth.Stub
 
@@ -87,7 +90,8 @@ config :logger, :default_formatter,
     :github_repo,
     :fly_org,
     :fly_app,
-    :sprites_api_base
+    :sprites_api_base,
+    :sprite_ids
   ]
 
 # Use Jason for JSON parsing in Phoenix

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -60,6 +60,14 @@ config :lattice, LatticeWeb.Endpoint,
 # Enable dev routes for dashboard and mailbox
 config :lattice, dev_routes: true
 
+# Dev fleet — synthetic sprites for dashboard development
+config :lattice, :fleet,
+  sprites: [
+    %{id: "sprite-dev-001", desired_state: :hibernating},
+    %{id: "sprite-dev-002", desired_state: :hibernating},
+    %{id: "sprite-dev-003", desired_state: :hibernating}
+  ]
+
 # Do not include metadata nor timestamps in development logs
 config :logger, :default_formatter, format: "[$level] $message\n"
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -32,3 +32,6 @@ config :lattice, :capabilities,
 
 # Use stub auth provider in tests (returns a hardcoded dev operator)
 config :lattice, :auth, provider: Lattice.Auth.Stub
+
+# Empty fleet in tests — individual tests configure their own sprites
+config :lattice, :fleet, sprites: []

--- a/lib/lattice/application.ex
+++ b/lib/lattice/application.ex
@@ -23,8 +23,10 @@ defmodule Lattice.Application do
       LatticeWeb.Telemetry,
       {DNSCluster, query: Application.get_env(:lattice, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Lattice.PubSub},
-      # Start a worker by calling: Lattice.Worker.start_link(arg)
-      # {Lattice.Worker, arg},
+      # Sprite process infrastructure
+      {Registry, keys: :unique, name: Lattice.Sprites.Registry},
+      {DynamicSupervisor, name: Lattice.Sprites.DynamicSupervisor, strategy: :one_for_one},
+      Lattice.Sprites.FleetManager,
       # Start to serve requests, typically the last entry
       LatticeWeb.Endpoint
     ]

--- a/lib/lattice/sprites/fleet_manager.ex
+++ b/lib/lattice/sprites/fleet_manager.ex
@@ -1,0 +1,301 @@
+defmodule Lattice.Sprites.FleetManager do
+  @moduledoc """
+  Fleet Manager: sprite discovery and lifecycle coordination.
+
+  The Fleet Manager is a GenServer responsible for:
+
+  - **Discovery** -- reading the configured sprite list and starting a
+    `Lattice.Sprites.Sprite` GenServer for each one under a DynamicSupervisor
+  - **Fleet queries** -- `list_sprites/0`, `fleet_summary/0`, `get_sprite_pid/1`
+  - **Fleet-wide operations** -- `wake_sprites/1`, `sleep_sprites/1`, `run_audit/0`
+  - **Observability** -- broadcasting fleet summary updates via PubSub on the
+    `"sprites:fleet"` topic after every fleet-mutating operation
+
+  ## Supervision
+
+  The Fleet Manager sits in the application supervision tree alongside:
+
+  - `Lattice.Sprites.Registry` -- process lookup by sprite_id
+  - `Lattice.Sprites.DynamicSupervisor` -- supervises individual Sprite GenServers
+
+  ## Configuration
+
+  Sprite discovery reads from application config:
+
+      config :lattice, :fleet,
+        sprites: [
+          %{id: "sprite-001", desired_state: :hibernating},
+          %{id: "sprite-002", desired_state: :ready}
+        ]
+
+  ## Events
+
+  After fleet-mutating operations, the Fleet Manager broadcasts a
+  `{:fleet_summary, summary}` message on the `"sprites:fleet"` PubSub topic
+  and emits a `[:lattice, :fleet, :summary]` Telemetry event.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Lattice.Events
+  alias Lattice.Sprites.Sprite
+  alias Lattice.Sprites.State
+
+  defmodule FleetState do
+    @moduledoc false
+    @type t :: %__MODULE__{
+            sprite_ids: [String.t()],
+            supervisor: atom() | pid(),
+            started_at: DateTime.t()
+          }
+
+    @enforce_keys [:supervisor, :started_at]
+    defstruct [:supervisor, :started_at, sprite_ids: []]
+  end
+
+  # ── Public API ──────────────────────────────────────────────────────
+
+  @doc """
+  Start the Fleet Manager.
+
+  ## Options
+
+  - `:name` -- GenServer name (default: `__MODULE__`)
+  - `:supervisor` -- DynamicSupervisor name (default: `Lattice.Sprites.DynamicSupervisor`)
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  List all managed sprite IDs with their current state.
+
+  Returns a list of `{sprite_id, %Lattice.Sprites.State{}}` tuples for all
+  sprites that are alive and responding.
+  """
+  @spec list_sprites(GenServer.server()) :: [{String.t(), State.t()}]
+  def list_sprites(server \\ __MODULE__) do
+    GenServer.call(server, :list_sprites)
+  end
+
+  @doc """
+  Get the PID of a sprite process by its ID.
+
+  Returns `{:ok, pid}` if the sprite is found in the Registry, or
+  `{:error, :not_found}` otherwise.
+  """
+  @spec get_sprite_pid(String.t()) :: {:ok, pid()} | {:error, :not_found}
+  def get_sprite_pid(sprite_id) when is_binary(sprite_id) do
+    case Registry.lookup(Lattice.Sprites.Registry, sprite_id) do
+      [{pid, _value}] -> {:ok, pid}
+      [] -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Return a summary of the fleet: total count and breakdown by observed state.
+
+  ## Example
+
+      FleetManager.fleet_summary()
+      #=> %{total: 3, by_state: %{hibernating: 2, ready: 1}}
+  """
+  @spec fleet_summary(GenServer.server()) :: map()
+  def fleet_summary(server \\ __MODULE__) do
+    GenServer.call(server, :fleet_summary)
+  end
+
+  @doc """
+  Set the desired state to `:ready` for the given sprite IDs (wake them up).
+
+  Returns a map of `%{sprite_id => :ok | {:error, reason}}`.
+  """
+  @spec wake_sprites([String.t()], GenServer.server()) :: %{String.t() => :ok | {:error, term()}}
+  def wake_sprites(sprite_ids, server \\ __MODULE__) when is_list(sprite_ids) do
+    GenServer.call(server, {:wake_sprites, sprite_ids})
+  end
+
+  @doc """
+  Set the desired state to `:hibernating` for the given sprite IDs (put them to sleep).
+
+  Returns a map of `%{sprite_id => :ok | {:error, reason}}`.
+  """
+  @spec sleep_sprites([String.t()], GenServer.server()) :: %{
+          String.t() => :ok | {:error, term()}
+        }
+  def sleep_sprites(sprite_ids, server \\ __MODULE__) when is_list(sprite_ids) do
+    GenServer.call(server, {:sleep_sprites, sprite_ids})
+  end
+
+  @doc """
+  Trigger an immediate reconciliation cycle on all managed sprites.
+
+  Returns `:ok` after sending reconcile commands to all sprites.
+  """
+  @spec run_audit(GenServer.server()) :: :ok
+  def run_audit(server \\ __MODULE__) do
+    GenServer.call(server, :run_audit)
+  end
+
+  # ── GenServer Callbacks ─────────────────────────────────────────────
+
+  @impl true
+  def init(opts) do
+    supervisor = Keyword.get(opts, :supervisor, Lattice.Sprites.DynamicSupervisor)
+
+    state = %FleetState{
+      supervisor: supervisor,
+      started_at: DateTime.utc_now()
+    }
+
+    {:ok, state, {:continue, :discover_sprites}}
+  end
+
+  @impl true
+  def handle_continue(:discover_sprites, %FleetState{} = state) do
+    sprite_configs = configured_sprites()
+
+    sprite_ids =
+      sprite_configs
+      |> Enum.map(&start_sprite(&1, state.supervisor))
+      |> Enum.filter(&match?({:ok, _}, &1))
+      |> Enum.map(fn {:ok, sprite_id} -> sprite_id end)
+
+    new_state = %{state | sprite_ids: sprite_ids}
+
+    Logger.info("Fleet Manager started #{length(sprite_ids)} sprites",
+      total: length(sprite_ids),
+      sprite_ids: inspect(sprite_ids)
+    )
+
+    broadcast_fleet_summary(new_state)
+
+    {:noreply, new_state}
+  end
+
+  @impl true
+  def handle_call(:list_sprites, _from, %FleetState{} = state) do
+    sprites =
+      state.sprite_ids
+      |> Enum.map(fn id -> {id, get_sprite_state(id)} end)
+      |> Enum.filter(fn {_id, result} -> match?({:ok, _}, result) end)
+      |> Enum.map(fn {id, {:ok, sprite_state}} -> {id, sprite_state} end)
+
+    {:reply, sprites, state}
+  end
+
+  def handle_call(:fleet_summary, _from, %FleetState{} = state) do
+    summary = compute_fleet_summary(state)
+    {:reply, summary, state}
+  end
+
+  def handle_call({:wake_sprites, sprite_ids}, _from, %FleetState{} = state) do
+    results = set_desired_states(sprite_ids, :ready)
+    broadcast_fleet_summary(state)
+    {:reply, results, state}
+  end
+
+  def handle_call({:sleep_sprites, sprite_ids}, _from, %FleetState{} = state) do
+    results = set_desired_states(sprite_ids, :hibernating)
+    broadcast_fleet_summary(state)
+    {:reply, results, state}
+  end
+
+  def handle_call(:run_audit, _from, %FleetState{} = state) do
+    Enum.each(state.sprite_ids, fn id ->
+      case get_sprite_pid(id) do
+        {:ok, pid} -> Sprite.reconcile_now(pid)
+        {:error, :not_found} -> :ok
+      end
+    end)
+
+    broadcast_fleet_summary(state)
+    {:reply, :ok, state}
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────
+
+  defp configured_sprites do
+    :lattice
+    |> Application.get_env(:fleet, [])
+    |> Keyword.get(:sprites, [])
+  end
+
+  defp start_sprite(%{id: sprite_id} = config, supervisor) do
+    desired = Map.get(config, :desired_state, :hibernating)
+
+    child_spec =
+      {Sprite,
+       [
+         sprite_id: sprite_id,
+         desired_state: desired,
+         name: Sprite.via(sprite_id)
+       ]}
+
+    case DynamicSupervisor.start_child(supervisor, child_spec) do
+      {:ok, _pid} ->
+        Logger.info("Started sprite #{sprite_id}")
+        {:ok, sprite_id}
+
+      {:error, {:already_started, _pid}} ->
+        Logger.info("Sprite #{sprite_id} already running")
+        {:ok, sprite_id}
+
+      {:error, reason} ->
+        Logger.error("Failed to start sprite #{sprite_id}: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp get_sprite_state(sprite_id) do
+    case get_sprite_pid(sprite_id) do
+      {:ok, pid} -> Sprite.get_state(pid)
+      {:error, :not_found} -> {:error, :not_found}
+    end
+  end
+
+  defp set_desired_states(sprite_ids, desired_state) do
+    Map.new(sprite_ids, fn id ->
+      result =
+        case get_sprite_pid(id) do
+          {:ok, pid} -> Sprite.set_desired_state(pid, desired_state)
+          {:error, :not_found} -> {:error, :not_found}
+        end
+
+      {id, result}
+    end)
+  end
+
+  defp compute_fleet_summary(%FleetState{} = state) do
+    sprites =
+      state.sprite_ids
+      |> Enum.map(fn id -> {id, get_sprite_state(id)} end)
+      |> Enum.filter(fn {_id, result} -> match?({:ok, _}, result) end)
+      |> Enum.map(fn {_id, {:ok, sprite_state}} -> sprite_state end)
+
+    by_state =
+      sprites
+      |> Enum.group_by(& &1.observed_state)
+      |> Map.new(fn {state_name, group} -> {state_name, length(group)} end)
+
+    %{
+      total: length(sprites),
+      by_state: by_state
+    }
+  end
+
+  defp broadcast_fleet_summary(%FleetState{} = state) do
+    summary = compute_fleet_summary(state)
+    Events.emit_fleet_summary(summary)
+
+    Phoenix.PubSub.broadcast(
+      Lattice.PubSub,
+      Events.fleet_topic(),
+      {:fleet_summary, summary}
+    )
+  end
+end

--- a/test/lattice/sprites/fleet_manager_test.exs
+++ b/test/lattice/sprites/fleet_manager_test.exs
@@ -1,0 +1,342 @@
+defmodule Lattice.Sprites.FleetManagerTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  import Mox
+
+  alias Lattice.Events
+  alias Lattice.Sprites.FleetManager
+  alias Lattice.Sprites.Sprite
+  alias Lattice.Sprites.State
+
+  # Mox requires verify_on_exit! for each test.
+  # set_mox_global allows stubs to be called from any process (the GenServer).
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  # ── Helpers ─────────────────────────────────────────────────────────
+
+  defp unique_name(prefix) do
+    :"#{prefix}_#{System.unique_integer([:positive])}"
+  end
+
+  defp start_fleet_manager(sprite_configs, opts \\ []) do
+    sup_name = Keyword.get(opts, :supervisor, unique_name("test_sup"))
+    fm_name = Keyword.get(opts, :name, unique_name("test_fm"))
+
+    # Temporarily set the fleet config
+    original_config = Application.get_env(:lattice, :fleet, [])
+    Application.put_env(:lattice, :fleet, sprites: sprite_configs)
+
+    # Start a dedicated DynamicSupervisor for this test
+    {:ok, _sup_pid} = DynamicSupervisor.start_link(name: sup_name, strategy: :one_for_one)
+
+    {:ok, fm_pid} = FleetManager.start_link(name: fm_name, supervisor: sup_name)
+
+    # Allow the :continue callback to finish
+    Process.sleep(50)
+
+    sprite_ids = Enum.map(sprite_configs, & &1.id)
+
+    on_exit(fn ->
+      Application.put_env(:lattice, :fleet, original_config)
+      safe_stop(fm_pid)
+      safe_stop_named(sup_name)
+      cleanup_registry_sprites(sprite_ids)
+    end)
+
+    %{fm: fm_name, sup: sup_name}
+  end
+
+  defp cleanup_registry_sprites(sprite_ids) do
+    Enum.each(sprite_ids, &stop_registered_sprite/1)
+  end
+
+  defp stop_registered_sprite(sprite_id) do
+    case Registry.lookup(Lattice.Sprites.Registry, sprite_id) do
+      [{pid, _}] when is_pid(pid) -> safe_stop(pid)
+      _ -> :ok
+    end
+  end
+
+  defp safe_stop(pid) when is_pid(pid) do
+    if Process.alive?(pid), do: GenServer.stop(pid, :normal, 5_000)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp safe_stop(_), do: :ok
+
+  defp safe_stop_named(name) when is_atom(name) do
+    case Process.whereis(name) do
+      nil -> :ok
+      pid -> safe_stop(pid)
+    end
+  end
+
+  # ── Discovery & Startup ────────────────────────────────────────────
+
+  describe "sprite discovery and startup" do
+    test "starts with no sprites when config is empty" do
+      %{fm: fm} = start_fleet_manager([])
+
+      assert FleetManager.list_sprites(fm) == []
+    end
+
+    test "starts configured sprites" do
+      configs = [
+        %{id: "fleet-test-001", desired_state: :hibernating},
+        %{id: "fleet-test-002", desired_state: :hibernating}
+      ]
+
+      %{fm: fm} = start_fleet_manager(configs)
+
+      sprites = FleetManager.list_sprites(fm)
+      ids = Enum.map(sprites, fn {id, _state} -> id end)
+
+      assert length(sprites) == 2
+      assert "fleet-test-001" in ids
+      assert "fleet-test-002" in ids
+    end
+
+    test "started sprites are registered in the Registry" do
+      configs = [%{id: "fleet-reg-001", desired_state: :hibernating}]
+
+      %{fm: _fm} = start_fleet_manager(configs)
+
+      assert {:ok, pid} = FleetManager.get_sprite_pid("fleet-reg-001")
+      assert Process.alive?(pid)
+    end
+
+    test "started sprites respect desired_state from config" do
+      configs = [%{id: "fleet-desired-001", desired_state: :ready}]
+
+      %{fm: fm} = start_fleet_manager(configs)
+
+      [{_id, state}] = FleetManager.list_sprites(fm)
+      assert state.desired_state == :ready
+    end
+
+    test "started sprites default to hibernating desired state" do
+      configs = [%{id: "fleet-default-001"}]
+
+      %{fm: fm} = start_fleet_manager(configs)
+
+      [{_id, state}] = FleetManager.list_sprites(fm)
+      assert state.desired_state == :hibernating
+    end
+  end
+
+  # ── Fleet Queries ──────────────────────────────────────────────────
+
+  describe "list_sprites/1" do
+    test "returns sprite IDs with their current state" do
+      configs = [%{id: "fleet-list-001", desired_state: :hibernating}]
+
+      %{fm: fm} = start_fleet_manager(configs)
+
+      sprites = FleetManager.list_sprites(fm)
+      assert [{id, %State{}}] = sprites
+      assert id == "fleet-list-001"
+    end
+  end
+
+  describe "get_sprite_pid/1" do
+    test "returns {:ok, pid} for a known sprite" do
+      configs = [%{id: "fleet-pid-001", desired_state: :hibernating}]
+      start_fleet_manager(configs)
+
+      assert {:ok, pid} = FleetManager.get_sprite_pid("fleet-pid-001")
+      assert is_pid(pid)
+    end
+
+    test "returns {:error, :not_found} for unknown sprite" do
+      start_fleet_manager([])
+
+      assert {:error, :not_found} = FleetManager.get_sprite_pid("nonexistent")
+    end
+  end
+
+  describe "fleet_summary/1" do
+    test "returns total count and breakdown by state" do
+      configs = [
+        %{id: "fleet-sum-001", desired_state: :hibernating},
+        %{id: "fleet-sum-002", desired_state: :hibernating}
+      ]
+
+      %{fm: fm} = start_fleet_manager(configs)
+
+      summary = FleetManager.fleet_summary(fm)
+      assert summary.total == 2
+      assert summary.by_state[:hibernating] == 2
+    end
+
+    test "returns zeros when fleet is empty" do
+      %{fm: fm} = start_fleet_manager([])
+
+      summary = FleetManager.fleet_summary(fm)
+      assert summary.total == 0
+      assert summary.by_state == %{}
+    end
+  end
+
+  # ── Fleet-Wide Operations ──────────────────────────────────────────
+
+  describe "wake_sprites/2" do
+    test "sets desired state to ready for specified sprites" do
+      configs = [
+        %{id: "fleet-wake-001", desired_state: :hibernating},
+        %{id: "fleet-wake-002", desired_state: :hibernating}
+      ]
+
+      %{fm: fm} = start_fleet_manager(configs)
+
+      results = FleetManager.wake_sprites(["fleet-wake-001"], fm)
+      assert results["fleet-wake-001"] == :ok
+
+      [{_id, state}] =
+        FleetManager.list_sprites(fm)
+        |> Enum.filter(fn {id, _} -> id == "fleet-wake-001" end)
+
+      assert state.desired_state == :ready
+    end
+
+    test "returns error for unknown sprite IDs" do
+      %{fm: fm} = start_fleet_manager([])
+
+      results = FleetManager.wake_sprites(["unknown-001"], fm)
+      assert results["unknown-001"] == {:error, :not_found}
+    end
+  end
+
+  describe "sleep_sprites/2" do
+    test "sets desired state to hibernating for specified sprites" do
+      configs = [%{id: "fleet-sleep-001", desired_state: :hibernating}]
+
+      %{fm: fm} = start_fleet_manager(configs)
+
+      # First wake the sprite
+      FleetManager.wake_sprites(["fleet-sleep-001"], fm)
+
+      # Then sleep it
+      results = FleetManager.sleep_sprites(["fleet-sleep-001"], fm)
+      assert results["fleet-sleep-001"] == :ok
+
+      [{_id, state}] = FleetManager.list_sprites(fm)
+      assert state.desired_state == :hibernating
+    end
+  end
+
+  describe "run_audit/1" do
+    test "triggers reconciliation on all sprites" do
+      configs = [%{id: "fleet-audit-001", desired_state: :hibernating}]
+
+      %{fm: fm} = start_fleet_manager(configs)
+
+      :ok = Events.subscribe_sprite("fleet-audit-001")
+
+      assert :ok = FleetManager.run_audit(fm)
+
+      # Should receive a reconciliation result
+      assert_receive %Lattice.Events.ReconciliationResult{
+                       sprite_id: "fleet-audit-001"
+                     },
+                     1_000
+    end
+  end
+
+  # ── PubSub Broadcasting ────────────────────────────────────────────
+
+  describe "fleet summary broadcasting" do
+    test "broadcasts fleet summary on wake_sprites" do
+      configs = [%{id: "fleet-bc-001", desired_state: :hibernating}]
+
+      %{fm: fm} = start_fleet_manager(configs)
+
+      :ok = Events.subscribe_fleet()
+
+      FleetManager.wake_sprites(["fleet-bc-001"], fm)
+
+      assert_receive {:fleet_summary, %{total: 1}}, 1_000
+    end
+
+    test "broadcasts fleet summary on sleep_sprites" do
+      configs = [%{id: "fleet-bc-002", desired_state: :hibernating}]
+
+      %{fm: fm} = start_fleet_manager(configs)
+
+      :ok = Events.subscribe_fleet()
+
+      FleetManager.sleep_sprites(["fleet-bc-002"], fm)
+
+      assert_receive {:fleet_summary, %{total: 1}}, 1_000
+    end
+
+    test "broadcasts fleet summary on run_audit" do
+      configs = [%{id: "fleet-bc-003", desired_state: :hibernating}]
+
+      %{fm: fm} = start_fleet_manager(configs)
+
+      :ok = Events.subscribe_fleet()
+
+      FleetManager.run_audit(fm)
+
+      assert_receive {:fleet_summary, %{total: 1}}, 1_000
+    end
+
+    test "broadcasts fleet summary after initial discovery" do
+      :ok = Events.subscribe_fleet()
+
+      configs = [%{id: "fleet-bc-004", desired_state: :hibernating}]
+      start_fleet_manager(configs)
+
+      assert_receive {:fleet_summary, %{total: 1}}, 1_000
+    end
+  end
+
+  # ── Telemetry ──────────────────────────────────────────────────────
+
+  describe "telemetry events" do
+    setup do
+      test_pid = self()
+      ref = make_ref()
+      handler_id = "fleet-manager-test-#{inspect(ref)}"
+
+      :telemetry.attach(
+        handler_id,
+        [:lattice, :fleet, :summary],
+        fn event_name, measurements, metadata, _config ->
+          send(test_pid, {:telemetry, ref, event_name, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      %{ref: ref}
+    end
+
+    test "emits fleet summary telemetry on discovery", %{ref: ref} do
+      configs = [%{id: "fleet-tel-001", desired_state: :hibernating}]
+      start_fleet_manager(configs)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :fleet, :summary], %{total: 1}, _metadata},
+                     1_000
+    end
+  end
+
+  # ── Sprite via Registry ────────────────────────────────────────────
+
+  describe "Sprite.via/1 integration" do
+    test "sprite can be reached via Registry name" do
+      configs = [%{id: "fleet-via-001", desired_state: :hibernating}]
+      start_fleet_manager(configs)
+
+      via = Sprite.via("fleet-via-001")
+      {:ok, state} = Sprite.get_state(via)
+      assert %State{} = state
+      assert state.sprite_id == "fleet-via-001"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implement `Lattice.Sprites.FleetManager` GenServer that reads sprite configuration at boot, starts a `Sprite` GenServer for each one under a `DynamicSupervisor`, and provides fleet-level queries and operations
- Add `Lattice.Sprites.Registry` and `Lattice.Sprites.DynamicSupervisor` to the application supervision tree for process lookup and supervision
- Update `Lattice.Sprites.Sprite` to auto-register in the Registry via `Sprite.via/1`, enabling process lookup by sprite ID
- Add fleet sprite configuration (`config :lattice, :fleet`) with dev defaults and empty test config

### Fleet Manager API

| Function | Description |
|----------|-------------|
| `list_sprites/0` | Returns all sprite IDs with their current state |
| `fleet_summary/0` | Returns total count and breakdown by observed state |
| `get_sprite_pid/1` | Looks up a sprite process by ID via the Registry |
| `wake_sprites/1` | Sets desired state to `:ready` for given sprite IDs |
| `sleep_sprites/1` | Sets desired state to `:hibernating` for given sprite IDs |
| `run_audit/0` | Triggers immediate reconciliation on all sprites |

### Observability

Fleet-mutating operations broadcast `{:fleet_summary, summary}` on the `"sprites:fleet"` PubSub topic and emit `[:lattice, :fleet, :summary]` Telemetry events.

## Test plan

- [x] Fleet Manager starts with empty config (no sprites)
- [x] Fleet Manager discovers and starts configured sprites
- [x] Started sprites register in the Registry
- [x] Sprites respect `desired_state` from config
- [x] `list_sprites/1` returns IDs with state structs
- [x] `get_sprite_pid/1` returns pid or not_found
- [x] `fleet_summary/1` returns correct totals and breakdown
- [x] `wake_sprites/2` and `sleep_sprites/2` set desired states
- [x] `run_audit/1` triggers reconciliation on all sprites
- [x] PubSub broadcasts fleet summary on fleet-mutating operations
- [x] Telemetry events emitted on discovery
- [x] Sprites addressable via `Sprite.via/1` Registry name
- [x] All 296 tests pass, zero warnings, credo --strict clean

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)