### PR TITLE
Complete baseline CI with PR template and prod compile check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What does this PR do? 1-3 bullet points. -->
+
+-
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] Format clean (`mix format --check-formatted`)
+- [ ] Credo clean (`mix credo --strict`)
+- [ ] Compiles without warnings (`mix compile --warnings-as-errors`)
+- [ ] Vertical PR — small, focused, one concern
+
+## Test plan
+
+<!-- How did you verify this works? -->
+
+-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,33 @@ jobs:
 
       - name: Run tests
         run: mix test
+
+  prod-compile:
+    name: Prod compile check
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: prod
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        id: beam
+        with:
+          otp-version: "27.2.4"
+          elixir-version: "1.18.3"
+
+      - name: Cache deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-prod-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-prod-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+
+      - name: Install dependencies
+        run: mix deps.get --only prod
+
+      - name: Compile (prod, warnings as errors)
+        run: mix compile --warnings-as-errors

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,16 @@ config :lattice, :resources,
   sprites_api_base: System.get_env("SPRITES_API_BASE")
 ```
 
+## Branch Protection
+
+The `main` branch should have these protection rules configured in GitHub (Settings > Branches > Branch protection rules):
+
+- **Require status checks to pass before merging** — select both `Build and test` and `Prod compile check` jobs
+- **Require branches to be up to date before merging** — ensures PRs are tested against the latest main
+- **Require pull request reviews before merging** (optional) — at least 1 approval recommended
+
+These rules must be set manually in the GitHub UI. They cannot be applied via CI.
+
 ## Issue Tracker
 
 Active issues are in [github.com/plattegruber/lattice/issues](https://github.com/plattegruber/lattice/issues).


### PR DESCRIPTION
## Summary
- Add PR template (`.github/pull_request_template.md`) with quality checklist: tests, format, credo, compile, vertical PR
- Add parallel `prod-compile` job in CI that runs `mix compile --warnings-as-errors` under `MIX_ENV=prod` to catch prod-only build failures early
- Document branch protection rules in CLAUDE.md (require CI pass, require up-to-date branch, optional PR reviews)

Closes #16

## Test plan
- Verified all 488 tests pass (`mix test`)
- Verified `mix format --check-formatted` passes
- Verified `mix credo --strict` passes
- Verified `mix compile --warnings-as-errors` passes
- CI workflow YAML validated: two parallel jobs (`test` and `prod-compile`) with independent caches
- PR template file confirmed at correct path for GitHub auto-detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)