### PR TITLE
Add GitHub HITL capability with label state machine

### DIFF
--- a/lib/lattice/capabilities/github.ex
+++ b/lib/lattice/capabilities/github.ex
@@ -49,6 +49,9 @@ defmodule Lattice.Capabilities.GitHub do
   @doc "List issues, optionally filtered by labels or other criteria."
   @callback list_issues(list_opts()) :: {:ok, [issue()]} | {:error, term()}
 
+  @doc "Get a single issue by number."
+  @callback get_issue(issue_number()) :: {:ok, issue()} | {:error, term()}
+
   @doc "Create a new GitHub issue with the given attributes."
   def create_issue(title, attrs), do: impl().create_issue(title, attrs)
 
@@ -66,6 +69,9 @@ defmodule Lattice.Capabilities.GitHub do
 
   @doc "List issues, optionally filtered by labels or other criteria."
   def list_issues(opts \\ []), do: impl().list_issues(opts)
+
+  @doc "Get a single issue by number."
+  def get_issue(number), do: impl().get_issue(number)
 
   defp impl, do: Application.get_env(:lattice, :capabilities)[:github]
 end

--- a/lib/lattice/capabilities/github/labels.ex
+++ b/lib/lattice/capabilities/github/labels.ex
@@ -1,0 +1,150 @@
+defmodule Lattice.Capabilities.GitHub.Labels do
+  @moduledoc """
+  Label state machine for GitHub issue-based approval workflows.
+
+  Defines the valid labels and their allowed transitions. Each label represents
+  a stage in the human-in-the-loop approval lifecycle:
+
+  - `proposed` -- a Sprite has proposed work; awaiting human review
+  - `approved` -- a human has approved the proposed work
+  - `in-progress` -- the Sprite is actively executing the approved work
+  - `blocked` -- work is paused due to an issue (can return to `proposed` or `approved`)
+  - `done` -- work is complete (terminal state)
+
+  ## State Machine
+
+  ```
+  proposed --> approved --> in-progress --> done
+      ^           |              |
+      |           v              v
+      +------- blocked <--------+
+  ```
+
+  Transition validation enforces this flow. Any attempt to transition outside
+  the allowed paths returns `{:error, {:invalid_transition, from, to}}`.
+  """
+
+  @labels ~w(proposed approved in-progress blocked done)
+
+  @transitions %{
+    "proposed" => ~w(approved blocked),
+    "approved" => ~w(in-progress blocked),
+    "in-progress" => ~w(done blocked),
+    "blocked" => ~w(proposed approved),
+    "done" => []
+  }
+
+  @doc """
+  Returns all valid HITL labels.
+
+  ## Examples
+
+      iex> Lattice.Capabilities.GitHub.Labels.all()
+      ["proposed", "approved", "in-progress", "blocked", "done"]
+
+  """
+  @spec all() :: [String.t()]
+  def all, do: @labels
+
+  @doc """
+  Returns `true` if the given string is a valid HITL label.
+
+  ## Examples
+
+      iex> Lattice.Capabilities.GitHub.Labels.valid?("proposed")
+      true
+
+      iex> Lattice.Capabilities.GitHub.Labels.valid?("invalid")
+      false
+
+  """
+  @spec valid?(String.t()) :: boolean()
+  def valid?(label) when is_binary(label), do: label in @labels
+
+  @doc """
+  Returns the list of labels that can be transitioned to from the given label.
+
+  Returns `{:error, :unknown_label}` if the label is not recognized.
+
+  ## Examples
+
+      iex> Lattice.Capabilities.GitHub.Labels.valid_transitions("proposed")
+      {:ok, ["approved", "blocked"]}
+
+      iex> Lattice.Capabilities.GitHub.Labels.valid_transitions("done")
+      {:ok, []}
+
+      iex> Lattice.Capabilities.GitHub.Labels.valid_transitions("invalid")
+      {:error, :unknown_label}
+
+  """
+  @spec valid_transitions(String.t()) :: {:ok, [String.t()]} | {:error, :unknown_label}
+  def valid_transitions(from) when is_binary(from) do
+    case Map.get(@transitions, from) do
+      nil -> {:error, :unknown_label}
+      targets -> {:ok, targets}
+    end
+  end
+
+  @doc """
+  Validate a label transition from one state to another.
+
+  Returns `:ok` if the transition is valid, or
+  `{:error, {:invalid_transition, from, to}}` if not.
+
+  ## Examples
+
+      iex> Lattice.Capabilities.GitHub.Labels.validate_transition("proposed", "approved")
+      :ok
+
+      iex> Lattice.Capabilities.GitHub.Labels.validate_transition("proposed", "done")
+      {:error, {:invalid_transition, "proposed", "done"}}
+
+      iex> Lattice.Capabilities.GitHub.Labels.validate_transition("invalid", "approved")
+      {:error, {:invalid_transition, "invalid", "approved"}}
+
+  """
+  @spec validate_transition(String.t(), String.t()) ::
+          :ok | {:error, {:invalid_transition, String.t(), String.t()}}
+  def validate_transition(from, to) when is_binary(from) and is_binary(to) do
+    case Map.get(@transitions, from) do
+      nil ->
+        {:error, {:invalid_transition, from, to}}
+
+      targets ->
+        if to in targets do
+          :ok
+        else
+          {:error, {:invalid_transition, from, to}}
+        end
+    end
+  end
+
+  @doc """
+  Returns `true` if the label represents a terminal state.
+
+  ## Examples
+
+      iex> Lattice.Capabilities.GitHub.Labels.terminal?("done")
+      true
+
+      iex> Lattice.Capabilities.GitHub.Labels.terminal?("proposed")
+      false
+
+  """
+  @spec terminal?(String.t()) :: boolean()
+  def terminal?("done"), do: true
+  def terminal?(_label), do: false
+
+  @doc """
+  Returns the initial label for a new work proposal.
+
+  ## Examples
+
+      iex> Lattice.Capabilities.GitHub.Labels.initial()
+      "proposed"
+
+  """
+  @spec initial() :: String.t()
+  def initial, do: "proposed"
+end

--- a/lib/lattice/capabilities/github/live.ex
+++ b/lib/lattice/capabilities/github/live.ex
@@ -1,0 +1,309 @@
+defmodule Lattice.Capabilities.GitHub.Live do
+  @moduledoc """
+  Live implementation of the GitHub capability backed by the `gh` CLI.
+
+  Uses `System.cmd("gh", ...)` to call the GitHub CLI, which handles
+  authentication via its own config. This avoids managing OAuth tokens
+  directly and works on any machine where `gh auth login` has been run.
+
+  ## Configuration
+
+  The target repository is read from `Lattice.Instance.resource(:github_repo)`.
+  All operations are scoped to this repository.
+
+  ## Telemetry
+
+  Every GitHub API call emits a `[:lattice, :capability, :call]` telemetry
+  event via `Lattice.Events.emit_capability_call/4` with:
+
+  - capability: `:github`
+  - operation: the callback name (e.g., `:create_issue`)
+  - duration_ms: wall-clock time of the `gh` CLI call
+  - result: `:ok` or `{:error, reason}`
+  """
+
+  @behaviour Lattice.Capabilities.GitHub
+
+  require Logger
+
+  alias Lattice.Events
+
+  # ── Callbacks ──────────────────────────────────────────────────────────
+
+  @impl true
+  def create_issue(title, attrs) do
+    body = Map.get(attrs, :body, "")
+    labels = Map.get(attrs, :labels, [])
+
+    args = ["issue", "create", "--title", title, "--body", body]
+    args = if labels != [], do: args ++ ["--label", Enum.join(labels, ",")], else: args
+
+    timed_cmd(:create_issue, args, fn json ->
+      parse_issue(json)
+    end)
+  end
+
+  @impl true
+  def update_issue(number, attrs) do
+    args = ["issue", "edit", to_string(number)]
+
+    args =
+      args
+      |> maybe_add_flag(attrs, :title, "--title")
+      |> maybe_add_flag(attrs, :body, "--body")
+      |> maybe_add_flag(attrs, :state, "--state", fn
+        "closed" -> "closed"
+        "open" -> "open"
+        other -> other
+      end)
+
+    timed_cmd(:update_issue, args, fn _output ->
+      # gh issue edit does not return JSON by default; fetch the updated issue
+      get_issue(number)
+    end)
+  end
+
+  @impl true
+  def add_label(number, label) do
+    args = ["issue", "edit", to_string(number), "--add-label", label]
+
+    timed_cmd(:add_label, args, fn _output ->
+      # Fetch the issue to get the current label list
+      case get_issue_raw(number) do
+        {:ok, issue} -> {:ok, Map.get(issue, "labels", []) |> extract_label_names()}
+        error -> error
+      end
+    end)
+  end
+
+  @impl true
+  def remove_label(number, label) do
+    args = ["issue", "edit", to_string(number), "--remove-label", label]
+
+    timed_cmd(:remove_label, args, fn _output ->
+      # Fetch the issue to get the current label list
+      case get_issue_raw(number) do
+        {:ok, issue} -> {:ok, Map.get(issue, "labels", []) |> extract_label_names()}
+        error -> error
+      end
+    end)
+  end
+
+  @impl true
+  def create_comment(number, body) do
+    args = ["issue", "comment", to_string(number), "--body", body]
+
+    timed_cmd(:create_comment, args, fn _output ->
+      # gh issue comment does not return the comment JSON; construct from known data
+      {:ok,
+       %{
+         id: System.unique_integer([:positive]),
+         body: body,
+         issue_number: number
+       }}
+    end)
+  end
+
+  @impl true
+  def list_issues(opts) do
+    labels = Keyword.get(opts, :labels, [])
+    state = Keyword.get(opts, :state, "open")
+    limit = Keyword.get(opts, :limit, 100)
+
+    args = [
+      "issue",
+      "list",
+      "--state",
+      state,
+      "--limit",
+      to_string(limit),
+      "--json",
+      "number,title,body,state,labels,comments"
+    ]
+
+    args = if labels != [], do: args ++ ["--label", Enum.join(labels, ",")], else: args
+
+    timed_cmd(:list_issues, args, fn json ->
+      case Jason.decode(json) do
+        {:ok, issues} when is_list(issues) ->
+          {:ok, Enum.map(issues, &parse_issue_from_json/1)}
+
+        {:ok, _} ->
+          {:ok, []}
+
+        {:error, _} ->
+          {:error, {:invalid_json, json}}
+      end
+    end)
+  end
+
+  @impl true
+  def get_issue(number) do
+    timed_cmd(:get_issue, issue_view_args(number), fn json ->
+      case Jason.decode(json) do
+        {:ok, data} when is_map(data) -> {:ok, parse_issue_from_json(data)}
+        {:error, _} -> {:error, {:invalid_json, json}}
+      end
+    end)
+  end
+
+  # ── Private: gh CLI Execution ──────────────────────────────────────────
+
+  defp timed_cmd(operation, args, on_success) do
+    repo = repo()
+    full_args = args ++ ["--repo", repo]
+
+    start_time = System.monotonic_time(:millisecond)
+
+    result = run_gh(full_args)
+
+    duration_ms = System.monotonic_time(:millisecond) - start_time
+
+    case result do
+      {:ok, output} ->
+        case on_success.(output) do
+          {:ok, _} = success ->
+            Events.emit_capability_call(:github, operation, duration_ms, :ok)
+            success
+
+          {:error, _} = error ->
+            Events.emit_capability_call(:github, operation, duration_ms, error)
+            error
+        end
+
+      {:error, reason} = error ->
+        Events.emit_capability_call(:github, operation, duration_ms, error)
+        Logger.error("GitHub #{operation} failed: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp run_gh(args) do
+    Logger.debug("gh #{Enum.join(args, " ")}")
+
+    try do
+      case System.cmd("gh", args, stderr_to_stdout: true) do
+        {output, 0} ->
+          {:ok, String.trim(output)}
+
+        {output, exit_code} ->
+          parse_gh_error(output, exit_code)
+      end
+    rescue
+      e in ErlangError ->
+        Logger.error("Failed to execute gh CLI: #{inspect(e)}")
+        {:error, :gh_not_found}
+    end
+  end
+
+  defp parse_gh_error(output, _exit_code) do
+    cond do
+      String.contains?(output, "Could not resolve to an Issue") or
+          String.contains?(output, "not found") ->
+        {:error, :not_found}
+
+      String.contains?(output, "rate limit") or String.contains?(output, "API rate") ->
+        {:error, :rate_limited}
+
+      String.contains?(output, "401") or String.contains?(output, "authentication") or
+          String.contains?(output, "auth login") ->
+        {:error, :unauthorized}
+
+      true ->
+        {:error, {:gh_error, String.trim(output)}}
+    end
+  end
+
+  # ── Private: Raw Fetchers ──────────────────────────────────────────────
+
+  defp get_issue_raw(number) do
+    repo = repo()
+    args = issue_view_args(number) ++ ["--repo", repo]
+
+    case run_gh(args) do
+      {:ok, json} ->
+        case Jason.decode(json) do
+          {:ok, data} when is_map(data) -> {:ok, data}
+          {:error, _} -> {:error, {:invalid_json, json}}
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp issue_view_args(number) do
+    ["issue", "view", to_string(number), "--json", "number,title,body,state,labels,comments"]
+  end
+
+  # ── Private: Argument Building ─────────────────────────────────────────
+
+  defp maybe_add_flag(args, attrs, key, flag) do
+    maybe_add_flag(args, attrs, key, flag, &to_string/1)
+  end
+
+  defp maybe_add_flag(args, attrs, key, flag, transform) do
+    case Map.get(attrs, key) do
+      nil -> args
+      value -> args ++ [flag, transform.(value)]
+    end
+  end
+
+  # ── Private: Parsing ───────────────────────────────────────────────────
+
+  defp parse_issue(output) do
+    # gh issue create outputs a URL like: https://github.com/owner/repo/issues/42
+    case Regex.run(~r|/issues/(\d+)|, output) do
+      [_, number_str] ->
+        number = String.to_integer(number_str)
+
+        case get_issue_raw(number) do
+          {:ok, data} -> {:ok, parse_issue_from_json(data)}
+          error -> error
+        end
+
+      nil ->
+        # Try to parse as JSON (in case --json flag was used)
+        case Jason.decode(output) do
+          {:ok, data} when is_map(data) -> {:ok, parse_issue_from_json(data)}
+          _ -> {:error, {:unexpected_output, output}}
+        end
+    end
+  end
+
+  @doc false
+  def parse_issue_from_json(data) when is_map(data) do
+    %{
+      number: data["number"],
+      title: data["title"],
+      body: data["body"] || "",
+      state: data["state"] || "open",
+      labels: extract_label_names(data["labels"] || []),
+      comments: parse_comments(data["comments"] || [])
+    }
+  end
+
+  defp extract_label_names(labels) when is_list(labels) do
+    Enum.map(labels, fn
+      %{"name" => name} -> name
+      name when is_binary(name) -> name
+    end)
+  end
+
+  defp parse_comments(comments) when is_list(comments) do
+    Enum.map(comments, fn comment ->
+      %{
+        id: comment["id"] || comment["databaseId"],
+        body: comment["body"] || ""
+      }
+    end)
+  end
+
+  # ── Private: Configuration ─────────────────────────────────────────────
+
+  defp repo do
+    Lattice.Instance.resource(:github_repo) ||
+      raise "GITHUB_REPO resource binding is not configured. " <>
+              "Set the GITHUB_REPO environment variable."
+  end
+end

--- a/lib/lattice/capabilities/github/stub.ex
+++ b/lib/lattice/capabilities/github/stub.ex
@@ -99,6 +99,14 @@ defmodule Lattice.Capabilities.GitHub.Stub do
   end
 
   @impl true
+  def get_issue(number) do
+    case Enum.find(@stub_issues, &(&1.number == number)) do
+      nil -> {:error, :not_found}
+      issue -> {:ok, issue}
+    end
+  end
+
+  @impl true
   def list_issues(opts) do
     issues =
       case Keyword.get(opts, :labels) do

--- a/lib/lattice/capabilities/github/work_proposal.ex
+++ b/lib/lattice/capabilities/github/work_proposal.ex
@@ -1,0 +1,192 @@
+defmodule Lattice.Capabilities.GitHub.WorkProposal do
+  @moduledoc """
+  Orchestrates the work proposal flow for the GitHub human-in-the-loop workflow.
+
+  When a Sprite wants to perform a non-trivial action, Lattice creates a GitHub
+  issue with the `proposed` label and a structured body describing the intent.
+  Humans review and apply the `approved` label to grant permission.
+
+  ## Safety Rules
+
+  - Lattice NEVER merges PRs autonomously
+  - Lattice only acts after `approved` label is present
+  - All proposals are logged via telemetry and audit
+
+  ## Flow
+
+  1. `propose_work/2` creates an issue with the `proposed` label
+  2. Humans review the issue, discuss in comments, and add `approved`
+  3. `check_approval/1` polls the issue to see if `approved` label is present
+  4. Once approved, the caller can transition to `in-progress` and execute
+  """
+
+  alias Lattice.Capabilities.GitHub
+  alias Lattice.Capabilities.GitHub.Labels
+  alias Lattice.Safety.Audit
+
+  @doc """
+  Propose work by creating a GitHub issue with the `proposed` label.
+
+  The proposal includes the action description, the sprite that will execute it,
+  and any relevant context.
+
+  ## Parameters
+
+  - `action` -- a short description of the proposed action (used as issue title)
+  - `opts` -- keyword list with:
+    - `:sprite_id` (required) -- the Sprite that will execute the action
+    - `:reason` -- why this action is needed
+    - `:context` -- additional context map (current state, etc.)
+
+  ## Examples
+
+      WorkProposal.propose_work("Deploy new version to staging", [
+        sprite_id: "sprite-001",
+        reason: "New feature branch is ready for testing",
+        context: %{branch: "feature/new-ui", current_version: "1.2.3"}
+      ])
+
+  """
+  @spec propose_work(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def propose_work(action, opts) when is_binary(action) and is_list(opts) do
+    sprite_id = Keyword.fetch!(opts, :sprite_id)
+    reason = Keyword.get(opts, :reason, "No reason provided")
+    context = Keyword.get(opts, :context, %{})
+
+    body = format_proposal_body(action, sprite_id, reason, context)
+
+    attrs = %{
+      body: body,
+      labels: [Labels.initial()]
+    }
+
+    case GitHub.create_issue("[Sprite] #{action}", attrs) do
+      {:ok, issue} ->
+        Audit.log(:github, :propose_work, :controlled, :ok, :system, args: [action, sprite_id])
+
+        {:ok, issue}
+
+      {:error, reason} = error ->
+        Audit.log(:github, :propose_work, :controlled, error, :system, args: [action, sprite_id])
+
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Check whether a proposed issue has been approved.
+
+  Fetches the issue and checks if the `approved` label is present.
+
+  Returns `{:ok, :approved}` if approved, `{:ok, :pending}` if still
+  waiting, or `{:error, reason}` on failure.
+
+  ## Examples
+
+      WorkProposal.check_approval(42)
+      #=> {:ok, :approved}
+
+      WorkProposal.check_approval(42)
+      #=> {:ok, :pending}
+
+  """
+  @spec check_approval(pos_integer()) :: {:ok, :approved | :pending} | {:error, term()}
+  def check_approval(issue_number) when is_integer(issue_number) do
+    case GitHub.get_issue(issue_number) do
+      {:ok, issue} ->
+        if "approved" in Map.get(issue, :labels, []) do
+          {:ok, :approved}
+        else
+          {:ok, :pending}
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Transition an issue's HITL label, validating the state machine.
+
+  Removes the `from` label and adds the `to` label, but only if the
+  transition is valid according to `Labels.validate_transition/2`.
+
+  ## Examples
+
+      WorkProposal.transition_label(42, "approved", "in-progress")
+      #=> {:ok, ["in-progress"]}
+
+      WorkProposal.transition_label(42, "proposed", "done")
+      #=> {:error, {:invalid_transition, "proposed", "done"}}
+
+  """
+  @spec transition_label(pos_integer(), String.t(), String.t()) ::
+          {:ok, [String.t()]} | {:error, term()}
+  def transition_label(issue_number, from, to) do
+    case Labels.validate_transition(from, to) do
+      :ok ->
+        with {:ok, _} <- GitHub.remove_label(issue_number, from) do
+          GitHub.add_label(issue_number, to)
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Mark a proposal as complete by transitioning to `done`.
+
+  Also adds a completion comment to the issue.
+
+  ## Examples
+
+      WorkProposal.complete(42, "in-progress", "Deployment successful")
+
+  """
+  @spec complete(pos_integer(), String.t(), String.t()) ::
+          {:ok, [String.t()]} | {:error, term()}
+  def complete(issue_number, current_label, summary) do
+    case transition_label(issue_number, current_label, "done") do
+      {:ok, labels} ->
+        GitHub.create_comment(
+          issue_number,
+          "## Completed\n\n#{summary}\n\n_Marked done by Lattice._"
+        )
+
+        {:ok, labels}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp format_proposal_body(action, sprite_id, reason, context) do
+    context_section =
+      if context == %{} do
+        ""
+      else
+        context_lines =
+          Enum.map_join(context, "\n", fn {key, value} -> "- **#{key}:** #{value}" end)
+
+        "\n## Context\n\n#{context_lines}\n"
+      end
+
+    """
+    ## Proposed Action
+
+    **Action:** #{action}
+    **Sprite:** `#{sprite_id}`
+    **Reason:** #{reason}
+    #{context_section}
+    ## Approval
+
+    Add the `approved` label to authorize this action.
+
+    ---
+    _Created by Lattice. Do not merge PRs from this issue automatically._
+    """
+  end
+end

--- a/lib/lattice/safety/classifier.ex
+++ b/lib/lattice/safety/classifier.ex
@@ -48,6 +48,7 @@ defmodule Lattice.Safety.Classifier do
     {:sprites, :exec} => :controlled,
     # GitHub
     {:github, :list_issues} => :safe,
+    {:github, :get_issue} => :safe,
     {:github, :create_issue} => :controlled,
     {:github, :update_issue} => :controlled,
     {:github, :add_label} => :controlled,

--- a/test/lattice/capabilities/github/labels_test.exs
+++ b/test/lattice/capabilities/github/labels_test.exs
@@ -1,0 +1,140 @@
+defmodule Lattice.Capabilities.GitHub.LabelsTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Capabilities.GitHub.Labels
+
+  describe "all/0" do
+    test "returns all five HITL labels" do
+      labels = Labels.all()
+
+      assert length(labels) == 5
+      assert "proposed" in labels
+      assert "approved" in labels
+      assert "in-progress" in labels
+      assert "blocked" in labels
+      assert "done" in labels
+    end
+  end
+
+  describe "valid?/1" do
+    test "returns true for valid labels" do
+      for label <- Labels.all() do
+        assert Labels.valid?(label), "expected #{label} to be valid"
+      end
+    end
+
+    test "returns false for invalid labels" do
+      refute Labels.valid?("invalid")
+      refute Labels.valid?("open")
+      refute Labels.valid?("")
+    end
+  end
+
+  describe "valid_transitions/1" do
+    test "proposed can transition to approved or blocked" do
+      assert {:ok, transitions} = Labels.valid_transitions("proposed")
+      assert "approved" in transitions
+      assert "blocked" in transitions
+      assert length(transitions) == 2
+    end
+
+    test "approved can transition to in-progress or blocked" do
+      assert {:ok, transitions} = Labels.valid_transitions("approved")
+      assert "in-progress" in transitions
+      assert "blocked" in transitions
+      assert length(transitions) == 2
+    end
+
+    test "in-progress can transition to done or blocked" do
+      assert {:ok, transitions} = Labels.valid_transitions("in-progress")
+      assert "done" in transitions
+      assert "blocked" in transitions
+      assert length(transitions) == 2
+    end
+
+    test "blocked can transition to proposed or approved" do
+      assert {:ok, transitions} = Labels.valid_transitions("blocked")
+      assert "proposed" in transitions
+      assert "approved" in transitions
+      assert length(transitions) == 2
+    end
+
+    test "done has no valid transitions (terminal)" do
+      assert {:ok, []} = Labels.valid_transitions("done")
+    end
+
+    test "returns error for unknown labels" do
+      assert {:error, :unknown_label} = Labels.valid_transitions("invalid")
+    end
+  end
+
+  describe "validate_transition/2" do
+    test "allows valid forward transitions" do
+      assert :ok = Labels.validate_transition("proposed", "approved")
+      assert :ok = Labels.validate_transition("approved", "in-progress")
+      assert :ok = Labels.validate_transition("in-progress", "done")
+    end
+
+    test "allows transitions to blocked" do
+      assert :ok = Labels.validate_transition("proposed", "blocked")
+      assert :ok = Labels.validate_transition("approved", "blocked")
+      assert :ok = Labels.validate_transition("in-progress", "blocked")
+    end
+
+    test "allows recovery from blocked" do
+      assert :ok = Labels.validate_transition("blocked", "proposed")
+      assert :ok = Labels.validate_transition("blocked", "approved")
+    end
+
+    test "rejects skipping states" do
+      assert {:error, {:invalid_transition, "proposed", "done"}} =
+               Labels.validate_transition("proposed", "done")
+
+      assert {:error, {:invalid_transition, "proposed", "in-progress"}} =
+               Labels.validate_transition("proposed", "in-progress")
+    end
+
+    test "rejects backward transitions (except from blocked)" do
+      assert {:error, {:invalid_transition, "approved", "proposed"}} =
+               Labels.validate_transition("approved", "proposed")
+
+      assert {:error, {:invalid_transition, "in-progress", "approved"}} =
+               Labels.validate_transition("in-progress", "approved")
+
+      assert {:error, {:invalid_transition, "done", "proposed"}} =
+               Labels.validate_transition("done", "proposed")
+    end
+
+    test "rejects transitions from unknown labels" do
+      assert {:error, {:invalid_transition, "invalid", "proposed"}} =
+               Labels.validate_transition("invalid", "proposed")
+    end
+
+    test "rejects transitions from done" do
+      for target <- Labels.all(), target != "done" do
+        assert {:error, {:invalid_transition, "done", ^target}} =
+                 Labels.validate_transition("done", target)
+      end
+    end
+  end
+
+  describe "terminal?/1" do
+    test "done is terminal" do
+      assert Labels.terminal?("done")
+    end
+
+    test "other labels are not terminal" do
+      for label <- ["proposed", "approved", "in-progress", "blocked"] do
+        refute Labels.terminal?(label), "expected #{label} to not be terminal"
+      end
+    end
+  end
+
+  describe "initial/0" do
+    test "returns proposed" do
+      assert Labels.initial() == "proposed"
+    end
+  end
+end

--- a/test/lattice/capabilities/github/live_integration_test.exs
+++ b/test/lattice/capabilities/github/live_integration_test.exs
@@ -1,0 +1,86 @@
+defmodule Lattice.Capabilities.GitHub.LiveIntegrationTest do
+  @moduledoc """
+  Integration tests for the live GitHub capability backed by the `gh` CLI.
+
+  These tests hit the real GitHub API via the `gh` CLI and require:
+
+  1. The `gh` CLI to be installed and authenticated (`gh auth login`)
+  2. The `GITHUB_REPO` environment variable set (e.g., `plattegruber/lattice`)
+
+  Run with:
+
+      GITHUB_REPO=owner/repo mix test --only integration test/lattice/capabilities/github/live_integration_test.exs
+
+  WARNING: These tests create real GitHub issues. Use a test repository.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :integration
+
+  alias Lattice.Capabilities.GitHub.Live
+
+  setup do
+    unless System.get_env("GITHUB_REPO") do
+      raise "GITHUB_REPO must be set for integration tests"
+    end
+
+    # Temporarily override capabilities config to use Live implementation
+    original = Application.get_env(:lattice, :capabilities)
+
+    Application.put_env(
+      :lattice,
+      :capabilities,
+      Keyword.put(original, :github, Lattice.Capabilities.GitHub.Live)
+    )
+
+    on_exit(fn ->
+      Application.put_env(:lattice, :capabilities, original)
+    end)
+
+    :ok
+  end
+
+  describe "list_issues/1" do
+    test "returns {:ok, list} from the live API" do
+      assert {:ok, issues} = Live.list_issues([])
+      assert is_list(issues)
+
+      for issue <- issues do
+        assert Map.has_key?(issue, :number)
+        assert Map.has_key?(issue, :title)
+        assert Map.has_key?(issue, :labels)
+        assert is_integer(issue.number)
+      end
+    end
+
+    test "filters by label" do
+      assert {:ok, _issues} = Live.list_issues(labels: ["bug"])
+    end
+  end
+
+  describe "create_issue/2 and get_issue/1" do
+    test "creates an issue and retrieves it" do
+      title = "Integration test issue #{System.unique_integer([:positive])}"
+
+      assert {:ok, issue} =
+               Live.create_issue(title, %{
+                 body: "This is an automated integration test issue. Safe to close.",
+                 labels: []
+               })
+
+      assert issue.title == title
+      assert is_integer(issue.number)
+
+      # Retrieve the same issue
+      assert {:ok, fetched} = Live.get_issue(issue.number)
+      assert fetched.number == issue.number
+      assert fetched.title == title
+    end
+  end
+
+  describe "get_issue/1" do
+    test "returns {:error, :not_found} for a nonexistent issue" do
+      assert {:error, :not_found} = Live.get_issue(999_999_999)
+    end
+  end
+end

--- a/test/lattice/capabilities/github/live_test.exs
+++ b/test/lattice/capabilities/github/live_test.exs
@@ -1,0 +1,84 @@
+defmodule Lattice.Capabilities.GitHub.LiveTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Capabilities.GitHub.Live
+
+  describe "parse_issue_from_json/1" do
+    test "parses a full issue response" do
+      json = %{
+        "number" => 42,
+        "title" => "Deploy to staging",
+        "body" => "Please deploy the new version",
+        "state" => "open",
+        "labels" => [%{"name" => "proposed"}, %{"name" => "enhancement"}],
+        "comments" => [
+          %{"id" => 1, "body" => "Looks good to me"},
+          %{"id" => 2, "body" => "Approved"}
+        ]
+      }
+
+      result = Live.parse_issue_from_json(json)
+
+      assert result.number == 42
+      assert result.title == "Deploy to staging"
+      assert result.body == "Please deploy the new version"
+      assert result.state == "open"
+      assert result.labels == ["proposed", "enhancement"]
+      assert length(result.comments) == 2
+      assert hd(result.comments).body == "Looks good to me"
+    end
+
+    test "handles missing optional fields" do
+      json = %{
+        "number" => 1,
+        "title" => "Minimal issue"
+      }
+
+      result = Live.parse_issue_from_json(json)
+
+      assert result.number == 1
+      assert result.title == "Minimal issue"
+      assert result.body == ""
+      assert result.state == "open"
+      assert result.labels == []
+      assert result.comments == []
+    end
+
+    test "handles labels as plain strings" do
+      json = %{
+        "number" => 5,
+        "title" => "Test",
+        "labels" => ["bug", "urgent"]
+      }
+
+      result = Live.parse_issue_from_json(json)
+      assert result.labels == ["bug", "urgent"]
+    end
+
+    test "handles labels as objects with name field" do
+      json = %{
+        "number" => 5,
+        "title" => "Test",
+        "labels" => [%{"name" => "bug"}, %{"name" => "urgent"}]
+      }
+
+      result = Live.parse_issue_from_json(json)
+      assert result.labels == ["bug", "urgent"]
+    end
+
+    test "handles comments with databaseId instead of id" do
+      json = %{
+        "number" => 5,
+        "title" => "Test",
+        "comments" => [%{"databaseId" => 123, "body" => "Hello"}]
+      }
+
+      result = Live.parse_issue_from_json(json)
+      assert [comment] = result.comments
+      assert comment.id == 123
+      assert comment.body == "Hello"
+    end
+  end
+end

--- a/test/lattice/capabilities/github/work_proposal_test.exs
+++ b/test/lattice/capabilities/github/work_proposal_test.exs
@@ -1,0 +1,158 @@
+defmodule Lattice.Capabilities.GitHub.WorkProposalTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  @moduletag :unit
+
+  alias Lattice.Capabilities.GitHub.WorkProposal
+
+  setup :verify_on_exit!
+
+  describe "propose_work/2" do
+    test "creates a GitHub issue with proposed label" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_issue, fn title, attrs ->
+        assert title =~ "[Sprite]"
+        assert title =~ "Deploy app"
+        assert "proposed" in attrs.labels
+        assert attrs.body =~ "sprite-001"
+        assert attrs.body =~ "Deploy app"
+
+        {:ok,
+         %{
+           number: 42,
+           title: title,
+           body: attrs.body,
+           state: "open",
+           labels: attrs.labels,
+           comments: []
+         }}
+      end)
+
+      assert {:ok, issue} =
+               WorkProposal.propose_work("Deploy app", sprite_id: "sprite-001")
+
+      assert issue.number == 42
+      assert "proposed" in issue.labels
+    end
+
+    test "includes reason and context in the issue body" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_issue, fn _title, attrs ->
+        assert attrs.body =~ "Need to update"
+        assert attrs.body =~ "branch"
+        assert attrs.body =~ "main"
+
+        {:ok,
+         %{
+           number: 43,
+           title: "[Sprite] Update",
+           body: attrs.body,
+           state: "open",
+           labels: ["proposed"],
+           comments: []
+         }}
+      end)
+
+      assert {:ok, _issue} =
+               WorkProposal.propose_work("Update",
+                 sprite_id: "sprite-002",
+                 reason: "Need to update",
+                 context: %{branch: "main"}
+               )
+    end
+
+    test "returns error when GitHub API fails" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_issue, fn _title, _attrs ->
+        {:error, :rate_limited}
+      end)
+
+      assert {:error, :rate_limited} =
+               WorkProposal.propose_work("Fail", sprite_id: "sprite-003")
+    end
+  end
+
+  describe "check_approval/1" do
+    test "returns :approved when approved label is present" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 42 ->
+        {:ok, %{number: 42, labels: ["proposed", "approved"]}}
+      end)
+
+      assert {:ok, :approved} = WorkProposal.check_approval(42)
+    end
+
+    test "returns :pending when approved label is not present" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 42 ->
+        {:ok, %{number: 42, labels: ["proposed"]}}
+      end)
+
+      assert {:ok, :pending} = WorkProposal.check_approval(42)
+    end
+
+    test "returns error when issue cannot be fetched" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 999 ->
+        {:error, :not_found}
+      end)
+
+      assert {:error, :not_found} = WorkProposal.check_approval(999)
+    end
+  end
+
+  describe "transition_label/3" do
+    test "transitions between valid states" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:remove_label, fn 42, "proposed" ->
+        {:ok, []}
+      end)
+      |> expect(:add_label, fn 42, "approved" ->
+        {:ok, ["approved"]}
+      end)
+
+      assert {:ok, ["approved"]} = WorkProposal.transition_label(42, "proposed", "approved")
+    end
+
+    test "rejects invalid transitions without calling GitHub" do
+      # No expectations set — should not call GitHub at all
+      assert {:error, {:invalid_transition, "proposed", "done"}} =
+               WorkProposal.transition_label(42, "proposed", "done")
+    end
+
+    test "returns error when remove_label fails" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:remove_label, fn 42, "proposed" ->
+        {:error, :not_found}
+      end)
+
+      assert {:error, :not_found} = WorkProposal.transition_label(42, "proposed", "approved")
+    end
+  end
+
+  describe "complete/3" do
+    test "transitions to done and adds a comment" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:remove_label, fn 42, "in-progress" ->
+        {:ok, []}
+      end)
+      |> expect(:add_label, fn 42, "done" ->
+        {:ok, ["done"]}
+      end)
+      |> expect(:create_comment, fn 42, body ->
+        assert body =~ "Completed"
+        assert body =~ "Deployment successful"
+        {:ok, %{id: 1, body: body, issue_number: 42}}
+      end)
+
+      assert {:ok, ["done"]} = WorkProposal.complete(42, "in-progress", "Deployment successful")
+    end
+
+    test "returns error for invalid transition" do
+      assert {:error, {:invalid_transition, "proposed", "done"}} =
+               WorkProposal.complete(42, "proposed", "Nope")
+    end
+  end
+end

--- a/test/lattice/capabilities/github_stub_test.exs
+++ b/test/lattice/capabilities/github_stub_test.exs
@@ -79,6 +79,18 @@ defmodule Lattice.Capabilities.GitHub.StubTest do
     end
   end
 
+  describe "get_issue/1" do
+    test "returns a known issue" do
+      assert {:ok, issue} = Stub.get_issue(1)
+      assert issue.number == 1
+      assert issue.title == "Set up CI pipeline"
+    end
+
+    test "returns error for an unknown issue" do
+      assert {:error, :not_found} = Stub.get_issue(999)
+    end
+  end
+
   describe "list_issues/1" do
     test "returns all issues when no filters are given" do
       assert {:ok, [_, _ | _]} = Stub.list_issues([])

--- a/test/lattice/safety/classifier_test.exs
+++ b/test/lattice/safety/classifier_test.exs
@@ -25,6 +25,10 @@ defmodule Lattice.Safety.ClassifierTest do
       assert {:ok, %Action{classification: :safe}} = Classifier.classify(:github, :list_issues)
     end
 
+    test "classifies github:get_issue as safe" do
+      assert {:ok, %Action{classification: :safe}} = Classifier.classify(:github, :get_issue)
+    end
+
     test "classifies fly:logs as safe" do
       assert {:ok, %Action{classification: :safe}} = Classifier.classify(:fly, :logs)
     end
@@ -124,6 +128,7 @@ defmodule Lattice.Safety.ClassifierTest do
       assert {:sprites, :get_sprite} in safe_actions
       assert {:sprites, :fetch_logs} in safe_actions
       assert {:github, :list_issues} in safe_actions
+      assert {:github, :get_issue} in safe_actions
       assert {:fly, :logs} in safe_actions
       assert {:fly, :machine_status} in safe_actions
       assert {:secret_store, :get_secret} in safe_actions
@@ -168,9 +173,9 @@ defmodule Lattice.Safety.ClassifierTest do
       sprites_ops = Enum.filter(all, fn {{cap, _op}, _class} -> cap == :sprites end)
       assert length(sprites_ops) == 6
 
-      # GitHub: 6 operations
+      # GitHub: 7 operations
       github_ops = Enum.filter(all, fn {{cap, _op}, _class} -> cap == :github end)
-      assert length(github_ops) == 6
+      assert length(github_ops) == 7
 
       # Fly: 3 operations
       fly_ops = Enum.filter(all, fn {{cap, _op}, _class} -> cap == :fly end)


### PR DESCRIPTION
## Summary
- Add `Lattice.Capabilities.GitHub.Live` module implementing all GitHub behaviour callbacks via the `gh` CLI, with telemetry instrumentation and error handling for rate limiting, auth failures, and not-found responses
- Add `Lattice.Capabilities.GitHub.Labels` module defining a label state machine (`proposed -> approved -> in-progress -> done`, with `blocked` as a recovery state) and transition validation
- Add `Lattice.Capabilities.GitHub.WorkProposal` module orchestrating the work proposal flow: `propose_work/2` creates issues with `proposed` label, `check_approval/1` polls for `approved` label, `transition_label/3` validates state machine transitions, and `complete/3` marks work as done
- Add `get_issue/1` callback to the `Lattice.Capabilities.GitHub` behaviour, with implementations in Stub and Live, plus safety classification as `:safe`
- Update `config/runtime.exs` to auto-select `GitHub.Live` when `GITHUB_REPO` is set, using a cleaner capability merge pattern

## Test plan
- 42 new tests added (412 -> 454 total), all passing
- Labels state machine: all transitions tested including valid forward, blocked recovery, invalid skip, terminal state, and unknown label paths
- WorkProposal: Mox-based tests for propose_work, check_approval, transition_label, and complete (including error paths)
- Live module: unit tests for JSON parsing (full issue, minimal issue, label formats, comment ID variants)
- Stub: get_issue tests for known and unknown issues
- Classifier: updated for new get_issue classification, operation count assertions updated
- Integration test file for live GitHub API (excluded by default, requires `GITHUB_REPO` env var)
- All quality gates pass: `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)