### PR TITLE
Add Phoenix API layer for fleet and sprite endpoints

### DIFF
--- a/lib/lattice_web/controllers/api/fleet_controller.ex
+++ b/lib/lattice_web/controllers/api/fleet_controller.ex
@@ -1,0 +1,48 @@
+defmodule LatticeWeb.Api.FleetController do
+  @moduledoc """
+  API controller for fleet-wide operations.
+
+  Provides endpoints for querying fleet status and triggering fleet-wide
+  reconciliation audits.
+  """
+
+  use LatticeWeb, :controller
+
+  alias Lattice.Sprites.FleetManager
+
+  @doc """
+  GET /api/fleet — fleet summary with sprite counts by state and overall health.
+  """
+  def index(conn, _params) do
+    summary = FleetManager.fleet_summary()
+
+    conn
+    |> put_status(200)
+    |> json(%{
+      data: %{
+        total: summary.total,
+        by_state: serialize_by_state(summary.by_state)
+      },
+      timestamp: DateTime.utc_now()
+    })
+  end
+
+  @doc """
+  POST /api/fleet/audit — trigger a fleet-wide reconciliation audit.
+  """
+  def audit(conn, _params) do
+    :ok = FleetManager.run_audit()
+
+    conn
+    |> put_status(200)
+    |> json(%{
+      data: %{status: "audit_triggered"},
+      timestamp: DateTime.utc_now()
+    })
+  end
+
+  # Convert atom keys to strings for consistent JSON output
+  defp serialize_by_state(by_state) do
+    Map.new(by_state, fn {state, count} -> {Atom.to_string(state), count} end)
+  end
+end

--- a/lib/lattice_web/controllers/api/sprite_controller.ex
+++ b/lib/lattice_web/controllers/api/sprite_controller.ex
@@ -1,0 +1,162 @@
+defmodule LatticeWeb.Api.SpriteController do
+  @moduledoc """
+  API controller for individual sprite operations.
+
+  Provides endpoints for listing sprites, querying sprite details,
+  updating desired state, and triggering single-sprite reconciliation.
+  """
+
+  use LatticeWeb, :controller
+
+  alias Lattice.Sprites.FleetManager
+  alias Lattice.Sprites.Sprite
+  alias Lattice.Sprites.State
+
+  @allowed_desired_states ~w(ready hibernating)
+
+  @doc """
+  GET /api/sprites — list all sprites with current state.
+  """
+  def index(conn, _params) do
+    sprites = FleetManager.list_sprites()
+
+    conn
+    |> put_status(200)
+    |> json(%{
+      data: Enum.map(sprites, fn {id, state} -> serialize_sprite(id, state) end),
+      timestamp: DateTime.utc_now()
+    })
+  end
+
+  @doc """
+  GET /api/sprites/:id — single sprite detail.
+  """
+  def show(conn, %{"id" => sprite_id}) do
+    case get_sprite_state(sprite_id) do
+      {:ok, state} ->
+        conn
+        |> put_status(200)
+        |> json(%{
+          data: serialize_sprite_detail(sprite_id, state),
+          timestamp: DateTime.utc_now()
+        })
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "Sprite not found", code: "SPRITE_NOT_FOUND"})
+    end
+  end
+
+  @doc """
+  PUT /api/sprites/:id/desired — update desired state for a sprite.
+
+  Body: `{ "state": "ready" | "hibernating" }`
+  """
+  def update_desired(conn, %{"id" => sprite_id, "state" => desired_state_str})
+      when desired_state_str in @allowed_desired_states do
+    desired_state = String.to_existing_atom(desired_state_str)
+
+    with {:ok, pid} <- FleetManager.get_sprite_pid(sprite_id),
+         :ok <- Sprite.set_desired_state(pid, desired_state) do
+      {:ok, updated_state} = Sprite.get_state(pid)
+
+      conn
+      |> put_status(200)
+      |> json(%{
+        data: serialize_sprite_detail(sprite_id, updated_state),
+        timestamp: DateTime.utc_now()
+      })
+    else
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "Sprite not found", code: "SPRITE_NOT_FOUND"})
+
+      {:error, {:invalid_lifecycle, _}} ->
+        conn
+        |> put_status(422)
+        |> json(%{error: "Invalid state transition", code: "INVALID_STATE_TRANSITION"})
+
+      {:error, reason} ->
+        conn
+        |> put_status(422)
+        |> json(%{
+          error: "Failed to update desired state: #{inspect(reason)}",
+          code: "INVALID_STATE_TRANSITION"
+        })
+    end
+  end
+
+  def update_desired(conn, %{"id" => _sprite_id, "state" => invalid_state}) do
+    conn
+    |> put_status(422)
+    |> json(%{
+      error:
+        "Invalid desired state: #{inspect(invalid_state)}. Allowed: #{inspect(@allowed_desired_states)}",
+      code: "INVALID_STATE"
+    })
+  end
+
+  def update_desired(conn, %{"id" => _sprite_id}) do
+    conn
+    |> put_status(422)
+    |> json(%{
+      error: "Missing required field: state",
+      code: "MISSING_FIELD"
+    })
+  end
+
+  @doc """
+  POST /api/sprites/:id/reconcile — trigger reconciliation for a single sprite.
+  """
+  def reconcile(conn, %{"id" => sprite_id}) do
+    case FleetManager.get_sprite_pid(sprite_id) do
+      {:ok, pid} ->
+        Sprite.reconcile_now(pid)
+
+        conn
+        |> put_status(200)
+        |> json(%{
+          data: %{sprite_id: sprite_id, status: "reconciliation_triggered"},
+          timestamp: DateTime.utc_now()
+        })
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "Sprite not found", code: "SPRITE_NOT_FOUND"})
+    end
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp get_sprite_state(sprite_id) do
+    case FleetManager.get_sprite_pid(sprite_id) do
+      {:ok, pid} -> Sprite.get_state(pid)
+      {:error, :not_found} -> {:error, :not_found}
+    end
+  end
+
+  defp serialize_sprite(id, %State{} = state) do
+    %{
+      id: id,
+      observed_state: state.observed_state,
+      desired_state: state.desired_state,
+      health: state.health
+    }
+  end
+
+  defp serialize_sprite_detail(id, %State{} = state) do
+    %{
+      id: id,
+      observed_state: state.observed_state,
+      desired_state: state.desired_state,
+      health: state.health,
+      failure_count: state.failure_count,
+      last_observed_at: state.last_observed_at,
+      started_at: state.started_at,
+      updated_at: state.updated_at
+    }
+  end
+end

--- a/lib/lattice_web/router.ex
+++ b/lib/lattice_web/router.ex
@@ -40,10 +40,16 @@ defmodule LatticeWeb.Router do
   end
 
   # Authenticated API routes -- protected by bearer token
-  scope "/api", LatticeWeb do
+  scope "/api", LatticeWeb.Api do
     pipe_through :authenticated_api
 
-    # Future API endpoints go here
+    get "/fleet", FleetController, :index
+    post "/fleet/audit", FleetController, :audit
+
+    get "/sprites", SpriteController, :index
+    get "/sprites/:id", SpriteController, :show
+    put "/sprites/:id/desired", SpriteController, :update_desired
+    post "/sprites/:id/reconcile", SpriteController, :reconcile
   end
 
   # Authenticated LiveView routes

--- a/test/lattice_web/controllers/api/fleet_controller_test.exs
+++ b/test/lattice_web/controllers/api/fleet_controller_test.exs
@@ -1,0 +1,136 @@
+defmodule LatticeWeb.Api.FleetControllerTest do
+  use LatticeWeb.ConnCase
+
+  import Mox
+
+  alias Lattice.Sprites.FleetManager
+  alias Lattice.Sprites.Sprite
+
+  @moduletag :unit
+
+  setup :verify_on_exit!
+  setup :set_mox_global
+
+  # ── Helpers ──────────────────────────────────────────────────────────
+
+  defp authenticated(conn) do
+    put_req_header(conn, "authorization", "Bearer test-token")
+  end
+
+  defp start_sprites(sprite_configs) do
+    sprite_ids = Enum.map(sprite_configs, & &1.id)
+
+    # Start sprite processes under the existing DynamicSupervisor
+    Enum.each(sprite_configs, &start_sprite_process/1)
+
+    # Add sprite IDs to the FleetManager's internal state
+    :sys.replace_state(FleetManager, fn state ->
+      %{state | sprite_ids: state.sprite_ids ++ sprite_ids}
+    end)
+
+    on_exit(fn ->
+      # Remove sprite IDs from the FleetManager
+      :sys.replace_state(FleetManager, fn state ->
+        %{state | sprite_ids: state.sprite_ids -- sprite_ids}
+      end)
+
+      # Stop the sprite processes
+      Enum.each(sprite_ids, &terminate_sprite/1)
+    end)
+
+    :ok
+  end
+
+  defp start_sprite_process(config) do
+    desired = Map.get(config, :desired_state, :hibernating)
+
+    {:ok, _pid} =
+      DynamicSupervisor.start_child(
+        Lattice.Sprites.DynamicSupervisor,
+        {Sprite,
+         [
+           sprite_id: config.id,
+           desired_state: desired,
+           name: Sprite.via(config.id),
+           reconcile_interval_ms: 600_000
+         ]}
+      )
+  end
+
+  defp terminate_sprite(sprite_id) do
+    case Registry.lookup(Lattice.Sprites.Registry, sprite_id) do
+      [{pid, _}] when is_pid(pid) ->
+        DynamicSupervisor.terminate_child(Lattice.Sprites.DynamicSupervisor, pid)
+
+      _ ->
+        :ok
+    end
+  end
+
+  # ── GET /api/fleet ──────────────────────────────────────────────────
+
+  describe "GET /api/fleet" do
+    test "returns fleet summary when authenticated", %{conn: conn} do
+      start_sprites([
+        %{id: "api-fleet-001", desired_state: :hibernating},
+        %{id: "api-fleet-002", desired_state: :hibernating}
+      ])
+
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/fleet")
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["total"] == 2
+      assert body["data"]["by_state"]["hibernating"] == 2
+      assert is_binary(body["timestamp"])
+    end
+
+    test "returns empty fleet summary when no sprites", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/fleet")
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["total"] == 0
+      assert body["data"]["by_state"] == %{}
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = get(conn, "/api/fleet")
+
+      assert json_response(conn, 401)
+    end
+  end
+
+  # ── POST /api/fleet/audit ──────────────────────────────────────────
+
+  describe "POST /api/fleet/audit" do
+    test "triggers fleet-wide audit", %{conn: conn} do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "api-audit-001", status: :hibernating}} end)
+
+      start_sprites([%{id: "api-audit-001", desired_state: :hibernating}])
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/fleet/audit")
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["status"] == "audit_triggered"
+      assert is_binary(body["timestamp"])
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = post(conn, "/api/fleet/audit")
+
+      assert json_response(conn, 401)
+    end
+  end
+end

--- a/test/lattice_web/controllers/api/sprite_controller_test.exs
+++ b/test/lattice_web/controllers/api/sprite_controller_test.exs
@@ -1,0 +1,270 @@
+defmodule LatticeWeb.Api.SpriteControllerTest do
+  use LatticeWeb.ConnCase
+
+  import Mox
+
+  alias Lattice.Sprites.FleetManager
+  alias Lattice.Sprites.Sprite
+
+  @moduletag :unit
+
+  setup :verify_on_exit!
+  setup :set_mox_global
+
+  # ── Helpers ──────────────────────────────────────────────────────────
+
+  defp authenticated(conn) do
+    put_req_header(conn, "authorization", "Bearer test-token")
+  end
+
+  defp start_sprites(sprite_configs) do
+    sprite_ids = Enum.map(sprite_configs, & &1.id)
+
+    # Start sprite processes under the existing DynamicSupervisor
+    Enum.each(sprite_configs, &start_sprite_process/1)
+
+    # Add sprite IDs to the FleetManager's internal state
+    :sys.replace_state(FleetManager, fn state ->
+      %{state | sprite_ids: state.sprite_ids ++ sprite_ids}
+    end)
+
+    on_exit(fn ->
+      # Remove sprite IDs from the FleetManager
+      :sys.replace_state(FleetManager, fn state ->
+        %{state | sprite_ids: state.sprite_ids -- sprite_ids}
+      end)
+
+      # Stop the sprite processes
+      Enum.each(sprite_ids, &terminate_sprite/1)
+    end)
+
+    :ok
+  end
+
+  defp start_sprite_process(config) do
+    desired = Map.get(config, :desired_state, :hibernating)
+
+    {:ok, _pid} =
+      DynamicSupervisor.start_child(
+        Lattice.Sprites.DynamicSupervisor,
+        {Sprite,
+         [
+           sprite_id: config.id,
+           desired_state: desired,
+           name: Sprite.via(config.id),
+           reconcile_interval_ms: 600_000
+         ]}
+      )
+  end
+
+  defp terminate_sprite(sprite_id) do
+    case Registry.lookup(Lattice.Sprites.Registry, sprite_id) do
+      [{pid, _}] when is_pid(pid) ->
+        DynamicSupervisor.terminate_child(Lattice.Sprites.DynamicSupervisor, pid)
+
+      _ ->
+        :ok
+    end
+  end
+
+  # ── GET /api/sprites ────────────────────────────────────────────────
+
+  describe "GET /api/sprites" do
+    test "lists all sprites with state", %{conn: conn} do
+      start_sprites([
+        %{id: "api-sprite-001", desired_state: :hibernating},
+        %{id: "api-sprite-002", desired_state: :hibernating}
+      ])
+
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/sprites")
+
+      body = json_response(conn, 200)
+
+      assert length(body["data"]) == 2
+
+      sprite_ids = Enum.map(body["data"], & &1["id"])
+      assert "api-sprite-001" in sprite_ids
+      assert "api-sprite-002" in sprite_ids
+
+      first = Enum.find(body["data"], &(&1["id"] == "api-sprite-001"))
+      assert first["observed_state"] == "hibernating"
+      assert first["desired_state"] == "hibernating"
+      assert is_binary(body["timestamp"])
+    end
+
+    test "returns empty list when no sprites", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/sprites")
+
+      body = json_response(conn, 200)
+
+      assert body["data"] == []
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = get(conn, "/api/sprites")
+
+      assert json_response(conn, 401)
+    end
+  end
+
+  # ── GET /api/sprites/:id ───────────────────────────────────────────
+
+  describe "GET /api/sprites/:id" do
+    test "returns sprite detail when found", %{conn: conn} do
+      start_sprites([%{id: "api-show-001", desired_state: :hibernating}])
+
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/sprites/api-show-001")
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["id"] == "api-show-001"
+      assert body["data"]["observed_state"] == "hibernating"
+      assert body["data"]["desired_state"] == "hibernating"
+      assert is_integer(body["data"]["failure_count"])
+      assert is_binary(body["data"]["started_at"])
+      assert is_binary(body["data"]["updated_at"])
+      assert is_binary(body["timestamp"])
+    end
+
+    test "returns 404 for unknown sprite", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/sprites/nonexistent")
+
+      body = json_response(conn, 404)
+
+      assert body["error"] == "Sprite not found"
+      assert body["code"] == "SPRITE_NOT_FOUND"
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = get(conn, "/api/sprites/some-id")
+
+      assert json_response(conn, 401)
+    end
+  end
+
+  # ── PUT /api/sprites/:id/desired ───────────────────────────────────
+
+  describe "PUT /api/sprites/:id/desired" do
+    test "updates desired state to ready", %{conn: conn} do
+      start_sprites([%{id: "api-desired-001", desired_state: :hibernating}])
+
+      conn =
+        conn
+        |> authenticated()
+        |> put("/api/sprites/api-desired-001/desired", %{"state" => "ready"})
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["id"] == "api-desired-001"
+      assert body["data"]["desired_state"] == "ready"
+    end
+
+    test "updates desired state to hibernating", %{conn: conn} do
+      start_sprites([%{id: "api-desired-002", desired_state: :ready}])
+
+      conn =
+        conn
+        |> authenticated()
+        |> put("/api/sprites/api-desired-002/desired", %{"state" => "hibernating"})
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["id"] == "api-desired-002"
+      assert body["data"]["desired_state"] == "hibernating"
+    end
+
+    test "returns 422 for invalid state", %{conn: conn} do
+      start_sprites([%{id: "api-desired-003", desired_state: :hibernating}])
+
+      conn =
+        conn
+        |> authenticated()
+        |> put("/api/sprites/api-desired-003/desired", %{"state" => "invalid"})
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "INVALID_STATE"
+    end
+
+    test "returns 422 when state field is missing", %{conn: conn} do
+      start_sprites([%{id: "api-desired-004", desired_state: :hibernating}])
+
+      conn =
+        conn
+        |> authenticated()
+        |> put("/api/sprites/api-desired-004/desired", %{})
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 404 for unknown sprite", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> put("/api/sprites/nonexistent/desired", %{"state" => "ready"})
+
+      body = json_response(conn, 404)
+
+      assert body["code"] == "SPRITE_NOT_FOUND"
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = put(conn, "/api/sprites/some-id/desired", %{"state" => "ready"})
+
+      assert json_response(conn, 401)
+    end
+  end
+
+  # ── POST /api/sprites/:id/reconcile ────────────────────────────────
+
+  describe "POST /api/sprites/:id/reconcile" do
+    test "triggers reconciliation for a sprite", %{conn: conn} do
+      Lattice.Capabilities.MockSprites
+      |> stub(:get_sprite, fn _id -> {:ok, %{id: "api-recon-001", status: :hibernating}} end)
+
+      start_sprites([%{id: "api-recon-001", desired_state: :hibernating}])
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/sprites/api-recon-001/reconcile")
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["sprite_id"] == "api-recon-001"
+      assert body["data"]["status"] == "reconciliation_triggered"
+      assert is_binary(body["timestamp"])
+    end
+
+    test "returns 404 for unknown sprite", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/sprites/nonexistent/reconcile")
+
+      body = json_response(conn, 404)
+
+      assert body["code"] == "SPRITE_NOT_FOUND"
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = post(conn, "/api/sprites/some-id/reconcile")
+
+      assert json_response(conn, 401)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add authenticated JSON API endpoints under `/api/` for fleet and sprite management
- `GET /api/fleet` returns fleet summary with sprite counts by state
- `POST /api/fleet/audit` triggers fleet-wide reconciliation
- `GET /api/sprites` lists all sprites with current state
- `GET /api/sprites/:id` returns single sprite detail (state, health, timestamps)
- `PUT /api/sprites/:id/desired` updates desired state (validates allowed transitions)
- `POST /api/sprites/:id/reconcile` triggers single-sprite reconciliation
- Consistent JSON response format: `{data: ...}` envelope for success, `{error: msg, code: CODE}` for errors
- All endpoints protected by existing bearer token auth infrastructure
- Proper HTTP status codes: 200, 401, 404, 422

Closes #10

## Test plan
- 20 new tests covering all 6 endpoints
- Tests verify authentication (401 without bearer token)
- Tests verify correct response format and data for happy paths
- Tests verify 404 for unknown sprites
- Tests verify 422 for invalid/missing state in desired state updates
- Tests verify fleet summary with sprites and empty fleet
- Tests verify reconciliation trigger responses
- Full suite passes: 412 tests, 0 failures
- All quality checks pass: `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)