### PR TITLE
Add Fly scheduled machines, audit task, and FlyCapability live implementation

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -51,6 +51,13 @@ capabilities =
     capabilities
   end
 
+capabilities =
+  if System.get_env("FLY_APP") do
+    Keyword.put(capabilities, :fly, Lattice.Capabilities.Fly.Live)
+  else
+    capabilities
+  end
+
 config :lattice, :capabilities, capabilities
 
 # Auth provider: use Clerk when secret key is configured, otherwise stub

--- a/fly.toml
+++ b/fly.toml
@@ -31,3 +31,35 @@ kill_signal = 'SIGTERM'
   cpu_kind = 'shared'
   cpus = 1
   memory_mb = 1024
+
+# ── Scheduled Machines ────────────────────────────────────────────────────
+#
+# Fly Scheduled Machines run one-off tasks on a cron schedule. The audit
+# task boots a minimal Lattice instance, reconciles every sprite, logs the
+# results, and exits.
+#
+# Create the scheduled machine (once):
+#
+#   fly machines run . \
+#     --schedule "0 */6 * * *" \
+#     --region ord \
+#     --vm-memory 512 \
+#     --restart on-fail \
+#     --name lattice-audit \
+#     --env PHX_SERVER=false \
+#     --env SECRET_KEY_BASE="$(fly secrets list --json | jq -r '.[] | select(.Name=="SECRET_KEY_BASE") | .Digest')" \
+#     -- /app/bin/lattice eval "Mix.Tasks.Lattice.Audit.run_release()"
+#
+# Or run an ad-hoc audit immediately:
+#
+#   fly machines run . \
+#     --region ord \
+#     --vm-memory 512 \
+#     --restart no \
+#     --rm \
+#     --env PHX_SERVER=false \
+#     -- /app/bin/lattice eval "Mix.Tasks.Lattice.Audit.run_release()"
+#
+# The scheduled machine inherits the app's secrets (SECRET_KEY_BASE, etc.)
+# but runs with PHX_SERVER=false so the Phoenix HTTP server is not started.
+# ──────────────────────────────────────────────────────────────────────────

--- a/lib/lattice/capabilities/fly/live.ex
+++ b/lib/lattice/capabilities/fly/live.ex
@@ -1,0 +1,187 @@
+defmodule Lattice.Capabilities.Fly.Live do
+  @moduledoc """
+  Live implementation of the Fly capability backed by the `fly` CLI.
+
+  Uses `System.cmd("fly", ...)` to call the Fly.io CLI (`flyctl`), which
+  handles authentication via its own token config. This avoids managing
+  API tokens directly and works on any machine where `fly auth login` has
+  been run or where `FLY_API_TOKEN` is set.
+
+  ## Configuration
+
+  The target Fly app is read from `Lattice.Instance.resource(:fly_app)`.
+  All operations are scoped to this app.
+
+  ## Safety
+
+  Read operations (`machine_status/1`, `logs/1`) are implemented.
+  The `deploy/1` operation is classified as `:dangerous` by the safety
+  classifier and is not implemented here -- it returns an error directing
+  the operator to use `fly deploy` directly.
+
+  ## Telemetry
+
+  Every Fly CLI call emits a `[:lattice, :capability, :call]` telemetry
+  event via `Lattice.Events.emit_capability_call/4` with:
+
+  - capability: `:fly`
+  - operation: the callback name (e.g., `:machine_status`)
+  - duration_ms: wall-clock time of the `fly` CLI call
+  - result: `:ok` or `{:error, reason}`
+  """
+
+  @behaviour Lattice.Capabilities.Fly
+
+  require Logger
+
+  alias Lattice.Events
+
+  # ── Callbacks ──────────────────────────────────────────────────────────
+
+  @impl true
+  def deploy(_config) do
+    Logger.warning("Fly deploy is classified as dangerous and is not implemented in Fly.Live")
+    {:error, :not_implemented}
+  end
+
+  @impl true
+  def machine_status(machine_id) do
+    timed_cmd(:machine_status, ["machine", "status", machine_id, "--json"], fn json ->
+      case Jason.decode(json) do
+        {:ok, data} when is_map(data) ->
+          {:ok, parse_machine_status(data)}
+
+        {:error, _} ->
+          {:error, {:invalid_json, json}}
+      end
+    end)
+  end
+
+  @impl true
+  def logs(machine_id, opts) do
+    args = build_logs_args(machine_id, opts)
+
+    timed_cmd(:logs, args, fn output ->
+      lines =
+        output
+        |> String.split("\n", trim: true)
+
+      {:ok, lines}
+    end)
+  end
+
+  # ── Private: fly CLI Execution ──────────────────────────────────────────
+
+  defp timed_cmd(operation, args, on_success) do
+    app = app()
+    full_args = args ++ ["--app", app]
+
+    start_time = System.monotonic_time(:millisecond)
+
+    result = run_fly(full_args)
+
+    duration_ms = System.monotonic_time(:millisecond) - start_time
+
+    case result do
+      {:ok, output} ->
+        case on_success.(output) do
+          {:ok, _} = success ->
+            Events.emit_capability_call(:fly, operation, duration_ms, :ok)
+            success
+
+          {:error, _} = error ->
+            Events.emit_capability_call(:fly, operation, duration_ms, error)
+            error
+        end
+
+      {:error, reason} = error ->
+        Events.emit_capability_call(:fly, operation, duration_ms, error)
+        Logger.error("Fly #{operation} failed: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp run_fly(args) do
+    Logger.debug("fly #{Enum.join(args, " ")}")
+
+    try do
+      case System.cmd("fly", args, stderr_to_stdout: true) do
+        {output, 0} ->
+          {:ok, String.trim(output)}
+
+        {output, exit_code} ->
+          parse_fly_error(output, exit_code)
+      end
+    rescue
+      e in ErlangError ->
+        Logger.error("Failed to execute fly CLI: #{inspect(e)}")
+        {:error, :fly_not_found}
+    end
+  end
+
+  defp parse_fly_error(output, _exit_code) do
+    cond do
+      String.contains?(output, "not found") or
+          String.contains?(output, "could not find") ->
+        {:error, :not_found}
+
+      String.contains?(output, "not authenticated") or
+        String.contains?(output, "unauthorized") or
+          String.contains?(output, "401") ->
+        {:error, :unauthorized}
+
+      true ->
+        {:error, {:fly_error, String.trim(output)}}
+    end
+  end
+
+  # ── Private: Argument Building ─────────────────────────────────────────
+
+  defp build_logs_args(machine_id, opts) do
+    args = ["machine", "logs", machine_id]
+
+    args =
+      case Keyword.get(opts, :lines) do
+        nil -> args
+        n -> args ++ ["--lines", to_string(n)]
+      end
+
+    case Keyword.get(opts, :region) do
+      nil -> args
+      region -> args ++ ["--region", region]
+    end
+  end
+
+  # ── Private: Parsing ───────────────────────────────────────────────────
+
+  @doc false
+  def parse_machine_status(data) when is_map(data) do
+    %{
+      machine_id: data["id"] || data["machine_id"],
+      state: data["state"] || "unknown",
+      region: data["region"],
+      image: get_in(data, ["config", "image"]) || data["image"],
+      created_at: data["created_at"],
+      checks: parse_checks(data["checks"] || [])
+    }
+  end
+
+  defp parse_checks(checks) when is_list(checks) do
+    Enum.map(checks, fn check ->
+      %{
+        name: check["name"] || "unknown",
+        status: check["status"] || "unknown"
+      }
+    end)
+  end
+
+  defp parse_checks(_), do: []
+
+  # ── Private: Configuration ─────────────────────────────────────────────
+
+  defp app do
+    Lattice.Instance.resource(:fly_app) ||
+      raise "FLY_APP resource binding is not configured. " <>
+              "Set the FLY_APP environment variable."
+  end
+end

--- a/lib/mix/tasks/lattice/audit.ex
+++ b/lib/mix/tasks/lattice/audit.ex
@@ -1,0 +1,98 @@
+defmodule Mix.Tasks.Lattice.Audit do
+  @shortdoc "Run a fleet-wide audit and exit"
+
+  @moduledoc """
+  Boots the Lattice application in minimal mode, triggers a fleet-wide
+  reconciliation audit, logs the results, and exits.
+
+  Designed for use as a Fly Scheduled Machine one-off command:
+
+      fly machines run . --command "/app/bin/lattice eval 'Mix.Tasks.Lattice.Audit.run_release()'"
+
+  Or via Mix in development:
+
+      mix lattice.audit
+
+  ## Exit Codes
+
+  - `0` — audit completed successfully
+  - `1` — audit encountered errors
+
+  ## Options
+
+  - `--timeout` — max milliseconds to wait for audit completion (default: 30000)
+  """
+
+  use Mix.Task
+
+  require Logger
+
+  alias Lattice.Events
+  alias Lattice.Sprites.FleetManager
+
+  @default_timeout 30_000
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args, strict: [timeout: :integer])
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+
+    # Start the application (this boots the supervision tree including
+    # FleetManager, PubSub, Registry, etc.)
+    Mix.Task.run("app.start")
+
+    do_audit(timeout)
+  end
+
+  @doc """
+  Entry point for release mode (no Mix available).
+
+  Called via:
+
+      /app/bin/lattice eval 'Mix.Tasks.Lattice.Audit.run_release()'
+
+  In a release context the application is already started by `eval`,
+  so we skip `app.start` and go straight to the audit.
+  """
+  @spec run_release(keyword()) :: :ok
+  def run_release(opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+    do_audit(timeout)
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp do_audit(timeout) do
+    Logger.info("Lattice audit starting")
+
+    # Subscribe to fleet events so we can observe the audit outcome
+    :ok = Events.subscribe_fleet()
+
+    # Trigger the fleet-wide audit
+    :ok = FleetManager.run_audit()
+
+    # Wait for the fleet summary broadcast that follows the audit
+    result =
+      receive do
+        {:fleet_summary, summary} ->
+          {:ok, summary}
+      after
+        timeout ->
+          {:error, :timeout}
+      end
+
+    case result do
+      {:ok, summary} ->
+        Logger.info(
+          "Lattice audit complete: #{summary.total} sprites, " <>
+            "states: #{inspect(summary.by_state)}"
+        )
+
+        :ok
+
+      {:error, :timeout} ->
+        Logger.error("Lattice audit timed out after #{timeout}ms")
+        exit({:shutdown, 1})
+    end
+  end
+end

--- a/test/lattice/capabilities/fly/live_test.exs
+++ b/test/lattice/capabilities/fly/live_test.exs
@@ -1,0 +1,107 @@
+defmodule Lattice.Capabilities.Fly.LiveTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Capabilities.Fly.Live
+
+  describe "parse_machine_status/1" do
+    test "parses a full machine status response" do
+      data = %{
+        "id" => "mach-abc123",
+        "state" => "started",
+        "region" => "ord",
+        "config" => %{
+          "image" => "registry.fly.io/lattice:deploy-abc"
+        },
+        "created_at" => "2026-02-16T10:00:00Z",
+        "checks" => [
+          %{"name" => "http", "status" => "passing"},
+          %{"name" => "tcp", "status" => "passing"}
+        ]
+      }
+
+      result = Live.parse_machine_status(data)
+
+      assert result.machine_id == "mach-abc123"
+      assert result.state == "started"
+      assert result.region == "ord"
+      assert result.image == "registry.fly.io/lattice:deploy-abc"
+      assert result.created_at == "2026-02-16T10:00:00Z"
+      assert length(result.checks) == 2
+      assert hd(result.checks).name == "http"
+      assert hd(result.checks).status == "passing"
+    end
+
+    test "handles missing optional fields" do
+      data = %{
+        "id" => "mach-minimal",
+        "state" => "stopped"
+      }
+
+      result = Live.parse_machine_status(data)
+
+      assert result.machine_id == "mach-minimal"
+      assert result.state == "stopped"
+      assert result.region == nil
+      assert result.image == nil
+      assert result.checks == []
+    end
+
+    test "handles machine_id key instead of id" do
+      data = %{
+        "machine_id" => "mach-alt-key",
+        "state" => "started",
+        "region" => "iad"
+      }
+
+      result = Live.parse_machine_status(data)
+
+      assert result.machine_id == "mach-alt-key"
+    end
+
+    test "handles image at top level instead of nested config" do
+      data = %{
+        "id" => "mach-flat",
+        "state" => "started",
+        "image" => "lattice:latest"
+      }
+
+      result = Live.parse_machine_status(data)
+
+      assert result.image == "lattice:latest"
+    end
+
+    test "handles non-list checks gracefully" do
+      data = %{
+        "id" => "mach-no-checks",
+        "state" => "started",
+        "checks" => nil
+      }
+
+      result = Live.parse_machine_status(data)
+
+      assert result.checks == []
+    end
+
+    test "handles checks with missing fields" do
+      data = %{
+        "id" => "mach-partial-checks",
+        "state" => "started",
+        "checks" => [%{}]
+      }
+
+      result = Live.parse_machine_status(data)
+
+      assert [check] = result.checks
+      assert check.name == "unknown"
+      assert check.status == "unknown"
+    end
+  end
+
+  describe "deploy/1" do
+    test "returns :not_implemented error" do
+      assert {:error, :not_implemented} = Live.deploy(%{app: "test-app"})
+    end
+  end
+end

--- a/test/mix/tasks/lattice/audit_test.exs
+++ b/test/mix/tasks/lattice/audit_test.exs
@@ -1,0 +1,86 @@
+defmodule Mix.Tasks.Lattice.AuditTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  import Mox
+
+  alias Lattice.Capabilities.MockSprites
+  alias Lattice.Sprites.FleetManager
+  alias Mix.Tasks.Lattice.Audit
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  defp unique_name(prefix) do
+    :"#{prefix}_#{System.unique_integer([:positive])}"
+  end
+
+  defp start_fleet_manager(sprite_configs) do
+    sup_name = unique_name("audit_test_sup")
+    fm_name = unique_name("audit_test_fm")
+
+    original_config = Application.get_env(:lattice, :fleet, [])
+    Application.put_env(:lattice, :fleet, sprites: sprite_configs)
+
+    {:ok, _sup_pid} = DynamicSupervisor.start_link(name: sup_name, strategy: :one_for_one)
+    {:ok, fm_pid} = FleetManager.start_link(name: fm_name, supervisor: sup_name)
+
+    # Allow the :continue callback to finish
+    Process.sleep(50)
+
+    sprite_ids = Enum.map(sprite_configs, & &1.id)
+
+    on_exit(fn ->
+      Application.put_env(:lattice, :fleet, original_config)
+      safe_stop(fm_pid)
+      safe_stop_named(sup_name)
+      cleanup_registry_sprites(sprite_ids)
+    end)
+
+    %{fm: fm_name}
+  end
+
+  defp cleanup_registry_sprites(sprite_ids) do
+    Enum.each(sprite_ids, fn sprite_id ->
+      case Registry.lookup(Lattice.Sprites.Registry, sprite_id) do
+        [{pid, _}] when is_pid(pid) -> safe_stop(pid)
+        _ -> :ok
+      end
+    end)
+  end
+
+  defp safe_stop(pid) when is_pid(pid) do
+    if Process.alive?(pid), do: GenServer.stop(pid, :normal, 5_000)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp safe_stop(_), do: :ok
+
+  defp safe_stop_named(name) when is_atom(name) do
+    case Process.whereis(name) do
+      nil -> :ok
+      pid -> safe_stop(pid)
+    end
+  end
+
+  describe "run_release/1" do
+    test "completes audit and returns :ok for empty fleet" do
+      %{fm: _fm} = start_fleet_manager([])
+
+      assert :ok = Audit.run_release(timeout: 5_000)
+    end
+
+    test "completes audit with sprites present" do
+      MockSprites
+      |> stub(:get_sprite, fn _id ->
+        {:ok, %{id: "audit-task-001", status: :hibernating}}
+      end)
+
+      %{fm: _fm} = start_fleet_manager([%{id: "audit-task-001", desired_state: :hibernating}])
+
+      assert :ok = Audit.run_release(timeout: 5_000)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Lattice.Capabilities.Fly.Live` — live implementation of the Fly capability using the `fly` CLI, with `machine_status/1` and `logs/2` implemented, and `deploy/1` gated as `:not_implemented` (classified dangerous)
- Add `mix lattice.audit` Mix task — boots the app, triggers fleet-wide reconciliation, logs results, and exits with appropriate exit code (0 success, 1 failure); includes `run_release/1` for use in Fly release eval context
- Auto-select `Fly.Live` in `config/runtime.exs` when the `FLY_APP` environment variable is set, matching the pattern used for GitHub.Live and Sprites.Live
- Document Fly Scheduled Machines setup in `fly.toml` with commands for both cron-scheduled and ad-hoc audit runs

Closes #15

## Test plan
- [x] `Fly.LiveTest` — unit tests for `parse_machine_status/1` covering full responses, missing fields, alternative keys, flat image, nil checks, and partial checks
- [x] `Fly.LiveTest` — unit test for `deploy/1` returning `:not_implemented`
- [x] `Mix.Tasks.Lattice.AuditTest` — tests `run_release/1` completes audit on empty fleet
- [x] `Mix.Tasks.Lattice.AuditTest` — tests `run_release/1` completes audit with sprites present (Mox stubs)
- [x] All 488 tests pass, 0 failures
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format --check-formatted` — clean
- [x] `mix credo --strict` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)