### PR TITLE
Update guidance docs to reflect current project state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,41 +4,16 @@ Guidelines for AI agents working on this repository.
 
 ## Required Reading
 
-1. [PHILOSOPHY.md](PHILOSOPHY.md) — design principles and product thinking
-2. [CLAUDE.md](CLAUDE.md) — architecture, conventions, and commands
+1. [CLAUDE.md](CLAUDE.md) — architecture, conventions, commands, API contract
+2. [PHILOSOPHY.md](PHILOSOPHY.md) — design principles and safety spec
 
-## Project Overview
-
-Lattice is an Elixir/Phoenix control plane for managing AI coding agents (Sprites). It uses OTP processes (GenServer per Sprite), LiveView for real-time dashboards, and capability behaviours for safe, bounded access to external systems.
-
-## Build & Test Commands
+## Quick Reference
 
 ```bash
-mix setup                         # Bootstrap project
 mix test                          # Run all tests
-mix test --only unit              # Unit tests only
 mix format --check-formatted      # Check formatting
 mix credo --strict                # Static analysis
 mix compile --warnings-as-errors  # Strict compilation
 ```
 
-## Coding Style
-
-- Elixir with standard library conventions
-- 2-space indentation (Elixir default)
-- `mix format` enforced
-- Pattern matching over conditionals
-- Structs for domain types
-- Behaviours for external dependencies
-
-## Testing
-
-- ExUnit with Mox for behaviour mocking
-- Tests colocated in `test/` mirroring `lib/` structure
-- `@tag :unit` and `@tag :integration` for categorization
-
-## Commits & PRs
-
-- Imperative mood: "Add fleet dashboard", not "Added fleet dashboard"
-- Each PR is a complete vertical slice
-- Small, focused PRs preferred
+For coding conventions, project structure, tech stack, and commit guidelines, see [CLAUDE.md](CLAUDE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Lattice is an **Elixir/Phoenix control plane for managing AI coding agents ("Spr
 | Process model | GenServer, DynamicSupervisor, Registry |
 | Events | :telemetry + Phoenix.PubSub |
 | Persistence | ETS initially, PostgreSQL later |
-| Auth | Clerk (deferred — stubbed initially) |
+| Auth | Bearer token (current) / Clerk integration available |
 | Deployment | Fly.io + Fly Scheduled Machines |
 | CI | GitHub Actions |
 
@@ -177,6 +177,37 @@ config :lattice, :resources,
   sprites_api_base: System.get_env("SPRITES_API_BASE")
 ```
 
+## API Contract
+
+The `/api` scope is protected by bearer token auth (`Authorization: Bearer <token>`) via `LatticeWeb.Plugs.Auth`. Unauthenticated requests receive a `401` response.
+
+**Response envelope:**
+
+- Success: `%{data: ..., timestamp: DateTime.utc_now()}`
+- Error: `%{error: "message", code: "ERROR_CODE"}`
+
+**Status codes:**
+
+| Code | Meaning |
+|------|---------|
+| `200` | Success |
+| `401` | Missing or invalid bearer token |
+| `404` | Resource not found (e.g., `SPRITE_NOT_FOUND`) |
+| `422` | Validation error (e.g., `INVALID_STATE`, `MISSING_FIELD`, `INVALID_STATE_TRANSITION`) |
+
+**Endpoints:**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/fleet` | Fleet summary |
+| `POST` | `/api/fleet/audit` | Trigger fleet-wide reconciliation |
+| `GET` | `/api/sprites` | List all sprites |
+| `GET` | `/api/sprites/:id` | Sprite detail |
+| `PUT` | `/api/sprites/:id/desired` | Update desired state |
+| `POST` | `/api/sprites/:id/reconcile` | Trigger sprite reconciliation |
+
+`GET /health` is unauthenticated.
+
 ## Branch Protection
 
 The `main` branch should have these protection rules configured in GitHub (Settings > Branches > Branch protection rules):
@@ -192,8 +223,8 @@ These rules must be set manually in the GitHub UI. They cannot be applied via CI
 Active issues are in [github.com/plattegruber/lattice/issues](https://github.com/plattegruber/lattice/issues).
 
 Phases:
-1. **Foundation** — capability architecture, event infrastructure, safety framework, CI
-2. **Step 1** — scaffold, sprite processes, fleet manager, LiveView dashboard
-3. **Step 2** — real Sprites API integration, reconciliation, Phoenix API
-4. **Step 3** — GitHub HITL workflow, approvals queue
-5. **Step 4** — Fly deployment, Scheduled Machines
+1. **Foundation** (done) — capability architecture, event infrastructure, safety framework, CI
+2. **Step 1** (done) — scaffold, sprite processes, fleet manager, LiveView dashboard
+3. **Step 2** (done) — real Sprites API integration, reconciliation, Phoenix API
+4. **Step 3** (done) — GitHub HITL workflow, approvals queue
+5. **Step 4** (done) — Fly deployment, Scheduled Machines

--- a/README.md
+++ b/README.md
@@ -49,10 +49,32 @@ mix compile --warnings-as-errors  # Strict compilation
 
 See [CLAUDE.md](CLAUDE.md) for detailed conventions and [PHILOSOPHY.md](PHILOSOPHY.md) for design principles.
 
+## API
+
+Lattice exposes an authenticated JSON API under `/api`. All endpoints require a bearer token via the `Authorization: Bearer <token>` header.
+
+**Response envelope:**
+
+- Success: `{ "data": { ... }, "timestamp": "..." }`
+- Error: `{ "error": "message", "code": "ERROR_CODE" }`
+
+**Endpoints:**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/fleet` | Fleet summary (sprite counts by state) |
+| `POST` | `/api/fleet/audit` | Trigger fleet-wide reconciliation audit |
+| `GET` | `/api/sprites` | List all sprites with current state |
+| `GET` | `/api/sprites/:id` | Single sprite detail |
+| `PUT` | `/api/sprites/:id/desired` | Update desired state (`ready` / `hibernating`) |
+| `POST` | `/api/sprites/:id/reconcile` | Trigger reconciliation for one sprite |
+
+An unauthenticated `GET /health` endpoint is also available.
+
 ## Deployment
 
 Deployed on [Fly.io](https://fly.io). See issue tracker for deployment setup status.
 
 ## License
 
-Private.
+All rights reserved.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -57,11 +57,10 @@ Multi-agent PR review with confidence scoring.
 claude plugin install pr-review-toolkit@claude-plugin-directory
 ```
 
-### GitHub MCP Server
+### GitHub MCP Server (optional, not preconfigured)
 
-Structured access to repos, PRs, issues, Actions, and code search. Richer than the `gh` CLI for some workflows.
+Structured access to repos, PRs, issues, Actions, and code search. Richer than the `gh` CLI for some workflows. Not included in `.mcp.json` by default — add manually if needed:
 
-Add to `.mcp.json`:
 ```json
 {
   "mcpServers": {


### PR DESCRIPTION
## Summary
- Add API section to README.md with endpoint table, auth, and response envelope conventions
- Update CLAUDE.md Tech Stack auth row from 'Clerk (deferred)' to 'Bearer token (current) / Clerk integration available'
- Add API Contract section to CLAUDE.md documenting status codes, envelope format, and all endpoints
- Mark all phases as done in CLAUDE.md issue tracker section
- Add concrete Safety and Guardrails subsection to PHILOSOPHY.md with classifications, gating rules, approval mechanism, audit events, and config flags
- Slim AGENTS.md to required reading links and quick-reference commands, linking to CLAUDE.md for details
- Label GitHub MCP Server as 'optional, not preconfigured' in SKILLS.md to match actual .mcp.json contents
- Change README.md license line from 'Private.' to 'All rights reserved'

Closes #35

## Test plan
- [x] mix compile --warnings-as-errors passes
- [x] mix format --check-formatted passes
- [x] mix credo --strict passes
- [x] mix test passes (488 tests, 0 failures)
- [ ] Verify rendered Markdown looks correct in GitHub PR diff

Generated with Claude Code (https://claude.com/claude-code)