### PR TITLE
Add Intent data model with struct, kinds, and lifecycle state machine

### DIFF
--- a/lib/lattice/intents/intent.ex
+++ b/lib/lattice/intents/intent.ex
@@ -1,0 +1,212 @@
+defmodule Lattice.Intents.Intent do
+  @moduledoc """
+  The unit of work in Lattice.
+
+  An Intent is a durable declaration of something the system proposes to do,
+  ask, or improve. Nothing happens without an Intent — it is the boundary
+  between reasoning and side effects.
+
+  ## Kinds
+
+  - `:action` — produces side effects (deploy, modify infrastructure, scale fleet)
+  - `:inquiry` — requests human input or secrets
+  - `:maintenance` — proposes system improvements (update base image, pin dependency)
+
+  ## Lifecycle
+
+  All intents start in `:proposed` and move through a state machine managed
+  by `Lattice.Intents.Lifecycle`.
+
+      proposed → classified → awaiting_approval → approved → running → completed
+                           ↘ approved ──────────────────────────────↗
+  """
+
+  @valid_kinds [:action, :inquiry, :maintenance]
+  @valid_source_types [:sprite, :agent, :cron, :operator]
+
+  @type kind :: :action | :inquiry | :maintenance
+  @type state ::
+          :proposed
+          | :classified
+          | :awaiting_approval
+          | :approved
+          | :running
+          | :completed
+          | :failed
+          | :rejected
+          | :canceled
+  @type classification :: :safe | :controlled | :dangerous | nil
+  @type source :: %{type: :sprite | :agent | :cron | :operator, id: String.t()}
+  @type transition_entry :: %{
+          from: state(),
+          to: state(),
+          timestamp: DateTime.t(),
+          actor: term(),
+          reason: String.t() | nil
+        }
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          kind: kind(),
+          state: state(),
+          source: source(),
+          summary: String.t(),
+          payload: map(),
+          classification: classification(),
+          result: term(),
+          metadata: map(),
+          affected_resources: [String.t()],
+          expected_side_effects: [String.t()],
+          rollback_strategy: String.t() | nil,
+          transition_log: [transition_entry()],
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t(),
+          classified_at: DateTime.t() | nil,
+          approved_at: DateTime.t() | nil,
+          started_at: DateTime.t() | nil,
+          completed_at: DateTime.t() | nil
+        }
+
+  @enforce_keys [:id, :kind, :state, :source, :summary, :payload, :inserted_at, :updated_at]
+  defstruct [
+    :id,
+    :kind,
+    :state,
+    :source,
+    :summary,
+    :payload,
+    :rollback_strategy,
+    :classified_at,
+    :approved_at,
+    :started_at,
+    :completed_at,
+    :inserted_at,
+    :updated_at,
+    classification: nil,
+    result: nil,
+    metadata: %{},
+    affected_resources: [],
+    expected_side_effects: [],
+    transition_log: []
+  ]
+
+  # ── Constructors ─────────────────────────────────────────────────────
+
+  @doc """
+  Create a new action intent.
+
+  Actions produce side effects. Requires `source`, `summary`, `payload`,
+  `affected_resources` (non-empty list), and `expected_side_effects` (non-empty list).
+  """
+  @spec new_action(source(), keyword()) :: {:ok, t()} | {:error, term()}
+  def new_action(source, opts) do
+    with :ok <- validate_required(opts, :summary),
+         :ok <- validate_required(opts, :payload),
+         :ok <- validate_non_empty_list(opts, :affected_resources),
+         :ok <- validate_non_empty_list(opts, :expected_side_effects) do
+      build(:action, source, opts)
+    end
+  end
+
+  @doc """
+  Create a new inquiry intent.
+
+  Inquiries request human input or secrets. Payload must include string keys
+  `"what_requested"`, `"why_needed"`, `"scope_of_impact"`, and `"expiration"`.
+  """
+  @spec new_inquiry(source(), keyword()) :: {:ok, t()} | {:error, term()}
+  def new_inquiry(source, opts) do
+    with :ok <- validate_required(opts, :summary),
+         :ok <- validate_required(opts, :payload),
+         payload = Keyword.fetch!(opts, :payload),
+         :ok <- validate_payload_field(payload, "what_requested"),
+         :ok <- validate_payload_field(payload, "why_needed"),
+         :ok <- validate_payload_field(payload, "scope_of_impact"),
+         :ok <- validate_payload_field(payload, "expiration") do
+      build(:inquiry, source, opts)
+    end
+  end
+
+  @doc """
+  Create a new maintenance intent.
+
+  Maintenance intents propose system improvements. Requires `source`,
+  `summary`, and `payload`.
+  """
+  @spec new_maintenance(source(), keyword()) :: {:ok, t()} | {:error, term()}
+  def new_maintenance(source, opts) do
+    with :ok <- validate_required(opts, :summary),
+         :ok <- validate_required(opts, :payload) do
+      build(:maintenance, source, opts)
+    end
+  end
+
+  # ── Public Helpers ───────────────────────────────────────────────────
+
+  @doc "Returns the list of valid intent kinds."
+  @spec valid_kinds() :: [kind()]
+  def valid_kinds, do: @valid_kinds
+
+  @doc "Returns the list of valid source types."
+  @spec valid_source_types() :: [atom()]
+  def valid_source_types, do: @valid_source_types
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp build(kind, source, opts) do
+    with :ok <- validate_source(source) do
+      now = DateTime.utc_now()
+
+      {:ok,
+       %__MODULE__{
+         id: generate_id(),
+         kind: kind,
+         state: :proposed,
+         source: source,
+         summary: Keyword.fetch!(opts, :summary),
+         payload: Keyword.fetch!(opts, :payload),
+         metadata: Keyword.get(opts, :metadata, %{}),
+         affected_resources: Keyword.get(opts, :affected_resources, []),
+         expected_side_effects: Keyword.get(opts, :expected_side_effects, []),
+         rollback_strategy: Keyword.get(opts, :rollback_strategy),
+         inserted_at: now,
+         updated_at: now
+       }}
+    end
+  end
+
+  defp generate_id do
+    "int_" <> Base.url_encode64(:crypto.strong_rand_bytes(16), padding: false)
+  end
+
+  defp validate_source(%{type: type, id: id}) when type in @valid_source_types and is_binary(id),
+    do: :ok
+
+  defp validate_source(%{type: type}) when type not in @valid_source_types,
+    do: {:error, {:invalid_source_type, type}}
+
+  defp validate_source(_), do: {:error, {:invalid_source, :bad_format}}
+
+  defp validate_required(opts, field) do
+    case Keyword.fetch(opts, field) do
+      {:ok, _value} -> :ok
+      :error -> {:error, {:missing_field, field}}
+    end
+  end
+
+  defp validate_non_empty_list(opts, field) do
+    case Keyword.fetch(opts, field) do
+      {:ok, [_ | _]} -> :ok
+      {:ok, _} -> {:error, {:missing_field, field}}
+      :error -> {:error, {:missing_field, field}}
+    end
+  end
+
+  defp validate_payload_field(payload, key) when is_map(payload) do
+    if Map.has_key?(payload, key) do
+      :ok
+    else
+      {:error, {:missing_payload_field, key}}
+    end
+  end
+end

--- a/lib/lattice/intents/lifecycle.ex
+++ b/lib/lattice/intents/lifecycle.ex
@@ -1,0 +1,121 @@
+defmodule Lattice.Intents.Lifecycle do
+  @moduledoc """
+  State machine for Intent lifecycle transitions.
+
+  Validates and applies state transitions on `%Intent{}` structs, maintaining
+  a transition log and lifecycle timestamps.
+
+  ## States
+
+      proposed → classified → awaiting_approval → approved → running → completed
+                            ↘ approved ────────────────────────────↗
+                                                                    ↘ failed
+
+  Terminal states: `:completed`, `:failed`, `:rejected`, `:canceled`
+  """
+
+  alias Lattice.Intents.Intent
+
+  @transitions %{
+    proposed: [:classified],
+    classified: [:awaiting_approval, :approved],
+    awaiting_approval: [:approved, :rejected, :canceled],
+    approved: [:running, :canceled],
+    running: [:completed, :failed],
+    completed: [],
+    failed: [],
+    rejected: [],
+    canceled: []
+  }
+
+  @valid_states Map.keys(@transitions)
+  @terminal_states for {state, []} <- @transitions, do: state
+
+  # ── Public API ───────────────────────────────────────────────────────
+
+  @doc """
+  Transition an intent to a new state.
+
+  Updates the intent's state, `updated_at`, transition log, and the
+  appropriate lifecycle timestamp. Returns `{:ok, intent}` on success.
+
+  ## Options
+
+  - `:actor` — who triggered the transition (default: `nil`)
+  - `:reason` — why the transition happened (default: `nil`)
+  """
+  @spec transition(Intent.t(), Intent.state(), keyword()) ::
+          {:ok, Intent.t()} | {:error, term()}
+  def transition(%Intent{} = intent, new_state, opts \\ []) do
+    with :ok <- validate_state(new_state),
+         :ok <- validate_transition(intent.state, new_state) do
+      now = DateTime.utc_now()
+
+      entry = %{
+        from: intent.state,
+        to: new_state,
+        timestamp: now,
+        actor: Keyword.get(opts, :actor),
+        reason: Keyword.get(opts, :reason)
+      }
+
+      updated =
+        intent
+        |> Map.put(:state, new_state)
+        |> Map.put(:updated_at, now)
+        |> Map.update!(:transition_log, fn log -> [entry | log] end)
+        |> put_lifecycle_timestamp(new_state, now)
+
+      {:ok, updated}
+    end
+  end
+
+  @doc """
+  Returns the list of valid target states from the given state.
+
+  Returns an empty list for terminal states or `{:error, {:invalid_state, state}}`
+  for unrecognized states.
+  """
+  @spec valid_transitions(Intent.state()) :: [Intent.state()] | {:error, term()}
+  def valid_transitions(state) when is_map_key(@transitions, state) do
+    Map.fetch!(@transitions, state)
+  end
+
+  def valid_transitions(state), do: {:error, {:invalid_state, state}}
+
+  @doc "Returns `true` if the given state is terminal (no further transitions)."
+  @spec terminal?(Intent.state()) :: boolean()
+  def terminal?(state) when state in @terminal_states, do: true
+  def terminal?(_state), do: false
+
+  @doc "Returns all valid lifecycle states."
+  @spec valid_states() :: [Intent.state()]
+  def valid_states, do: @valid_states
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp validate_state(state) when state in @valid_states, do: :ok
+  defp validate_state(state), do: {:error, {:invalid_state, state}}
+
+  defp validate_transition(from, to) do
+    if to in Map.fetch!(@transitions, from) do
+      :ok
+    else
+      {:error, {:invalid_transition, %{from: from, to: to}}}
+    end
+  end
+
+  defp put_lifecycle_timestamp(intent, :classified, now),
+    do: Map.put(intent, :classified_at, now)
+
+  defp put_lifecycle_timestamp(intent, :approved, now),
+    do: Map.put(intent, :approved_at, now)
+
+  defp put_lifecycle_timestamp(intent, :running, now),
+    do: Map.put(intent, :started_at, now)
+
+  defp put_lifecycle_timestamp(intent, state, now) when state in [:completed, :failed],
+    do: Map.put(intent, :completed_at, now)
+
+  defp put_lifecycle_timestamp(intent, _state, _now), do: intent
+end

--- a/test/lattice/intents/intent_test.exs
+++ b/test/lattice/intents/intent_test.exs
@@ -1,0 +1,297 @@
+defmodule Lattice.Intents.IntentTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Intents.Intent
+
+  @valid_source %{type: :sprite, id: "sprite-001"}
+
+  # ── new_action/2 ─────────────────────────────────────────────────────
+
+  describe "new_action/2" do
+    test "creates an action intent with valid params" do
+      assert {:ok, intent} =
+               Intent.new_action(@valid_source,
+                 summary: "Deploy app",
+                 payload: %{"target" => "prod"},
+                 affected_resources: ["fly-app-1"],
+                 expected_side_effects: ["app restarted"]
+               )
+
+      assert intent.kind == :action
+      assert intent.state == :proposed
+      assert intent.source == @valid_source
+      assert intent.summary == "Deploy app"
+      assert intent.payload == %{"target" => "prod"}
+      assert intent.affected_resources == ["fly-app-1"]
+      assert intent.expected_side_effects == ["app restarted"]
+      assert String.starts_with?(intent.id, "int_")
+      assert %DateTime{} = intent.inserted_at
+      assert %DateTime{} = intent.updated_at
+    end
+
+    test "defaults optional fields" do
+      assert {:ok, intent} =
+               Intent.new_action(@valid_source,
+                 summary: "Deploy",
+                 payload: %{},
+                 affected_resources: ["res"],
+                 expected_side_effects: ["effect"]
+               )
+
+      assert intent.classification == nil
+      assert intent.result == nil
+      assert intent.metadata == %{}
+      assert intent.rollback_strategy == nil
+      assert intent.transition_log == []
+      assert intent.classified_at == nil
+      assert intent.approved_at == nil
+      assert intent.started_at == nil
+      assert intent.completed_at == nil
+    end
+
+    test "accepts optional metadata and rollback_strategy" do
+      assert {:ok, intent} =
+               Intent.new_action(@valid_source,
+                 summary: "Deploy",
+                 payload: %{},
+                 affected_resources: ["res"],
+                 expected_side_effects: ["effect"],
+                 metadata: %{"priority" => "high"},
+                 rollback_strategy: "redeploy previous version"
+               )
+
+      assert intent.metadata == %{"priority" => "high"}
+      assert intent.rollback_strategy == "redeploy previous version"
+    end
+
+    test "rejects missing summary" do
+      assert {:error, {:missing_field, :summary}} =
+               Intent.new_action(@valid_source,
+                 payload: %{},
+                 affected_resources: ["res"],
+                 expected_side_effects: ["effect"]
+               )
+    end
+
+    test "rejects missing payload" do
+      assert {:error, {:missing_field, :payload}} =
+               Intent.new_action(@valid_source,
+                 summary: "Deploy",
+                 affected_resources: ["res"],
+                 expected_side_effects: ["effect"]
+               )
+    end
+
+    test "rejects missing affected_resources" do
+      assert {:error, {:missing_field, :affected_resources}} =
+               Intent.new_action(@valid_source,
+                 summary: "Deploy",
+                 payload: %{},
+                 expected_side_effects: ["effect"]
+               )
+    end
+
+    test "rejects empty affected_resources list" do
+      assert {:error, {:missing_field, :affected_resources}} =
+               Intent.new_action(@valid_source,
+                 summary: "Deploy",
+                 payload: %{},
+                 affected_resources: [],
+                 expected_side_effects: ["effect"]
+               )
+    end
+
+    test "rejects missing expected_side_effects" do
+      assert {:error, {:missing_field, :expected_side_effects}} =
+               Intent.new_action(@valid_source,
+                 summary: "Deploy",
+                 payload: %{},
+                 affected_resources: ["res"]
+               )
+    end
+
+    test "rejects empty expected_side_effects list" do
+      assert {:error, {:missing_field, :expected_side_effects}} =
+               Intent.new_action(@valid_source,
+                 summary: "Deploy",
+                 payload: %{},
+                 affected_resources: ["res"],
+                 expected_side_effects: []
+               )
+    end
+  end
+
+  # ── new_inquiry/2 ────────────────────────────────────────────────────
+
+  describe "new_inquiry/2" do
+    @valid_inquiry_payload %{
+      "what_requested" => "API key for service X",
+      "why_needed" => "Required for integration",
+      "scope_of_impact" => "single service",
+      "expiration" => "2026-03-01"
+    }
+
+    test "creates an inquiry intent with valid params" do
+      assert {:ok, intent} =
+               Intent.new_inquiry(@valid_source,
+                 summary: "Need API key",
+                 payload: @valid_inquiry_payload
+               )
+
+      assert intent.kind == :inquiry
+      assert intent.state == :proposed
+      assert intent.summary == "Need API key"
+      assert intent.payload == @valid_inquiry_payload
+    end
+
+    test "rejects missing what_requested in payload" do
+      payload = Map.delete(@valid_inquiry_payload, "what_requested")
+
+      assert {:error, {:missing_payload_field, "what_requested"}} =
+               Intent.new_inquiry(@valid_source, summary: "Need key", payload: payload)
+    end
+
+    test "rejects missing why_needed in payload" do
+      payload = Map.delete(@valid_inquiry_payload, "why_needed")
+
+      assert {:error, {:missing_payload_field, "why_needed"}} =
+               Intent.new_inquiry(@valid_source, summary: "Need key", payload: payload)
+    end
+
+    test "rejects missing scope_of_impact in payload" do
+      payload = Map.delete(@valid_inquiry_payload, "scope_of_impact")
+
+      assert {:error, {:missing_payload_field, "scope_of_impact"}} =
+               Intent.new_inquiry(@valid_source, summary: "Need key", payload: payload)
+    end
+
+    test "rejects missing expiration in payload" do
+      payload = Map.delete(@valid_inquiry_payload, "expiration")
+
+      assert {:error, {:missing_payload_field, "expiration"}} =
+               Intent.new_inquiry(@valid_source, summary: "Need key", payload: payload)
+    end
+
+    test "rejects missing summary" do
+      assert {:error, {:missing_field, :summary}} =
+               Intent.new_inquiry(@valid_source, payload: @valid_inquiry_payload)
+    end
+
+    test "rejects missing payload" do
+      assert {:error, {:missing_field, :payload}} =
+               Intent.new_inquiry(@valid_source, summary: "Need key")
+    end
+
+    test "does not require affected_resources or expected_side_effects" do
+      assert {:ok, intent} =
+               Intent.new_inquiry(@valid_source,
+                 summary: "Need key",
+                 payload: @valid_inquiry_payload
+               )
+
+      assert intent.affected_resources == []
+      assert intent.expected_side_effects == []
+    end
+  end
+
+  # ── new_maintenance/2 ────────────────────────────────────────────────
+
+  describe "new_maintenance/2" do
+    test "creates a maintenance intent with valid params" do
+      assert {:ok, intent} =
+               Intent.new_maintenance(@valid_source,
+                 summary: "Update base image",
+                 payload: %{"image" => "elixir:1.18"}
+               )
+
+      assert intent.kind == :maintenance
+      assert intent.state == :proposed
+      assert intent.summary == "Update base image"
+    end
+
+    test "rejects missing summary" do
+      assert {:error, {:missing_field, :summary}} =
+               Intent.new_maintenance(@valid_source, payload: %{})
+    end
+
+    test "rejects missing payload" do
+      assert {:error, {:missing_field, :payload}} =
+               Intent.new_maintenance(@valid_source, summary: "Update")
+    end
+
+    test "does not require affected_resources or expected_side_effects" do
+      assert {:ok, intent} =
+               Intent.new_maintenance(@valid_source,
+                 summary: "Update",
+                 payload: %{}
+               )
+
+      assert intent.affected_resources == []
+      assert intent.expected_side_effects == []
+    end
+  end
+
+  # ── Source Validation ────────────────────────────────────────────────
+
+  describe "source validation" do
+    test "accepts all valid source types" do
+      for type <- Intent.valid_source_types() do
+        source = %{type: type, id: "test-id"}
+
+        assert {:ok, %Intent{source: ^source}} =
+                 Intent.new_maintenance(source, summary: "Test", payload: %{})
+      end
+    end
+
+    test "rejects invalid source type" do
+      source = %{type: :unknown, id: "test-id"}
+
+      assert {:error, {:invalid_source_type, :unknown}} =
+               Intent.new_maintenance(source, summary: "Test", payload: %{})
+    end
+  end
+
+  # ── ID Generation ───────────────────────────────────────────────────
+
+  describe "id generation" do
+    test "generates unique IDs with int_ prefix" do
+      {:ok, a} = Intent.new_maintenance(@valid_source, summary: "A", payload: %{})
+      {:ok, b} = Intent.new_maintenance(@valid_source, summary: "B", payload: %{})
+
+      assert String.starts_with?(a.id, "int_")
+      assert String.starts_with?(b.id, "int_")
+      assert a.id != b.id
+    end
+  end
+
+  # ── Public Helpers ──────────────────────────────────────────────────
+
+  describe "valid_kinds/0" do
+    test "returns all three kinds" do
+      assert Intent.valid_kinds() == [:action, :inquiry, :maintenance]
+    end
+  end
+
+  describe "valid_source_types/0" do
+    test "returns all valid source types" do
+      types = Intent.valid_source_types()
+      assert :sprite in types
+      assert :agent in types
+      assert :cron in types
+      assert :operator in types
+      assert length(types) == 4
+    end
+  end
+
+  # ── Struct ──────────────────────────────────────────────────────────
+
+  describe "struct" do
+    test "enforces required keys" do
+      assert_raise ArgumentError, fn ->
+        struct!(Intent, %{kind: :action})
+      end
+    end
+  end
+end

--- a/test/lattice/intents/lifecycle_test.exs
+++ b/test/lattice/intents/lifecycle_test.exs
@@ -1,0 +1,299 @@
+defmodule Lattice.Intents.LifecycleTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Lifecycle
+
+  @valid_source %{type: :sprite, id: "sprite-001"}
+
+  defp new_intent(state) do
+    {:ok, intent} =
+      Intent.new_maintenance(@valid_source, summary: "Test", payload: %{})
+
+    # For testing non-proposed states, manually set the state
+    if state == :proposed do
+      intent
+    else
+      %{intent | state: state}
+    end
+  end
+
+  # ── Valid Transitions ────────────────────────────────────────────────
+
+  describe "transition/3 valid paths" do
+    test "proposed → classified" do
+      intent = new_intent(:proposed)
+      assert {:ok, updated} = Lifecycle.transition(intent, :classified)
+      assert updated.state == :classified
+    end
+
+    test "classified → awaiting_approval" do
+      intent = new_intent(:classified)
+      assert {:ok, updated} = Lifecycle.transition(intent, :awaiting_approval)
+      assert updated.state == :awaiting_approval
+    end
+
+    test "classified → approved" do
+      intent = new_intent(:classified)
+      assert {:ok, updated} = Lifecycle.transition(intent, :approved)
+      assert updated.state == :approved
+    end
+
+    test "awaiting_approval → approved" do
+      intent = new_intent(:awaiting_approval)
+      assert {:ok, updated} = Lifecycle.transition(intent, :approved)
+      assert updated.state == :approved
+    end
+
+    test "awaiting_approval → rejected" do
+      intent = new_intent(:awaiting_approval)
+      assert {:ok, updated} = Lifecycle.transition(intent, :rejected)
+      assert updated.state == :rejected
+    end
+
+    test "awaiting_approval → canceled" do
+      intent = new_intent(:awaiting_approval)
+      assert {:ok, updated} = Lifecycle.transition(intent, :canceled)
+      assert updated.state == :canceled
+    end
+
+    test "approved → running" do
+      intent = new_intent(:approved)
+      assert {:ok, updated} = Lifecycle.transition(intent, :running)
+      assert updated.state == :running
+    end
+
+    test "approved → canceled" do
+      intent = new_intent(:approved)
+      assert {:ok, updated} = Lifecycle.transition(intent, :canceled)
+      assert updated.state == :canceled
+    end
+
+    test "running → completed" do
+      intent = new_intent(:running)
+      assert {:ok, updated} = Lifecycle.transition(intent, :completed)
+      assert updated.state == :completed
+    end
+
+    test "running → failed" do
+      intent = new_intent(:running)
+      assert {:ok, updated} = Lifecycle.transition(intent, :failed)
+      assert updated.state == :failed
+    end
+  end
+
+  # ── Invalid Transitions ──────────────────────────────────────────────
+
+  describe "transition/3 invalid paths" do
+    test "proposed cannot skip to approved" do
+      intent = new_intent(:proposed)
+
+      assert {:error, {:invalid_transition, %{from: :proposed, to: :approved}}} =
+               Lifecycle.transition(intent, :approved)
+    end
+
+    test "proposed cannot go to running" do
+      intent = new_intent(:proposed)
+
+      assert {:error, {:invalid_transition, %{from: :proposed, to: :running}}} =
+               Lifecycle.transition(intent, :running)
+    end
+
+    test "completed is terminal" do
+      intent = new_intent(:completed)
+
+      assert {:error, {:invalid_transition, %{from: :completed, to: :running}}} =
+               Lifecycle.transition(intent, :running)
+    end
+
+    test "failed is terminal" do
+      intent = new_intent(:failed)
+
+      assert {:error, {:invalid_transition, %{from: :failed, to: :running}}} =
+               Lifecycle.transition(intent, :running)
+    end
+
+    test "rejected is terminal" do
+      intent = new_intent(:rejected)
+
+      assert {:error, {:invalid_transition, %{from: :rejected, to: :proposed}}} =
+               Lifecycle.transition(intent, :proposed)
+    end
+
+    test "canceled is terminal" do
+      intent = new_intent(:canceled)
+
+      assert {:error, {:invalid_transition, %{from: :canceled, to: :proposed}}} =
+               Lifecycle.transition(intent, :proposed)
+    end
+
+    test "rejects invalid target state" do
+      intent = new_intent(:proposed)
+
+      assert {:error, {:invalid_state, :nonexistent}} =
+               Lifecycle.transition(intent, :nonexistent)
+    end
+
+    test "running cannot go back to approved" do
+      intent = new_intent(:running)
+
+      assert {:error, {:invalid_transition, %{from: :running, to: :approved}}} =
+               Lifecycle.transition(intent, :approved)
+    end
+  end
+
+  # ── Timestamp Updates ────────────────────────────────────────────────
+
+  describe "lifecycle timestamps" do
+    test "classified sets classified_at" do
+      intent = new_intent(:proposed)
+      assert intent.classified_at == nil
+
+      {:ok, updated} = Lifecycle.transition(intent, :classified)
+      assert %DateTime{} = updated.classified_at
+    end
+
+    test "approved sets approved_at" do
+      intent = new_intent(:classified)
+      {:ok, updated} = Lifecycle.transition(intent, :approved)
+      assert %DateTime{} = updated.approved_at
+    end
+
+    test "running sets started_at" do
+      intent = new_intent(:approved)
+      {:ok, updated} = Lifecycle.transition(intent, :running)
+      assert %DateTime{} = updated.started_at
+    end
+
+    test "completed sets completed_at" do
+      intent = new_intent(:running)
+      {:ok, updated} = Lifecycle.transition(intent, :completed)
+      assert %DateTime{} = updated.completed_at
+    end
+
+    test "failed sets completed_at" do
+      intent = new_intent(:running)
+      {:ok, updated} = Lifecycle.transition(intent, :failed)
+      assert %DateTime{} = updated.completed_at
+    end
+
+    test "updated_at is refreshed on transition" do
+      intent = new_intent(:proposed)
+      {:ok, updated} = Lifecycle.transition(intent, :classified)
+      assert DateTime.compare(updated.updated_at, intent.updated_at) in [:gt, :eq]
+    end
+  end
+
+  # ── Transition Log ──────────────────────────────────────────────────
+
+  describe "transition log" do
+    test "records transition entry" do
+      intent = new_intent(:proposed)
+      {:ok, updated} = Lifecycle.transition(intent, :classified, actor: "system", reason: "auto")
+
+      assert [entry] = updated.transition_log
+      assert entry.from == :proposed
+      assert entry.to == :classified
+      assert entry.actor == "system"
+      assert entry.reason == "auto"
+      assert %DateTime{} = entry.timestamp
+    end
+
+    test "prepends new entries" do
+      intent = new_intent(:proposed)
+      {:ok, intent} = Lifecycle.transition(intent, :classified)
+      intent = %{intent | state: :classified}
+      {:ok, intent} = Lifecycle.transition(intent, :approved)
+
+      assert [second, first] = intent.transition_log
+      assert first.from == :proposed
+      assert first.to == :classified
+      assert second.from == :classified
+      assert second.to == :approved
+    end
+
+    test "defaults actor and reason to nil" do
+      intent = new_intent(:proposed)
+      {:ok, updated} = Lifecycle.transition(intent, :classified)
+
+      [entry] = updated.transition_log
+      assert entry.actor == nil
+      assert entry.reason == nil
+    end
+  end
+
+  # ── valid_transitions/1 ─────────────────────────────────────────────
+
+  describe "valid_transitions/1" do
+    test "returns valid targets for proposed" do
+      assert Lifecycle.valid_transitions(:proposed) == [:classified]
+    end
+
+    test "returns valid targets for classified" do
+      assert Lifecycle.valid_transitions(:classified) == [:awaiting_approval, :approved]
+    end
+
+    test "returns empty list for terminal states" do
+      assert Lifecycle.valid_transitions(:completed) == []
+      assert Lifecycle.valid_transitions(:failed) == []
+      assert Lifecycle.valid_transitions(:rejected) == []
+      assert Lifecycle.valid_transitions(:canceled) == []
+    end
+
+    test "returns error for invalid state" do
+      assert {:error, {:invalid_state, :bogus}} = Lifecycle.valid_transitions(:bogus)
+    end
+  end
+
+  # ── terminal?/1 ─────────────────────────────────────────────────────
+
+  describe "terminal?/1" do
+    test "completed is terminal" do
+      assert Lifecycle.terminal?(:completed)
+    end
+
+    test "failed is terminal" do
+      assert Lifecycle.terminal?(:failed)
+    end
+
+    test "rejected is terminal" do
+      assert Lifecycle.terminal?(:rejected)
+    end
+
+    test "canceled is terminal" do
+      assert Lifecycle.terminal?(:canceled)
+    end
+
+    test "proposed is not terminal" do
+      refute Lifecycle.terminal?(:proposed)
+    end
+
+    test "running is not terminal" do
+      refute Lifecycle.terminal?(:running)
+    end
+
+    test "approved is not terminal" do
+      refute Lifecycle.terminal?(:approved)
+    end
+  end
+
+  # ── valid_states/0 ──────────────────────────────────────────────────
+
+  describe "valid_states/0" do
+    test "returns all 9 states" do
+      states = Lifecycle.valid_states()
+      assert length(states) == 9
+      assert :proposed in states
+      assert :classified in states
+      assert :awaiting_approval in states
+      assert :approved in states
+      assert :running in states
+      assert :completed in states
+      assert :failed in states
+      assert :rejected in states
+      assert :canceled in states
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `%Intent{}` struct (`lib/lattice/intents/intent.ex`) with three kinds (`:action`, `:inquiry`, `:maintenance`), source tracking, side-effect declarations, classification, and lifecycle timestamps
- Add `Lifecycle` module (`lib/lattice/intents/lifecycle.ex`) implementing a 9-state machine with transition validation, transition log, and automatic lifecycle timestamp updates
- Add 66 unit tests covering all constructors, validation paths, valid/invalid transitions, timestamps, and transition log behavior

## Test plan

- [x] `mix test test/lattice/intents/` — 66 tests pass
- [x] `mix test` — full suite (554 tests) passes with 0 failures
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format --check-formatted` — clean
- [x] `mix credo --strict` — no issues

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)