### PR TITLE
Add real sprite reconciliation with backoff and retry

### DIFF
--- a/lib/lattice/sprites/sprite.ex
+++ b/lib/lattice/sprites/sprite.ex
@@ -6,9 +6,11 @@ defmodule Lattice.Sprites.Sprite do
 
   - Owns the Sprite's internal state (`%Lattice.Sprites.State{}`)
   - Runs a periodic reconciliation loop comparing desired vs. observed state
+  - Fetches real observed state from the SpritesCapability API each cycle
   - Emits Telemetry events and PubSub broadcasts on state transitions
-  - Implements exponential backoff on reconciliation failures
-  - Resets backoff counters on successful reconciliation
+  - Implements exponential backoff with jitter on reconciliation failures
+  - Computes and broadcasts health assessments after each reconciliation
+  - Handles API edge cases: timeouts, not-found, concurrent changes
 
   ## Starting a Sprite
 
@@ -26,18 +28,20 @@ defmodule Lattice.Sprites.Sprite do
 
   The reconciliation loop runs on a timer (default: 5 seconds). Each cycle:
 
-  1. Compares `observed_state` to `desired_state`
-  2. If they differ, calls the appropriate capability to drive the transition
-  3. Emits a `ReconciliationResult` event with the outcome
-  4. On success, resets the backoff; on failure, applies exponential backoff
-
-  Reconciliation uses stub capabilities — no real API calls are made until
-  the real Sprites API integration in Step 2.
+  1. Calls `SpritesCapability.get_sprite/1` to fetch the real observed state
+  2. Compares observed state against desired state
+  3. If they differ, calls the appropriate capability to drive the transition
+  4. Emits a `ReconciliationResult` event with the outcome
+  5. Computes and broadcasts a health assessment
+  6. On success, resets the backoff; on failure, applies exponential backoff with jitter
   """
 
   use GenServer
 
+  require Logger
+
   alias Lattice.Events
+  alias Lattice.Events.HealthUpdate
   alias Lattice.Events.ReconciliationResult
   alias Lattice.Events.StateChange
   alias Lattice.Sprites.State
@@ -57,6 +61,7 @@ defmodule Lattice.Sprites.Sprite do
   - `:reconcile_interval_ms` -- reconciliation loop interval (default: 5000)
   - `:base_backoff_ms` -- base backoff for retries (default: 1000)
   - `:max_backoff_ms` -- max backoff cap (default: 60000)
+  - `:max_retries` -- max consecutive failures before health is `:error` (default: 10)
   - `:name` -- GenServer name registration (optional; when omitted and the
     `Lattice.Sprites.Registry` is running, the process registers itself via
     the Registry under `sprite_id`)
@@ -120,7 +125,8 @@ defmodule Lattice.Sprites.Sprite do
       desired_state: Keyword.get(opts, :desired_state, :hibernating),
       observed_state: Keyword.get(opts, :observed_state, :hibernating),
       base_backoff_ms: Keyword.get(opts, :base_backoff_ms, 1_000),
-      max_backoff_ms: Keyword.get(opts, :max_backoff_ms, 60_000)
+      max_backoff_ms: Keyword.get(opts, :max_backoff_ms, 60_000),
+      max_retries: Keyword.get(opts, :max_retries, 10)
     ]
 
     reconcile_interval = Keyword.get(opts, :reconcile_interval_ms, @default_reconcile_interval_ms)
@@ -170,15 +176,81 @@ defmodule Lattice.Sprites.Sprite do
   defp do_reconcile(%State{} = state) do
     start_time = System.monotonic_time(:millisecond)
 
-    if State.needs_reconciliation?(state) do
-      reconcile_transition(state, start_time)
-    else
-      emit_reconciliation_result(state, :no_change, 0)
-      {state, :no_change}
+    case fetch_observed_state(state) do
+      {:ok, api_observed} ->
+        state = update_from_observation(state, api_observed)
+        reconcile_with_observation(state, start_time)
+
+      {:error, :not_found} ->
+        handle_not_found(state, start_time)
+
+      {:error, reason} ->
+        handle_fetch_failure(state, reason, start_time)
     end
   end
 
-  defp reconcile_transition(state, start_time) do
+  # Fetch the real observed state from the SpritesCapability API.
+  defp fetch_observed_state(%State{sprite_id: sprite_id}) do
+    case sprites_capability().get_sprite(sprite_id) do
+      {:ok, %{status: status}} when is_atom(status) ->
+        {:ok, status}
+
+      {:ok, %{status: status}} when is_binary(status) ->
+        {:ok, parse_api_status(status)}
+
+      {:ok, _sprite_data} ->
+        {:ok, :error}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # Map API string statuses to internal lifecycle atoms.
+  defp parse_api_status("running"), do: :ready
+  defp parse_api_status("cold"), do: :hibernating
+  defp parse_api_status("warm"), do: :waking
+  defp parse_api_status("sleeping"), do: :hibernating
+  defp parse_api_status(_other), do: :error
+
+  # Update internal state with the observed API snapshot.
+  defp update_from_observation(%State{} = state, api_observed) do
+    old_observed = state.observed_state
+
+    case State.transition(state, api_observed) do
+      {:ok, new_state} ->
+        new_state = State.record_observation(new_state)
+
+        if old_observed != api_observed do
+          emit_state_change(
+            state.sprite_id,
+            old_observed,
+            api_observed,
+            "API observation"
+          )
+        end
+
+        new_state
+
+      {:error, _} ->
+        state
+    end
+  end
+
+  # After updating observed from the API, decide what action to take.
+  defp reconcile_with_observation(%State{} = state, start_time) do
+    if State.needs_reconciliation?(state) do
+      reconcile_transition(state, start_time)
+    else
+      duration = System.monotonic_time(:millisecond) - start_time
+      new_state = State.reset_backoff(state)
+      emit_reconciliation_result(new_state, :no_change, duration)
+      new_state = update_and_emit_health(new_state, duration)
+      {new_state, :no_change}
+    end
+  end
+
+  defp reconcile_transition(%State{} = state, start_time) do
     case attempt_transition(state) do
       {:ok, new_observed} ->
         duration = System.monotonic_time(:millisecond) - start_time
@@ -186,9 +258,18 @@ defmodule Lattice.Sprites.Sprite do
 
         {:ok, new_state} = State.transition(state, new_observed)
         new_state = State.reset_backoff(new_state)
+        new_state = State.record_observation(new_state)
 
         emit_state_change(state.sprite_id, old_observed, new_observed, "reconciliation")
-        emit_reconciliation_result(state, :success, duration, "transitioned to #{new_observed}")
+
+        emit_reconciliation_result(
+          new_state,
+          :success,
+          duration,
+          "transitioned to #{new_observed}"
+        )
+
+        new_state = update_and_emit_health(new_state, duration)
 
         {new_state, :success}
 
@@ -196,18 +277,68 @@ defmodule Lattice.Sprites.Sprite do
         duration = System.monotonic_time(:millisecond) - start_time
         new_state = State.record_failure(state)
 
-        # Transition to error state if not already there
         new_state = maybe_transition_to_error(new_state, state.observed_state)
 
         emit_reconciliation_result(
-          state,
+          new_state,
           :failure,
           duration,
           "reconciliation failed: #{inspect(reason)}"
         )
 
+        new_state = update_and_emit_health(new_state, duration)
+
         {new_state, :failure}
     end
+  end
+
+  # Handle the case where the sprite was not found in the API (removed externally).
+  defp handle_not_found(%State{} = state, start_time) do
+    duration = System.monotonic_time(:millisecond) - start_time
+    old_observed = state.observed_state
+    new_state = State.record_failure(state)
+
+    Logger.warning("Sprite #{state.sprite_id} not found in API (removed externally?)",
+      sprite_id: state.sprite_id
+    )
+
+    new_state = maybe_transition_to_error(new_state, old_observed)
+
+    emit_reconciliation_result(
+      new_state,
+      :failure,
+      duration,
+      "sprite not found in API"
+    )
+
+    new_state = update_and_emit_health(new_state, duration)
+
+    {new_state, :failure}
+  end
+
+  # Handle API fetch failure (timeout, network error, etc.) as a transient failure.
+  defp handle_fetch_failure(%State{} = state, reason, start_time) do
+    duration = System.monotonic_time(:millisecond) - start_time
+    old_observed = state.observed_state
+    new_state = State.record_failure(state)
+
+    Logger.warning("Sprite reconciliation failure",
+      sprite_id: state.sprite_id,
+      reason: inspect(reason)
+    )
+
+    new_state = maybe_transition_to_error(new_state, old_observed)
+
+    emit_reconciliation_result(
+      new_state,
+      :failure,
+      duration,
+      "API fetch failed: #{inspect(reason)}"
+    )
+
+    new_state = update_and_emit_health(new_state, duration)
+
+    {new_state, :failure}
   end
 
   defp maybe_transition_to_error(%State{} = state, previous_observed) do
@@ -232,57 +363,69 @@ defmodule Lattice.Sprites.Sprite do
   end
 
   # Determine what transition to attempt based on current and desired state.
-  # Uses stub capabilities — returns synthetic results.
-  defp attempt_transition(%State{observed_state: :hibernating, desired_state: desired})
+  # Calls the real SpritesCapability with the actual sprite_id.
+  defp attempt_transition(%State{
+         sprite_id: id,
+         observed_state: :hibernating,
+         desired_state: desired
+       })
        when desired in [:waking, :ready, :busy] do
-    case sprites_capability().wake("synthetic") do
+    case sprites_capability().wake(id) do
       {:ok, _} -> {:ok, :waking}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp attempt_transition(%State{observed_state: :waking, desired_state: desired})
+  defp attempt_transition(%State{sprite_id: id, observed_state: :waking, desired_state: desired})
        when desired in [:ready, :busy] do
-    # Simulate the waking -> ready transition completing
-    case sprites_capability().get_sprite("synthetic") do
-      {:ok, _} -> {:ok, :ready}
+    # Check if waking has completed
+    case sprites_capability().get_sprite(id) do
+      {:ok, %{status: status}} -> {:ok, resolve_observed(status)}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp attempt_transition(%State{observed_state: :ready, desired_state: :busy}) do
-    case sprites_capability().exec("synthetic", "start-task") do
+  defp attempt_transition(%State{sprite_id: id, observed_state: :ready, desired_state: :busy}) do
+    case sprites_capability().exec(id, "start-task") do
       {:ok, _} -> {:ok, :busy}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp attempt_transition(%State{observed_state: :ready, desired_state: :hibernating}) do
-    case sprites_capability().sleep("synthetic") do
+  defp attempt_transition(%State{
+         sprite_id: id,
+         observed_state: :ready,
+         desired_state: :hibernating
+       }) do
+    case sprites_capability().sleep(id) do
       {:ok, _} -> {:ok, :hibernating}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp attempt_transition(%State{observed_state: :busy, desired_state: :ready}) do
-    # Busy -> ready happens when the task completes
-    case sprites_capability().get_sprite("synthetic") do
+  defp attempt_transition(%State{sprite_id: id, observed_state: :busy, desired_state: :ready}) do
+    # Busy -> ready happens when the task completes; check the API
+    case sprites_capability().get_sprite(id) do
+      {:ok, %{status: status}} -> {:ok, resolve_observed(status)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp attempt_transition(%State{
+         sprite_id: id,
+         observed_state: :busy,
+         desired_state: :hibernating
+       }) do
+    case sprites_capability().sleep(id) do
       {:ok, _} -> {:ok, :ready}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp attempt_transition(%State{observed_state: :busy, desired_state: :hibernating}) do
-    case sprites_capability().sleep("synthetic") do
-      {:ok, _} -> {:ok, :ready}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp attempt_transition(%State{observed_state: :error, desired_state: desired})
+  defp attempt_transition(%State{sprite_id: id, observed_state: :error, desired_state: desired})
        when desired in [:hibernating, :waking, :ready] do
     # Attempt recovery from error state
-    case sprites_capability().wake("synthetic") do
+    case sprites_capability().wake(id) do
       {:ok, _} -> {:ok, :waking}
       {:error, reason} -> {:error, reason}
     end
@@ -290,6 +433,25 @@ defmodule Lattice.Sprites.Sprite do
 
   defp attempt_transition(%State{observed_state: observed, desired_state: desired}) do
     {:error, {:no_transition_path, from: observed, to: desired}}
+  end
+
+  # Resolve a status value (atom or string) from the API response to a lifecycle atom.
+  defp resolve_observed(status) when is_atom(status), do: status
+  defp resolve_observed(status) when is_binary(status), do: parse_api_status(status)
+
+  # ── Health Assessment ─────────────────────────────────────────────
+
+  defp update_and_emit_health(%State{} = state, duration_ms) do
+    new_health = State.compute_health(state)
+    old_health = state.health
+
+    new_state = %{state | health: new_health}
+
+    if old_health != new_health do
+      emit_health_update(new_state, new_health, duration_ms)
+    end
+
+    new_state
   end
 
   # ── Event Emission ──────────────────────────────────────────────────
@@ -310,6 +472,31 @@ defmodule Lattice.Sprites.Sprite do
     end
   end
 
+  defp emit_health_update(%State{} = state, health_status, duration_ms) do
+    # Map internal health atoms to HealthUpdate-compatible statuses
+    status = health_to_event_status(health_status)
+    message = health_message(health_status, state)
+
+    case HealthUpdate.new(state.sprite_id, status, duration_ms, message: message) do
+      {:ok, event} -> Events.broadcast_health_update(event)
+      {:error, _} -> :ok
+    end
+  end
+
+  defp health_to_event_status(:ok), do: :healthy
+  defp health_to_event_status(:converging), do: :healthy
+  defp health_to_event_status(:degraded), do: :degraded
+  defp health_to_event_status(:error), do: :unhealthy
+
+  defp health_message(:ok, _state), do: "observed matches desired"
+  defp health_message(:converging, _state), do: "action taken, waiting for effect"
+
+  defp health_message(:degraded, %State{failure_count: count}),
+    do: "retrying after #{count} consecutive failure(s)"
+
+  defp health_message(:error, %State{failure_count: count, max_retries: max}),
+    do: "max retries exceeded (#{count}/#{max})"
+
   # ── Scheduling ──────────────────────────────────────────────────────
 
   defp schedule_reconcile(interval_ms) do
@@ -317,7 +504,7 @@ defmodule Lattice.Sprites.Sprite do
   end
 
   defp reconcile_delay(%State{failure_count: 0}, interval), do: interval
-  defp reconcile_delay(%State{backoff_ms: backoff}, _interval), do: backoff
+  defp reconcile_delay(%State{} = state, _interval), do: State.backoff_with_jitter(state)
 
   # ── Registry ────────────────────────────────────────────────────────
 

--- a/test/lattice/sprites/fleet_manager_test.exs
+++ b/test/lattice/sprites/fleet_manager_test.exs
@@ -230,6 +230,10 @@ defmodule Lattice.Sprites.FleetManagerTest do
 
   describe "run_audit/1" do
     test "triggers reconciliation on all sprites" do
+      # Stub get_sprite since reconciliation now fetches real API state
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "fleet-audit-001", status: :hibernating}} end)
+
       configs = [%{id: "fleet-audit-001", desired_state: :hibernating}]
 
       %{fm: fm} = start_fleet_manager(configs)
@@ -274,6 +278,10 @@ defmodule Lattice.Sprites.FleetManagerTest do
     end
 
     test "broadcasts fleet summary on run_audit" do
+      # Stub get_sprite since reconciliation now fetches real API state
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "fleet-bc-003", status: :hibernating}} end)
+
       configs = [%{id: "fleet-bc-003", desired_state: :hibernating}]
 
       %{fm: fm} = start_fleet_manager(configs)

--- a/test/lattice/sprites/sprite_test.exs
+++ b/test/lattice/sprites/sprite_test.exs
@@ -6,6 +6,7 @@ defmodule Lattice.Sprites.SpriteTest do
   import Mox
 
   alias Lattice.Events
+  alias Lattice.Events.HealthUpdate
   alias Lattice.Events.ReconciliationResult
   alias Lattice.Events.StateChange
   alias Lattice.Sprites.Sprite
@@ -29,7 +30,8 @@ defmodule Lattice.Sprites.SpriteTest do
       sprite_id: sprite_id,
       reconcile_interval_ms: @long_interval,
       base_backoff_ms: Keyword.get(opts, :base_backoff_ms, 100),
-      max_backoff_ms: Keyword.get(opts, :max_backoff_ms, 1_000)
+      max_backoff_ms: Keyword.get(opts, :max_backoff_ms, 1_000),
+      max_retries: Keyword.get(opts, :max_retries, 10)
     ]
 
     merged = Keyword.merge(defaults, opts)
@@ -37,10 +39,18 @@ defmodule Lattice.Sprites.SpriteTest do
     {pid, sprite_id}
   end
 
+  # Stub get_sprite to return a specific observed status (atom).
+  # This is the observation call that happens at the start of every reconciliation cycle.
+  defp stub_observation(status) when is_atom(status) do
+    Lattice.Capabilities.MockSprites
+    |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: status}} end)
+  end
+
   # ── Start & Init ────────────────────────────────────────────────────
 
   describe "start_link/1" do
     test "starts a Sprite GenServer" do
+      stub_observation(:hibernating)
       {pid, _id} = start_sprite()
       assert Process.alive?(pid)
     end
@@ -52,6 +62,7 @@ defmodule Lattice.Sprites.SpriteTest do
     end
 
     test "accepts a name option" do
+      stub_observation(:hibernating)
       name = :"sprite-named-#{System.unique_integer([:positive])}"
 
       {:ok, pid} =
@@ -66,6 +77,7 @@ defmodule Lattice.Sprites.SpriteTest do
     end
 
     test "initializes with default hibernating state" do
+      stub_observation(:hibernating)
       {pid, _id} = start_sprite()
       {:ok, state} = Sprite.get_state(pid)
       assert state.observed_state == :hibernating
@@ -73,12 +85,14 @@ defmodule Lattice.Sprites.SpriteTest do
     end
 
     test "initializes with custom desired state" do
+      stub_observation(:hibernating)
       {pid, _id} = start_sprite(desired_state: :ready)
       {:ok, state} = Sprite.get_state(pid)
       assert state.desired_state == :ready
     end
 
     test "initializes with custom observed state" do
+      stub_observation(:ready)
       {pid, _id} = start_sprite(observed_state: :ready)
       {:ok, state} = Sprite.get_state(pid)
       assert state.observed_state == :ready
@@ -89,6 +103,7 @@ defmodule Lattice.Sprites.SpriteTest do
 
   describe "get_state/1" do
     test "returns the current state struct" do
+      stub_observation(:hibernating)
       {pid, sprite_id} = start_sprite()
       {:ok, state} = Sprite.get_state(pid)
 
@@ -101,6 +116,7 @@ defmodule Lattice.Sprites.SpriteTest do
 
   describe "set_desired_state/2" do
     test "updates the desired state" do
+      stub_observation(:hibernating)
       {pid, _id} = start_sprite()
       assert :ok = Sprite.set_desired_state(pid, :ready)
 
@@ -109,11 +125,13 @@ defmodule Lattice.Sprites.SpriteTest do
     end
 
     test "rejects invalid desired state" do
+      stub_observation(:hibernating)
       {pid, _id} = start_sprite()
       assert {:error, {:invalid_lifecycle, :bogus}} = Sprite.set_desired_state(pid, :bogus)
     end
 
     test "preserves state on error" do
+      stub_observation(:hibernating)
       {pid, _id} = start_sprite()
       Sprite.set_desired_state(pid, :bogus)
 
@@ -126,18 +144,137 @@ defmodule Lattice.Sprites.SpriteTest do
 
   describe "reconciliation with no change needed" do
     test "emits no_change reconciliation result when states match" do
+      # API says hibernating, desired is hibernating -> no change
+      stub_observation(:hibernating)
+
       {pid, sprite_id} = start_sprite()
 
       :ok = Events.subscribe_sprite(sprite_id)
       :ok = Events.subscribe_fleet()
 
-      # Trigger reconciliation
       Sprite.reconcile_now(pid)
 
-      # Should get a no_change result
       assert_receive %ReconciliationResult{
                        sprite_id: ^sprite_id,
                        outcome: :no_change
+                     },
+                     1_000
+    end
+
+    test "resets backoff on no-change reconciliation" do
+      stub_observation(:hibernating)
+
+      {pid, _id} = start_sprite()
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.failure_count == 0
+    end
+  end
+
+  # ── Reconciliation: Observation Updates Observed State ──────────────
+
+  describe "reconciliation observation from API" do
+    test "updates observed state from API response" do
+      # Sprite was initialized as hibernating but API says it is ready
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :ready}} end)
+
+      {pid, sprite_id} = start_sprite(desired_state: :ready)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      # The API says ready, desired is ready, so we should see
+      # an observation state change and a no_change reconciliation
+      assert_receive %StateChange{
+                       sprite_id: ^sprite_id,
+                       from_state: :hibernating,
+                       to_state: :ready
+                     },
+                     1_000
+
+      assert_receive %ReconciliationResult{
+                       sprite_id: ^sprite_id,
+                       outcome: :no_change
+                     },
+                     1_000
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.observed_state == :ready
+      assert state.failure_count == 0
+    end
+
+    test "handles string status from API response" do
+      # API returns string "running" which should be parsed to :ready
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: "running"}} end)
+
+      {pid, _id} = start_sprite(desired_state: :ready)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.observed_state == :ready
+    end
+
+    test "handles 'cold' API status as hibernating" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: "cold"}} end)
+
+      {pid, _id} = start_sprite()
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.observed_state == :hibernating
+    end
+
+    test "handles 'warm' API status as waking" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: "warm"}} end)
+
+      {pid, _id} = start_sprite(desired_state: :ready)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      # API says waking, but desired is ready, so attempt_transition may change it
+      # The key thing is the API observation was parsed correctly
+      assert state.observed_state in [:waking, :ready]
+    end
+
+    test "concurrent state change from another actor is detected" do
+      # Sprite thinks it is :ready but API reports :hibernating (someone else stopped it)
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :hibernating}} end)
+      |> stub(:wake, fn _id -> {:ok, %{id: "test", status: :waking}} end)
+
+      {pid, sprite_id} = start_sprite(observed_state: :ready, desired_state: :ready)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      # Should detect the external change: ready -> hibernating
+      assert_receive %StateChange{
+                       sprite_id: ^sprite_id,
+                       from_state: :ready,
+                       to_state: :hibernating
+                     },
+                     1_000
+
+      # Then attempt reconciliation since desired is :ready but observed is :hibernating
+      assert_receive %StateChange{
+                       sprite_id: ^sprite_id,
+                       from_state: :hibernating,
+                       to_state: :waking
                      },
                      1_000
     end
@@ -148,14 +285,13 @@ defmodule Lattice.Sprites.SpriteTest do
   describe "reconciliation with transition" do
     test "transitions hibernating -> waking when desired is ready" do
       Lattice.Capabilities.MockSprites
-      |> stub(:wake, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
-      |> stub(:get_sprite, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :hibernating}} end)
+      |> stub(:wake, fn _id -> {:ok, %{id: "test", status: "running"}} end)
 
       {pid, sprite_id} = start_sprite(desired_state: :ready)
 
       :ok = Events.subscribe_sprite(sprite_id)
 
-      # First reconcile: hibernating -> waking
       Sprite.reconcile_now(pid)
 
       assert_receive %StateChange{
@@ -173,8 +309,9 @@ defmodule Lattice.Sprites.SpriteTest do
     end
 
     test "transitions waking -> ready on next reconciliation" do
+      # API says still waking, but get_sprite in attempt_transition returns ready
       Lattice.Capabilities.MockSprites
-      |> stub(:get_sprite, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :ready}} end)
 
       {pid, sprite_id} = start_sprite(observed_state: :waking, desired_state: :ready)
 
@@ -182,6 +319,8 @@ defmodule Lattice.Sprites.SpriteTest do
 
       Sprite.reconcile_now(pid)
 
+      # The API observation says ready, which matches desired -> no transition needed
+      # (observation itself triggers the state change from waking to ready)
       assert_receive %StateChange{
                        sprite_id: ^sprite_id,
                        from_state: :waking,
@@ -192,6 +331,7 @@ defmodule Lattice.Sprites.SpriteTest do
 
     test "transitions ready -> busy" do
       Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :ready}} end)
       |> stub(:exec, fn _id, _cmd -> {:ok, %{exit_code: 0}} end)
 
       {pid, sprite_id} = start_sprite(observed_state: :ready, desired_state: :busy)
@@ -210,7 +350,8 @@ defmodule Lattice.Sprites.SpriteTest do
 
     test "transitions ready -> hibernating" do
       Lattice.Capabilities.MockSprites
-      |> stub(:sleep, fn _id -> {:ok, %{id: "synthetic", status: "sleeping"}} end)
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :ready}} end)
+      |> stub(:sleep, fn _id -> {:ok, %{id: "test", status: "sleeping"}} end)
 
       {pid, sprite_id} = start_sprite(observed_state: :ready, desired_state: :hibernating)
 
@@ -228,26 +369,48 @@ defmodule Lattice.Sprites.SpriteTest do
 
     test "resets backoff on successful reconciliation" do
       Lattice.Capabilities.MockSprites
-      |> stub(:wake, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :hibernating}} end)
+      |> stub(:wake, fn _id -> {:ok, %{id: "test", status: "running"}} end)
 
       {pid, _id} = start_sprite(desired_state: :waking)
 
       Sprite.reconcile_now(pid)
-
-      # Allow time for async processing
       Process.sleep(50)
 
       {:ok, state} = Sprite.get_state(pid)
       assert state.failure_count == 0
+    end
+
+    test "uses real sprite_id in API calls" do
+      test_sprite_id = "sprite-real-id-#{System.unique_integer([:positive])}"
+
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn id ->
+        # Verify the real sprite_id is passed, not "synthetic"
+        assert id == test_sprite_id
+        {:ok, %{id: id, status: :hibernating}}
+      end)
+      |> stub(:wake, fn id ->
+        assert id == test_sprite_id
+        {:ok, %{id: id, status: :waking}}
+      end)
+
+      {pid, ^test_sprite_id} = start_sprite(sprite_id: test_sprite_id, desired_state: :ready)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.sprite_id == test_sprite_id
     end
   end
 
   # ── Reconciliation: Failure & Backoff ───────────────────────────────
 
   describe "reconciliation failure and backoff" do
-    test "increments failure count on reconciliation failure" do
+    test "increments failure count on API fetch failure" do
       Lattice.Capabilities.MockSprites
-      |> stub(:wake, fn _id -> {:error, :api_timeout} end)
+      |> stub(:get_sprite, fn _id -> {:error, :api_timeout} end)
 
       {pid, _id} = start_sprite(desired_state: :waking)
 
@@ -258,8 +421,48 @@ defmodule Lattice.Sprites.SpriteTest do
       assert state.failure_count == 1
     end
 
-    test "transitions to error state on failure" do
+    test "increments failure count on transition failure" do
+      # Observation succeeds, but the wake call fails
       Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :hibernating}} end)
+      |> stub(:wake, fn _id -> {:error, :api_timeout} end)
+
+      {pid, _id} = start_sprite(desired_state: :ready)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.failure_count == 1
+    end
+
+    test "transitions to error state on fetch failure" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:error, :api_timeout} end)
+
+      {pid, sprite_id} = start_sprite(desired_state: :waking)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive %StateChange{
+                       sprite_id: ^sprite_id,
+                       from_state: :hibernating,
+                       to_state: :error
+                     },
+                     1_000
+
+      assert_receive %ReconciliationResult{
+                       sprite_id: ^sprite_id,
+                       outcome: :failure
+                     },
+                     1_000
+    end
+
+    test "transitions to error state on transition failure" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :hibernating}} end)
       |> stub(:wake, fn _id -> {:error, :api_timeout} end)
 
       {pid, sprite_id} = start_sprite(desired_state: :waking)
@@ -268,7 +471,6 @@ defmodule Lattice.Sprites.SpriteTest do
 
       Sprite.reconcile_now(pid)
 
-      # Should receive a state change to error
       assert_receive %StateChange{
                        sprite_id: ^sprite_id,
                        from_state: :hibernating,
@@ -276,7 +478,6 @@ defmodule Lattice.Sprites.SpriteTest do
                      },
                      1_000
 
-      # And a failure reconciliation result
       assert_receive %ReconciliationResult{
                        sprite_id: ^sprite_id,
                        outcome: :failure
@@ -286,7 +487,7 @@ defmodule Lattice.Sprites.SpriteTest do
 
     test "accumulates failures with exponential backoff" do
       Lattice.Capabilities.MockSprites
-      |> stub(:wake, fn _id -> {:error, :api_timeout} end)
+      |> stub(:get_sprite, fn _id -> {:error, :api_timeout} end)
 
       {pid, _id} =
         start_sprite(desired_state: :waking, base_backoff_ms: 100, max_backoff_ms: 10_000)
@@ -308,7 +509,7 @@ defmodule Lattice.Sprites.SpriteTest do
 
     test "caps backoff at max" do
       Lattice.Capabilities.MockSprites
-      |> stub(:wake, fn _id -> {:error, :api_timeout} end)
+      |> stub(:get_sprite, fn _id -> {:error, :api_timeout} end)
 
       {pid, _id} =
         start_sprite(desired_state: :waking, base_backoff_ms: 100, max_backoff_ms: 200)
@@ -326,7 +527,7 @@ defmodule Lattice.Sprites.SpriteTest do
     test "recovery from error state resets backoff" do
       # First, cause a failure
       Lattice.Capabilities.MockSprites
-      |> stub(:wake, fn _id -> {:error, :timeout} end)
+      |> stub(:get_sprite, fn _id -> {:error, :timeout} end)
 
       {pid, _id} = start_sprite(desired_state: :ready)
 
@@ -337,9 +538,10 @@ defmodule Lattice.Sprites.SpriteTest do
       assert state.observed_state == :error
       assert state.failure_count > 0
 
-      # Now succeed on next attempt
+      # Now succeed on next attempt: API returns healthy state and wake succeeds
       Lattice.Capabilities.MockSprites
-      |> stub(:wake, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :error}} end)
+      |> stub(:wake, fn _id -> {:ok, %{id: "test", status: "running"}} end)
 
       Sprite.reconcile_now(pid)
       Process.sleep(50)
@@ -351,12 +553,326 @@ defmodule Lattice.Sprites.SpriteTest do
     end
   end
 
+  # ── Edge Cases ──────────────────────────────────────────────────────
+
+  describe "edge cases" do
+    test "handles API not_found error (sprite removed externally)" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:error, :not_found} end)
+
+      {pid, sprite_id} = start_sprite(desired_state: :ready)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive %ReconciliationResult{
+                       sprite_id: ^sprite_id,
+                       outcome: :failure,
+                       details: "sprite not found in API"
+                     },
+                     1_000
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.observed_state == :error
+      assert state.failure_count == 1
+    end
+
+    test "handles API timeout gracefully" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:error, :timeout} end)
+
+      {pid, sprite_id} = start_sprite(desired_state: :ready)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive %ReconciliationResult{
+                       sprite_id: ^sprite_id,
+                       outcome: :failure
+                     },
+                     1_000
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.failure_count == 1
+      # Process should still be alive after timeout
+      assert Process.alive?(pid)
+    end
+
+    test "handles rate limiting error" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:error, :rate_limited} end)
+
+      {pid, _id} = start_sprite(desired_state: :ready)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.failure_count == 1
+      assert Process.alive?(pid)
+    end
+
+    test "handles server error from API" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:error, {:server_error, 500, "Internal Server Error"}} end)
+
+      {pid, _id} = start_sprite(desired_state: :ready)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.failure_count == 1
+      assert Process.alive?(pid)
+    end
+
+    test "handles API returning unknown status" do
+      # API returns a status we do not recognize
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: "unknown_status"}} end)
+      |> stub(:wake, fn _id -> {:ok, %{id: "test", status: :waking}} end)
+
+      {pid, _id} = start_sprite(desired_state: :ready)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      # Unknown status maps to :error, then reconciliation attempts recovery
+      assert state.observed_state in [:error, :waking]
+    end
+
+    test "handles API response without status field" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", name: "no-status"}} end)
+      |> stub(:wake, fn _id -> {:ok, %{id: "test", status: :waking}} end)
+
+      {pid, _id} = start_sprite(desired_state: :ready)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      # Missing status maps to :error, then reconciliation attempts recovery
+      assert state.observed_state in [:error, :waking]
+    end
+  end
+
+  # ── Health Assessment ───────────────────────────────────────────────
+
+  describe "health assessment" do
+    test "health is :ok when observed matches desired" do
+      stub_observation(:hibernating)
+
+      {pid, _id} = start_sprite()
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.health == :ok
+    end
+
+    test "health is :converging when action taken" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :hibernating}} end)
+      |> stub(:wake, fn _id -> {:ok, %{id: "test", status: :waking}} end)
+
+      {pid, _id} = start_sprite(desired_state: :ready)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      # After wake, observed is :waking, desired is :ready -> converging
+      assert state.health == :converging
+    end
+
+    test "health is :degraded when retrying after failure" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:error, :api_timeout} end)
+
+      {pid, _id} = start_sprite(desired_state: :ready, max_retries: 10)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.health == :degraded
+    end
+
+    test "health is :error when max retries exceeded" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:error, :api_timeout} end)
+
+      {pid, _id} =
+        start_sprite(
+          desired_state: :ready,
+          max_retries: 2,
+          base_backoff_ms: 10,
+          max_backoff_ms: 50
+        )
+
+      # Exhaust retries
+      for _ <- 1..3 do
+        Sprite.reconcile_now(pid)
+        Process.sleep(20)
+      end
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.health == :error
+      assert state.failure_count >= 2
+    end
+
+    test "emits health update event on health change" do
+      stub_observation(:hibernating)
+
+      {pid, sprite_id} = start_sprite()
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      # Health changes from :unknown to :ok
+      assert_receive %HealthUpdate{
+                       sprite_id: ^sprite_id,
+                       status: :healthy
+                     },
+                     1_000
+    end
+
+    test "emits degraded health update on failure" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:error, :api_timeout} end)
+
+      {pid, sprite_id} = start_sprite(desired_state: :ready, max_retries: 10)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive %HealthUpdate{
+                       sprite_id: ^sprite_id,
+                       status: :degraded
+                     },
+                     1_000
+    end
+
+    test "emits unhealthy health update when max retries exceeded" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:error, :api_timeout} end)
+
+      {pid, sprite_id} =
+        start_sprite(
+          desired_state: :ready,
+          max_retries: 1,
+          base_backoff_ms: 10,
+          max_backoff_ms: 50
+        )
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      # First failure -> degraded (failure_count=1, max_retries=1 -> error)
+      Sprite.reconcile_now(pid)
+
+      assert_receive %HealthUpdate{
+                       sprite_id: ^sprite_id,
+                       status: :unhealthy
+                     },
+                     1_000
+    end
+
+    test "health recovers after successful reconciliation" do
+      # Start with failure
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:error, :api_timeout} end)
+
+      {pid, sprite_id} = start_sprite(desired_state: :ready, max_retries: 10)
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.health == :degraded
+
+      # Now API recovers, returns desired state
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :ready}} end)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.health == :ok
+      assert state.failure_count == 0
+    end
+  end
+
+  # ── Backoff with Jitter ─────────────────────────────────────────────
+
+  describe "backoff with jitter" do
+    test "backoff delay includes jitter on failure" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:error, :api_timeout} end)
+
+      {pid, _id} =
+        start_sprite(desired_state: :ready, base_backoff_ms: 1_000, max_backoff_ms: 10_000)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      # backoff_with_jitter should return a value near 1000 +/- 25%
+      jittered = State.backoff_with_jitter(state)
+      assert jittered >= 750
+      assert jittered <= 1250
+    end
+  end
+
+  # ── Last Observed At ────────────────────────────────────────────────
+
+  describe "observation tracking" do
+    test "records last_observed_at on successful API fetch" do
+      stub_observation(:hibernating)
+
+      {pid, _id} = start_sprite()
+
+      # Initially nil
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.last_observed_at == nil
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert %DateTime{} = state.last_observed_at
+    end
+
+    test "does not update last_observed_at on API failure" do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:error, :timeout} end)
+
+      {pid, _id} = start_sprite(desired_state: :ready)
+
+      Sprite.reconcile_now(pid)
+      Process.sleep(50)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.last_observed_at == nil
+    end
+  end
+
   # ── PubSub Broadcasting ────────────────────────────────────────────
 
   describe "PubSub broadcasting" do
     test "broadcasts state changes to fleet topic" do
       Lattice.Capabilities.MockSprites
-      |> stub(:wake, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :hibernating}} end)
+      |> stub(:wake, fn _id -> {:ok, %{id: "test", status: "running"}} end)
 
       {pid, sprite_id} = start_sprite(desired_state: :waking)
 
@@ -368,6 +884,8 @@ defmodule Lattice.Sprites.SpriteTest do
     end
 
     test "broadcasts reconciliation results to fleet topic" do
+      stub_observation(:hibernating)
+
       {pid, sprite_id} = start_sprite()
 
       :ok = Events.subscribe_fleet()
@@ -379,7 +897,8 @@ defmodule Lattice.Sprites.SpriteTest do
 
     test "broadcasts to per-sprite topic" do
       Lattice.Capabilities.MockSprites
-      |> stub(:wake, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :hibernating}} end)
+      |> stub(:wake, fn _id -> {:ok, %{id: "test", status: "running"}} end)
 
       {pid, sprite_id} = start_sprite(desired_state: :waking)
 
@@ -389,6 +908,30 @@ defmodule Lattice.Sprites.SpriteTest do
 
       assert_receive %StateChange{sprite_id: ^sprite_id}, 1_000
       assert_receive %ReconciliationResult{sprite_id: ^sprite_id}, 1_000
+    end
+
+    test "broadcasts health updates to sprite topic" do
+      stub_observation(:hibernating)
+
+      {pid, sprite_id} = start_sprite()
+
+      :ok = Events.subscribe_sprite(sprite_id)
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive %HealthUpdate{sprite_id: ^sprite_id}, 1_000
+    end
+
+    test "broadcasts health updates to fleet topic" do
+      stub_observation(:hibernating)
+
+      {pid, sprite_id} = start_sprite()
+
+      :ok = Events.subscribe_fleet()
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive %HealthUpdate{sprite_id: ^sprite_id}, 1_000
     end
   end
 
@@ -402,7 +945,8 @@ defmodule Lattice.Sprites.SpriteTest do
 
       events = [
         [:lattice, :sprite, :state_change],
-        [:lattice, :sprite, :reconciliation]
+        [:lattice, :sprite, :reconciliation],
+        [:lattice, :sprite, :health_update]
       ]
 
       :telemetry.attach_many(
@@ -421,7 +965,8 @@ defmodule Lattice.Sprites.SpriteTest do
 
     test "emits telemetry on state change", %{ref: ref} do
       Lattice.Capabilities.MockSprites
-      |> stub(:wake, fn _id -> {:ok, %{id: "synthetic", status: "running"}} end)
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "test", status: :hibernating}} end)
+      |> stub(:wake, fn _id -> {:ok, %{id: "test", status: "running"}} end)
 
       {pid, sprite_id} = start_sprite(desired_state: :waking)
 
@@ -433,11 +978,25 @@ defmodule Lattice.Sprites.SpriteTest do
     end
 
     test "emits telemetry on reconciliation", %{ref: ref} do
+      stub_observation(:hibernating)
+
       {pid, sprite_id} = start_sprite()
 
       Sprite.reconcile_now(pid)
 
       assert_receive {:telemetry, ^ref, [:lattice, :sprite, :reconciliation], _measurements,
+                      %{sprite_id: ^sprite_id}},
+                     1_000
+    end
+
+    test "emits telemetry on health update", %{ref: ref} do
+      stub_observation(:hibernating)
+
+      {pid, sprite_id} = start_sprite()
+
+      Sprite.reconcile_now(pid)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :sprite, :health_update], _measurements,
                       %{sprite_id: ^sprite_id}},
                      1_000
     end
@@ -447,6 +1006,8 @@ defmodule Lattice.Sprites.SpriteTest do
 
   describe "periodic reconciliation" do
     test "runs reconciliation on schedule" do
+      stub_observation(:hibernating)
+
       {pid, sprite_id} = start_sprite(reconcile_interval_ms: 50)
 
       :ok = Events.subscribe_sprite(sprite_id)
@@ -456,6 +1017,28 @@ defmodule Lattice.Sprites.SpriteTest do
 
       # Verify process is still alive
       assert Process.alive?(pid)
+    end
+  end
+
+  # ── Max Retries ─────────────────────────────────────────────────────
+
+  describe "max retries configuration" do
+    test "accepts max_retries option" do
+      stub_observation(:hibernating)
+
+      {pid, _id} = start_sprite(max_retries: 5)
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.max_retries == 5
+    end
+
+    test "defaults max_retries to 10" do
+      stub_observation(:hibernating)
+
+      {pid, _id} = start_sprite()
+
+      {:ok, state} = Sprite.get_state(pid)
+      assert state.max_retries == 10
     end
   end
 end


### PR DESCRIPTION
## Summary
- Connect sprite processes to the live SpritesCapability API: each reconciliation cycle now calls `get_sprite/1` with the real sprite_id to fetch observed state, replacing the old synthetic approach
- Implement health assessment after each reconciliation: `:ok` (in sync), `:converging` (action taken, waiting), `:degraded` (retrying after failure), `:error` (max retries exceeded), with PubSub broadcasting on health changes
- Add exponential backoff with jitter (+/- 25%) on API failures to prevent thundering-herd effects across fleet
- Add configurable `max_retries` (default: 10) and `last_observed_at` timestamp tracking to the State struct
- Handle edge cases: API timeouts, not-found (externally removed sprites), rate limiting, server errors, unknown API statuses, missing status fields, and concurrent external state changes
- Use real sprite_id in all capability calls (wake, sleep, exec, get_sprite) instead of the previous "synthetic" placeholder
- Parse API string statuses ("running", "cold", "warm", "sleeping") to internal lifecycle atoms

## Test plan
- 392 total tests (up from 348), 0 failures
- New test coverage for API observation flow: verifying observed state updates from API, string status parsing, concurrent external state detection
- New test coverage for health assessment: `:ok`, `:converging`, `:degraded`, `:error` states; health event emission on PubSub; health recovery after successful reconciliation
- New edge case tests: not_found, timeout, rate_limited, server_error, unknown status, missing status field
- New tests for backoff with jitter, observation timestamp tracking, max_retries configuration
- New State module tests: `compute_health/1`, `record_observation/1`, `backoff_with_jitter/1`, max_retries support
- Updated fleet manager tests to stub `get_sprite` for reconciliation-triggering operations
- All quality gates pass: `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)