### PR TITLE
Add live Sprites API client with :httpc integration

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -34,6 +34,21 @@ config :lattice, :resources,
   fly_app: System.get_env("FLY_APP"),
   sprites_api_base: System.get_env("SPRITES_API_BASE")
 
+# Sprites capability: use live API client when token is configured, otherwise stub
+if System.get_env("SPRITES_API_TOKEN") do
+  config :lattice, :capabilities,
+    sprites: Lattice.Capabilities.Sprites.Live,
+    github:
+      Application.get_env(:lattice, :capabilities)[:github] ||
+        Lattice.Capabilities.GitHub.Stub,
+    fly:
+      Application.get_env(:lattice, :capabilities)[:fly] ||
+        Lattice.Capabilities.Fly.Stub,
+    secret_store:
+      Application.get_env(:lattice, :capabilities)[:secret_store] ||
+        Lattice.Capabilities.SecretStore.Env
+end
+
 # Auth provider: use Clerk when secret key is configured, otherwise stub
 if System.get_env("CLERK_SECRET_KEY") do
   config :lattice, :auth, provider: Lattice.Auth.Clerk

--- a/lib/lattice/capabilities/sprites/live.ex
+++ b/lib/lattice/capabilities/sprites/live.ex
@@ -1,0 +1,302 @@
+defmodule Lattice.Capabilities.Sprites.Live do
+  @moduledoc """
+  Live implementation of the Sprites capability backed by the Sprites API.
+
+  Communicates with the Sprites REST API at `api.sprites.dev` using `:httpc`
+  (Erlang's built-in HTTP client). Auth is via a Bearer token read from the
+  `SPRITES_API_TOKEN` environment variable.
+
+  ## Status Mapping
+
+  The API returns string statuses that are mapped to internal atoms:
+
+  | API Status  | Internal Atom   |
+  |-------------|-----------------|
+  | `"cold"`    | `:hibernating`  |
+  | `"warm"`    | `:waking`       |
+  | `"running"` | `:ready`        |
+  | other       | `:error`        |
+  """
+
+  @behaviour Lattice.Capabilities.Sprites
+
+  require Logger
+
+  @default_base_url "https://api.sprites.dev"
+  @default_timeout 15_000
+  @api_version "v1"
+
+  # ── Callbacks ──────────────────────────────────────────────────────────
+
+  @impl true
+  def list_sprites do
+    case get("/#{@api_version}/sprites") do
+      {:ok, sprites} when is_list(sprites) ->
+        {:ok, Enum.map(sprites, &parse_sprite/1)}
+
+      {:ok, %{"data" => sprites}} when is_list(sprites) ->
+        {:ok, Enum.map(sprites, &parse_sprite/1)}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @impl true
+  def get_sprite(id) do
+    case get("/#{@api_version}/sprites/#{URI.encode(id)}") do
+      {:ok, sprite} when is_map(sprite) ->
+        {:ok, parse_sprite(sprite)}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @impl true
+  def wake(id) do
+    case put("/#{@api_version}/sprites/#{URI.encode(id)}", %{status: "running"}) do
+      {:ok, sprite} when is_map(sprite) ->
+        {:ok, parse_sprite(sprite)}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @impl true
+  def sleep(id) do
+    case delete("/#{@api_version}/sprites/#{URI.encode(id)}") do
+      {:ok, sprite} when is_map(sprite) ->
+        {:ok, parse_sprite(sprite)}
+
+      {:ok, :no_content} ->
+        {:ok, %{id: id, status: :hibernating}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @impl true
+  def exec(id, command) do
+    body = %{cmd: command}
+
+    case post("/#{@api_version}/sprites/#{URI.encode(id)}/exec", body) do
+      {:ok, result} when is_map(result) ->
+        {:ok, parse_exec_result(id, command, result)}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @impl true
+  def fetch_logs(id, opts) do
+    query = build_log_query(opts)
+    path = "/#{@api_version}/sprites/#{URI.encode(id)}/services"
+
+    case get(path <> query) do
+      {:ok, services} when is_list(services) ->
+        # Aggregate logs from all services
+        logs = Enum.flat_map(services, fn svc -> Map.get(svc, "logs", []) end)
+        {:ok, logs}
+
+      {:ok, %{"data" => services}} when is_list(services) ->
+        logs = Enum.flat_map(services, fn svc -> Map.get(svc, "logs", []) end)
+        {:ok, logs}
+
+      {:ok, _other} ->
+        {:ok, []}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # ── HTTP Helpers ───────────────────────────────────────────────────────
+
+  defp get(path) do
+    request(:get, path, nil)
+  end
+
+  defp post(path, body) do
+    request(:post, path, body)
+  end
+
+  defp put(path, body) do
+    request(:put, path, body)
+  end
+
+  defp delete(path) do
+    request(:delete, path, nil)
+  end
+
+  defp request(method, path, body) do
+    url = build_url(path)
+    headers = build_headers()
+
+    httpc_request = build_httpc_request(method, url, headers, body)
+
+    Logger.debug("Sprites API #{method |> to_string() |> String.upcase()} #{path}")
+
+    case :httpc.request(method, httpc_request, http_opts(), []) do
+      {:ok, {{_http_version, status, _reason}, _resp_headers, resp_body}} ->
+        handle_response(status, resp_body)
+
+      {:error, reason} ->
+        Logger.error("Sprites API request failed: #{inspect(reason)}")
+        {:error, {:request_failed, reason}}
+    end
+  end
+
+  defp build_httpc_request(:get, url, headers, _body) do
+    {url, headers}
+  end
+
+  defp build_httpc_request(:delete, url, headers, _body) do
+    {url, headers}
+  end
+
+  defp build_httpc_request(_method, url, headers, body) do
+    encoded_body = if body, do: Jason.encode!(body), else: ""
+    {url, headers, ~c"application/json", encoded_body}
+  end
+
+  defp build_url(path) do
+    base = base_url()
+    String.to_charlist(base <> path)
+  end
+
+  defp build_headers do
+    token = auth_token()
+    [{~c"authorization", String.to_charlist("Bearer #{token}")}]
+  end
+
+  defp http_opts do
+    [
+      timeout: timeout(),
+      connect_timeout: timeout(),
+      ssl: ssl_opts()
+    ]
+  end
+
+  defp ssl_opts do
+    [
+      verify: :verify_peer,
+      cacerts: :public_key.cacerts_get(),
+      depth: 3,
+      customize_hostname_check: [
+        match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+      ]
+    ]
+  end
+
+  # ── Response Handling ──────────────────────────────────────────────────
+
+  defp handle_response(status, _body) when status == 204 do
+    {:ok, :no_content}
+  end
+
+  defp handle_response(status, body) when status in 200..299 do
+    body
+    |> to_string()
+    |> decode_json()
+  end
+
+  defp handle_response(401, _body) do
+    Logger.error("Sprites API authentication failed (401)")
+    {:error, :unauthorized}
+  end
+
+  defp handle_response(404, _body) do
+    {:error, :not_found}
+  end
+
+  defp handle_response(429, _body) do
+    Logger.warning("Sprites API rate limited (429)")
+    {:error, :rate_limited}
+  end
+
+  defp handle_response(status, body) when status in 400..499 do
+    Logger.warning("Sprites API client error (#{status}): #{to_string(body)}")
+    {:error, {:client_error, status, to_string(body)}}
+  end
+
+  defp handle_response(status, body) when status >= 500 do
+    Logger.error("Sprites API server error (#{status}): #{to_string(body)}")
+    {:error, {:server_error, status, to_string(body)}}
+  end
+
+  defp decode_json(""), do: {:ok, %{}}
+
+  defp decode_json(body) do
+    case Jason.decode(body) do
+      {:ok, parsed} -> {:ok, parsed}
+      {:error, _} -> {:error, {:invalid_json, body}}
+    end
+  end
+
+  # ── Parsing ────────────────────────────────────────────────────────────
+
+  @doc false
+  def parse_sprite(data) when is_map(data) do
+    %{
+      id: data["id"] || data["name"],
+      name: data["name"],
+      status: parse_status(data["status"]),
+      organization: data["organization"],
+      url: data["url"],
+      created_at: data["created_at"],
+      updated_at: data["updated_at"],
+      last_started_at: data["last_started_at"],
+      last_active_at: data["last_active_at"]
+    }
+  end
+
+  @doc false
+  def parse_status("cold"), do: :hibernating
+  def parse_status("warm"), do: :waking
+  def parse_status("running"), do: :ready
+  def parse_status(nil), do: :error
+  def parse_status(_other), do: :error
+
+  defp parse_exec_result(id, command, result) do
+    %{
+      sprite_id: id,
+      command: command,
+      output: result["stdout"] || result["output"] || "",
+      exit_code: result["exit_code"] || result["exitCode"] || 0
+    }
+  end
+
+  defp build_log_query(opts) do
+    params =
+      opts
+      |> Enum.flat_map(fn
+        {:since, value} -> [{"since", to_string(value)}]
+        {:limit, value} -> [{"limit", to_string(value)}]
+        _ -> []
+      end)
+
+    case params do
+      [] -> ""
+      pairs -> "?" <> URI.encode_query(pairs)
+    end
+  end
+
+  # ── Configuration ─────────────────────────────────────────────────────
+
+  defp base_url do
+    Application.get_env(:lattice, :resources)[:sprites_api_base] || @default_base_url
+  end
+
+  defp auth_token do
+    System.get_env("SPRITES_API_TOKEN") ||
+      raise "SPRITES_API_TOKEN environment variable is not set"
+  end
+
+  defp timeout do
+    Application.get_env(:lattice, :sprites_api_timeout, @default_timeout)
+  end
+end

--- a/test/lattice/capabilities/sprites_live_integration_test.exs
+++ b/test/lattice/capabilities/sprites_live_integration_test.exs
@@ -1,0 +1,59 @@
+defmodule Lattice.Capabilities.Sprites.LiveIntegrationTest do
+  @moduledoc """
+  Integration tests for the live Sprites API client.
+
+  These tests hit the real Sprites API and require a valid SPRITES_API_TOKEN
+  environment variable. Run with:
+
+      SPRITES_API_TOKEN=your-token mix test --only integration
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :integration
+
+  alias Lattice.Capabilities.Sprites.Live
+
+  setup do
+    unless System.get_env("SPRITES_API_TOKEN") do
+      raise "SPRITES_API_TOKEN must be set for integration tests"
+    end
+
+    :ok
+  end
+
+  describe "list_sprites/0" do
+    test "returns {:ok, list} from the live API" do
+      assert {:ok, sprites} = Live.list_sprites()
+      assert is_list(sprites)
+
+      for sprite <- sprites do
+        assert Map.has_key?(sprite, :id)
+        assert Map.has_key?(sprite, :name)
+        assert Map.has_key?(sprite, :status)
+        assert sprite.status in [:hibernating, :waking, :ready, :busy, :error]
+      end
+    end
+  end
+
+  describe "get_sprite/1" do
+    test "returns {:ok, sprite} for a known sprite" do
+      {:ok, sprites} = Live.list_sprites()
+
+      case sprites do
+        [first | _] ->
+          assert {:ok, sprite} = Live.get_sprite(first.name)
+          assert sprite.name == first.name
+          assert sprite.status in [:hibernating, :waking, :ready, :busy, :error]
+
+        [] ->
+          # No sprites available — skip gracefully
+          :ok
+      end
+    end
+
+    test "returns {:error, :not_found} for an unknown sprite" do
+      assert {:error, :not_found} =
+               Live.get_sprite("nonexistent-sprite-xyz-#{System.unique_integer()}")
+    end
+  end
+end

--- a/test/lattice/capabilities/sprites_live_test.exs
+++ b/test/lattice/capabilities/sprites_live_test.exs
@@ -1,0 +1,89 @@
+defmodule Lattice.Capabilities.Sprites.LiveTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Capabilities.Sprites.Live
+
+  describe "parse_sprite/1" do
+    test "maps API response fields to internal structure" do
+      api_response = %{
+        "id" => "abc-123",
+        "name" => "my-sprite",
+        "status" => "running",
+        "organization" => "plattegruber",
+        "url" => "https://my-sprite.sprites.dev",
+        "created_at" => "2026-02-16T08:00:00Z",
+        "updated_at" => "2026-02-16T09:00:00Z",
+        "last_started_at" => "2026-02-16T08:30:00Z",
+        "last_active_at" => "2026-02-16T09:00:00Z"
+      }
+
+      result = Live.parse_sprite(api_response)
+
+      assert result.id == "abc-123"
+      assert result.name == "my-sprite"
+      assert result.status == :ready
+      assert result.organization == "plattegruber"
+      assert result.url == "https://my-sprite.sprites.dev"
+      assert result.created_at == "2026-02-16T08:00:00Z"
+      assert result.updated_at == "2026-02-16T09:00:00Z"
+      assert result.last_started_at == "2026-02-16T08:30:00Z"
+      assert result.last_active_at == "2026-02-16T09:00:00Z"
+    end
+
+    test "uses name as id fallback when id is missing" do
+      api_response = %{
+        "name" => "my-sprite",
+        "status" => "cold"
+      }
+
+      result = Live.parse_sprite(api_response)
+
+      assert result.id == "my-sprite"
+      assert result.name == "my-sprite"
+    end
+
+    test "handles nil fields gracefully" do
+      api_response = %{
+        "id" => "abc-123",
+        "name" => "my-sprite",
+        "status" => "warm",
+        "organization" => nil,
+        "url" => nil,
+        "created_at" => nil,
+        "updated_at" => nil,
+        "last_started_at" => nil,
+        "last_active_at" => nil
+      }
+
+      result = Live.parse_sprite(api_response)
+
+      assert result.id == "abc-123"
+      assert result.status == :waking
+      assert result.organization == nil
+    end
+  end
+
+  describe "parse_status/1" do
+    test "maps 'cold' to :hibernating" do
+      assert Live.parse_status("cold") == :hibernating
+    end
+
+    test "maps 'warm' to :waking" do
+      assert Live.parse_status("warm") == :waking
+    end
+
+    test "maps 'running' to :ready" do
+      assert Live.parse_status("running") == :ready
+    end
+
+    test "maps nil to :error" do
+      assert Live.parse_status(nil) == :error
+    end
+
+    test "maps unknown status to :error" do
+      assert Live.parse_status("unknown") == :error
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,4 +5,4 @@ Mox.defmock(Lattice.Capabilities.MockGitHub, for: Lattice.Capabilities.GitHub)
 Mox.defmock(Lattice.Capabilities.MockFly, for: Lattice.Capabilities.Fly)
 Mox.defmock(Lattice.Capabilities.MockSecretStore, for: Lattice.Capabilities.SecretStore)
 
-ExUnit.start()
+ExUnit.start(exclude: [:integration])


### PR DESCRIPTION
## Summary

- Implement `Lattice.Capabilities.Sprites.Live` module that communicates with the Sprites REST API at `api.sprites.dev` using Erlang's built-in `:httpc` (no external HTTP deps)
- Bearer token auth via `SPRITES_API_TOKEN` env var, with automatic capability switching in `config/runtime.exs` when the token is present
- Maps API status strings to internal atoms: `"cold"` -> `:hibernating`, `"warm"` -> `:waking`, `"running"` -> `:ready`
- Handles HTTP errors (401, 404, 429, 4xx, 5xx), timeouts, rate limiting, and JSON parse failures with tagged tuple returns

## Files Changed

| File | What |
|------|------|
| `lib/lattice/capabilities/sprites/live.ex` | Live Sprites API client implementing the `Sprites` behaviour |
| `config/runtime.exs` | Auto-switch to `Live` impl when `SPRITES_API_TOKEN` is set |
| `test/lattice/capabilities/sprites_live_test.exs` | Unit tests for `parse_sprite/1` and `parse_status/1` |
| `test/lattice/capabilities/sprites_live_integration_test.exs` | Integration tests (excluded by default) |
| `test/test_helper.exs` | Exclude `@tag :integration` from default test runs |

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] `mix format --check-formatted` passes
- [x] `mix credo --strict` passes
- [x] `mix test` passes (348 tests, 0 failures, 3 integration tests excluded)
- [ ] Run `SPRITES_API_TOKEN=<token> mix test --include integration` to verify live API calls

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)