### PR TITLE
Add fleet dashboard LiveView with real-time updates

### DIFF
--- a/lib/lattice_web/components/layouts.ex
+++ b/lib/lattice_web/components/layouts.ex
@@ -35,35 +35,38 @@ defmodule LatticeWeb.Layouts do
 
   def app(assigns) do
     ~H"""
-    <header class="navbar px-4 sm:px-6 lg:px-8">
+    <header class="navbar bg-base-200 px-4 sm:px-6 lg:px-8 border-b border-base-300">
       <div class="flex-1">
-        <a href="/" class="flex-1 flex w-fit items-center gap-2">
-          <img src={~p"/images/logo.svg"} width="36" />
-          <span class="text-sm font-semibold">v{Application.spec(:phoenix, :vsn)}</span>
-        </a>
+        <.link navigate={~p"/sprites"} class="flex items-center gap-2 font-bold text-lg">
+          <.icon name="hero-cube-transparent" class="size-6" /> Lattice
+        </.link>
       </div>
       <div class="flex-none">
-        <ul class="flex flex-column px-1 space-x-4 items-center">
+        <ul class="menu menu-horizontal px-1 space-x-1 items-center">
           <li>
-            <a href="https://phoenixframework.org/" class="btn btn-ghost">Website</a>
+            <.link navigate={~p"/sprites"} class="font-medium">
+              <.icon name="hero-squares-2x2" class="size-4" /> Fleet
+            </.link>
           </li>
           <li>
-            <a href="https://github.com/phoenixframework/phoenix" class="btn btn-ghost">GitHub</a>
+            <span class="opacity-50 cursor-not-allowed">
+              <.icon name="hero-shield-check" class="size-4" /> Approvals
+            </span>
+          </li>
+          <li>
+            <span class="opacity-50 cursor-not-allowed">
+              <.icon name="hero-exclamation-triangle" class="size-4" /> Incidents
+            </span>
           </li>
           <li>
             <.theme_toggle />
-          </li>
-          <li>
-            <a href="https://hexdocs.pm/phoenix/overview.html" class="btn btn-primary">
-              Get Started <span aria-hidden="true">&rarr;</span>
-            </a>
           </li>
         </ul>
       </div>
     </header>
 
-    <main class="px-4 py-20 sm:px-6 lg:px-8">
-      <div class="mx-auto max-w-2xl space-y-4">
+    <main class="px-4 py-8 sm:px-6 lg:px-8">
+      <div class="mx-auto max-w-5xl space-y-4">
         {render_slot(@inner_block)}
       </div>
     </main>

--- a/lib/lattice_web/controllers/page_controller.ex
+++ b/lib/lattice_web/controllers/page_controller.ex
@@ -2,6 +2,6 @@ defmodule LatticeWeb.PageController do
   use LatticeWeb, :controller
 
   def home(conn, _params) do
-    render(conn, :home)
+    redirect(conn, to: ~p"/sprites")
   end
 end

--- a/lib/lattice_web/live/fleet_live.ex
+++ b/lib/lattice_web/live/fleet_live.ex
@@ -1,0 +1,233 @@
+defmodule LatticeWeb.FleetLive do
+  @moduledoc """
+  Fleet dashboard LiveView — the NOC glass.
+
+  Displays real-time status of all Sprites in the fleet. Subscribes to
+  `sprites:fleet` PubSub topic on mount and updates the view whenever
+  state changes, reconciliation results, or fleet summary updates arrive.
+
+  Uses a periodic safety-net refresh (~30s) to catch any missed PubSub
+  messages, per PHILOSOPHY.md's "Observable by Default" principle.
+  """
+
+  use LatticeWeb, :live_view
+
+  alias Lattice.Events
+  alias Lattice.Events.StateChange
+  alias Lattice.Sprites.FleetManager
+
+  @refresh_interval_ms 30_000
+
+  # ── Lifecycle ──────────────────────────────────────────────────────
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Events.subscribe_fleet()
+      schedule_refresh()
+    end
+
+    sprites = FleetManager.list_sprites()
+    summary = FleetManager.fleet_summary()
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Fleet")
+     |> assign(:sprites, sprites)
+     |> assign(:summary, summary)}
+  end
+
+  # ── Event Handlers ─────────────────────────────────────────────────
+
+  @impl true
+  def handle_info({:fleet_summary, summary}, socket) do
+    sprites = FleetManager.list_sprites()
+
+    {:noreply,
+     socket
+     |> assign(:summary, summary)
+     |> assign(:sprites, sprites)}
+  end
+
+  def handle_info(%StateChange{}, socket) do
+    sprites = FleetManager.list_sprites()
+    summary = FleetManager.fleet_summary()
+
+    {:noreply,
+     socket
+     |> assign(:sprites, sprites)
+     |> assign(:summary, summary)}
+  end
+
+  def handle_info(:refresh, socket) do
+    sprites = FleetManager.list_sprites()
+    summary = FleetManager.fleet_summary()
+    schedule_refresh()
+
+    {:noreply,
+     socket
+     |> assign(:sprites, sprites)
+     |> assign(:summary, summary)}
+  end
+
+  # Catch-all for other PubSub events on the fleet topic (reconciliation
+  # results, health updates, approval events). Refresh sprite data so the
+  # dashboard stays current.
+  def handle_info(_event, socket) do
+    sprites = FleetManager.list_sprites()
+    summary = FleetManager.fleet_summary()
+
+    {:noreply,
+     socket
+     |> assign(:sprites, sprites)
+     |> assign(:summary, summary)}
+  end
+
+  # ── Render ─────────────────────────────────────────────────────────
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-6">
+      <.header>
+        Fleet Dashboard
+        <:subtitle>
+          Real-time status of all Sprites in the fleet.
+        </:subtitle>
+      </.header>
+
+      <.fleet_summary summary={@summary} />
+
+      <div class="overflow-x-auto">
+        <.table
+          id="sprites-table"
+          rows={@sprites}
+          row_id={fn {id, _state} -> "sprite-#{id}" end}
+        >
+          <:col :let={{id, _state}} label="Sprite ID">{id}</:col>
+          <:col :let={{_id, state}} label="State">
+            <.state_badge state={state.observed_state} />
+          </:col>
+          <:col :let={{_id, state}} label="Desired">
+            <.state_badge state={state.desired_state} />
+          </:col>
+          <:col :let={{_id, state}} label="Health">
+            <.health_badge health={state.health} />
+          </:col>
+          <:col :let={{_id, state}} label="Last Update">
+            <.relative_time datetime={state.updated_at} />
+          </:col>
+          <:action :let={{id, _state}}>
+            <.link navigate={~p"/sprites/#{id}"} class="link link-primary text-sm">
+              View
+            </.link>
+          </:action>
+        </.table>
+
+        <div :if={@sprites == []} class="text-center py-12 text-base-content/60">
+          <.icon name="hero-cube-transparent" class="size-12 mx-auto mb-4" />
+          <p class="text-lg font-medium">No sprites in the fleet</p>
+          <p class="text-sm mt-1">Sprites will appear here once configured.</p>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # ── Functional Components ──────────────────────────────────────────
+
+  attr :summary, :map, required: true
+
+  defp fleet_summary(assigns) do
+    ~H"""
+    <div class="stats shadow w-full">
+      <div class="stat">
+        <div class="stat-title">Total Sprites</div>
+        <div class="stat-value">{@summary.total}</div>
+      </div>
+      <div :for={{state, count} <- sorted_states(@summary.by_state)} class="stat">
+        <div class="stat-title">{format_state(state)}</div>
+        <div class="stat-value text-lg">
+          <.state_badge state={state} />
+          <span class="ml-2">{count}</span>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :state, :atom, required: true
+
+  defp state_badge(assigns) do
+    ~H"""
+    <span class={["badge badge-sm", state_color(@state)]}>
+      {@state}
+    </span>
+    """
+  end
+
+  attr :health, :atom, required: true
+
+  defp health_badge(assigns) do
+    ~H"""
+    <span class={["badge badge-sm", health_color(@health)]}>
+      {@health}
+    </span>
+    """
+  end
+
+  attr :datetime, DateTime, required: true
+
+  defp relative_time(assigns) do
+    ~H"""
+    <time datetime={DateTime.to_iso8601(@datetime)} title={DateTime.to_iso8601(@datetime)}>
+      {format_relative(@datetime)}
+    </time>
+    """
+  end
+
+  # ── Helpers ────────────────────────────────────────────────────────
+
+  defp schedule_refresh do
+    Process.send_after(self(), :refresh, @refresh_interval_ms)
+  end
+
+  defp state_color(:hibernating), do: "badge-ghost"
+  defp state_color(:waking), do: "badge-info"
+  defp state_color(:ready), do: "badge-success"
+  defp state_color(:busy), do: "badge-warning"
+  defp state_color(:error), do: "badge-error"
+  defp state_color(_), do: "badge-ghost"
+
+  defp health_color(:healthy), do: "badge-success"
+  defp health_color(:degraded), do: "badge-warning"
+  defp health_color(:unhealthy), do: "badge-error"
+  defp health_color(:unknown), do: "badge-ghost"
+  defp health_color(_), do: "badge-ghost"
+
+  defp format_state(state) do
+    state
+    |> to_string()
+    |> String.capitalize()
+  end
+
+  defp format_relative(datetime) do
+    diff = DateTime.diff(DateTime.utc_now(), datetime, :second)
+
+    cond do
+      diff < 5 -> "just now"
+      diff < 60 -> "#{diff}s ago"
+      diff < 3600 -> "#{div(diff, 60)}m ago"
+      diff < 86_400 -> "#{div(diff, 3600)}h ago"
+      true -> "#{div(diff, 86_400)}d ago"
+    end
+  end
+
+  defp sorted_states(by_state) do
+    order = [:ready, :busy, :waking, :hibernating, :error]
+
+    order
+    |> Enum.filter(&Map.has_key?(by_state, &1))
+    |> Enum.map(fn state -> {state, Map.get(by_state, state)} end)
+  end
+end

--- a/lib/lattice_web/live/sprite_placeholder_live.ex
+++ b/lib/lattice_web/live/sprite_placeholder_live.ex
@@ -1,0 +1,45 @@
+defmodule LatticeWeb.SpritePlaceholderLive do
+  @moduledoc """
+  Placeholder LiveView for the Sprite detail page.
+
+  Will be replaced with a full Sprite detail view in a future issue.
+  """
+
+  use LatticeWeb, :live_view
+
+  @impl true
+  def mount(%{"id" => sprite_id}, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Sprite #{sprite_id}")
+     |> assign(:sprite_id, sprite_id)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-6">
+      <.header>
+        Sprite: {@sprite_id}
+        <:subtitle>
+          Detail view coming soon.
+        </:subtitle>
+      </.header>
+
+      <div class="text-center py-12 text-base-content/60">
+        <.icon name="hero-wrench-screwdriver" class="size-12 mx-auto mb-4" />
+        <p class="text-lg font-medium">Under construction</p>
+        <p class="text-sm mt-1">
+          The sprite detail view will be implemented in a future issue.
+        </p>
+      </div>
+
+      <div class="text-center">
+        <.link navigate={~p"/sprites"} class="btn btn-ghost">
+          <.icon name="hero-arrow-left" class="size-4 mr-1" /> Back to Fleet
+        </.link>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/lattice_web/router.ex
+++ b/lib/lattice_web/router.ex
@@ -25,6 +25,13 @@ defmodule LatticeWeb.Router do
     get "/", PageController, :home
   end
 
+  # Sprite placeholder route (detail view — future issue)
+  scope "/", LatticeWeb do
+    pipe_through :browser
+
+    live "/sprites/:id", SpritePlaceholderLive
+  end
+
   # Unauthenticated API routes
   scope "/", LatticeWeb do
     pipe_through :api
@@ -45,7 +52,7 @@ defmodule LatticeWeb.Router do
     scope "/", LatticeWeb do
       pipe_through :browser
 
-      # Future LiveView routes go here
+      live "/sprites", FleetLive
     end
   end
 

--- a/test/lattice_web/controllers/page_controller_test.exs
+++ b/test/lattice_web/controllers/page_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule LatticeWeb.PageControllerTest do
   use LatticeWeb.ConnCase
 
-  test "GET /", %{conn: conn} do
+  test "GET / redirects to /sprites", %{conn: conn} do
     conn = get(conn, ~p"/")
-    assert html_response(conn, 200) =~ "Peace of mind from prototype to production"
+    assert redirected_to(conn) == "/sprites"
   end
 end

--- a/test/lattice_web/live/fleet_live_test.exs
+++ b/test/lattice_web/live/fleet_live_test.exs
@@ -1,0 +1,108 @@
+defmodule LatticeWeb.FleetLiveTest do
+  use LatticeWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Lattice.Events
+  alias Lattice.Events.StateChange
+
+  @moduletag :unit
+
+  # The global FleetManager starts with an empty fleet in tests (config/test.exs).
+  # Tests that need sprites start them via a dedicated FleetManager+DynamicSupervisor
+  # pair, but since the LiveView reads from the global FleetManager, we test
+  # the empty-fleet rendering and PubSub handling separately.
+
+  # ── Empty Fleet Rendering ──────────────────────────────────────────
+
+  describe "fleet dashboard rendering (empty fleet)" do
+    test "renders fleet dashboard with page title", %{conn: conn} do
+      {:ok, view, html} = live(conn, ~p"/sprites")
+
+      assert html =~ "Fleet Dashboard"
+      assert has_element?(view, "header", "Fleet Dashboard")
+    end
+
+    test "shows empty fleet message when no sprites exist", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/sprites")
+
+      assert html =~ "No sprites in the fleet"
+    end
+
+    test "displays fleet summary with total of zero", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/sprites")
+
+      assert html =~ "Total Sprites"
+      assert html =~ "0"
+    end
+
+    test "renders the sprites table header", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/sprites")
+
+      assert html =~ "Sprite ID"
+      assert html =~ "State"
+      assert html =~ "Health"
+      assert html =~ "Last Update"
+    end
+  end
+
+  # ── Real-time Updates ──────────────────────────────────────────────
+
+  describe "real-time PubSub handling" do
+    test "handles fleet_summary broadcast without crashing", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/sprites")
+
+      Phoenix.PubSub.broadcast(
+        Lattice.PubSub,
+        Events.fleet_topic(),
+        {:fleet_summary, %{total: 5, by_state: %{ready: 3, hibernating: 2}}}
+      )
+
+      # The view should process the message and still be alive
+      html = render(view)
+      assert html =~ "Fleet Dashboard"
+      assert html =~ "Total Sprites"
+    end
+
+    test "handles state change broadcast without crashing", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/sprites")
+
+      {:ok, event} =
+        StateChange.new("some-sprite", :hibernating, :waking, reason: "test")
+
+      Phoenix.PubSub.broadcast(
+        Lattice.PubSub,
+        Events.fleet_topic(),
+        event
+      )
+
+      html = render(view)
+      assert html =~ "Fleet Dashboard"
+    end
+
+    test "handles unknown PubSub messages gracefully", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/sprites")
+
+      Phoenix.PubSub.broadcast(
+        Lattice.PubSub,
+        Events.fleet_topic(),
+        {:unexpected_message, %{}}
+      )
+
+      html = render(view)
+      assert html =~ "Fleet Dashboard"
+    end
+  end
+
+  # ── Sprite Detail Placeholder ──────────────────────────────────────
+
+  describe "sprite detail placeholder" do
+    test "renders placeholder for sprite detail page", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/sprites/test-sprite-001")
+
+      assert html =~ "test-sprite-001"
+      assert html =~ "Under construction"
+      assert html =~ "Back to Fleet"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implement `LatticeWeb.FleetLive` at `/sprites` with real-time PubSub subscriptions to `sprites:fleet` topic, displaying all sprites with state badges, health indicators, and relative timestamps
- Add application navigation layout with Fleet, Approvals (placeholder), and Incidents (placeholder) links; redirect `/` to `/sprites`
- Include `SpritePlaceholderLive` at `/sprites/:id` for future sprite detail view, and a 30-second safety-net refresh to catch missed PubSub messages

## Test plan
- [x] Fleet dashboard renders with page title and table headers
- [x] Empty fleet shows "No sprites in the fleet" message with zero total
- [x] PubSub fleet_summary, state_change, and unknown messages handled gracefully
- [x] Sprite detail placeholder renders correctly with back navigation
- [x] `GET /` redirects to `/sprites`
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] `mix credo --strict` passes
- [x] `mix test` passes (304 tests, 0 failures)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)