### PR TITLE
Add Intent API endpoints

### DIFF
--- a/lib/lattice_web/controllers/api/intent_controller.ex
+++ b/lib/lattice_web/controllers/api/intent_controller.ex
@@ -1,0 +1,390 @@
+defmodule LatticeWeb.Api.IntentController do
+  @moduledoc """
+  API controller for intent lifecycle operations.
+
+  Provides endpoints for listing, querying, proposing, approving, rejecting,
+  and canceling intents. All business logic delegates to `Lattice.Intents.Pipeline`
+  and `Lattice.Intents.Store`.
+  """
+
+  use LatticeWeb, :controller
+
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Pipeline
+  alias Lattice.Intents.Store
+
+  @valid_kinds ~w(action inquiry maintenance)
+  @valid_filter_states ~w(proposed classified awaiting_approval approved running completed failed rejected canceled)
+  @valid_source_types ~w(sprite agent cron operator)
+
+  # ── GET /api/intents ───────────────────────────────────────────────
+
+  @doc """
+  GET /api/intents — list intents with optional filters.
+
+  Query params: `kind`, `state`, `source_type`
+  """
+  def index(conn, params) do
+    filters = build_filters(params)
+
+    {:ok, intents} = Store.list(filters)
+
+    conn
+    |> put_status(200)
+    |> json(%{
+      data: Enum.map(intents, &serialize_intent/1),
+      timestamp: DateTime.utc_now()
+    })
+  end
+
+  # ── GET /api/intents/:id ──────────────────────────────────────────
+
+  @doc """
+  GET /api/intents/:id — intent detail with full transition history.
+  """
+  def show(conn, %{"id" => intent_id}) do
+    with {:ok, intent} <- Store.get(intent_id),
+         {:ok, history} <- Store.get_history(intent_id) do
+      conn
+      |> put_status(200)
+      |> json(%{
+        data: serialize_intent_detail(intent, history),
+        timestamp: DateTime.utc_now()
+      })
+    else
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "Intent not found", code: "INTENT_NOT_FOUND"})
+    end
+  end
+
+  # ── POST /api/intents ─────────────────────────────────────────────
+
+  @doc """
+  POST /api/intents — propose a new intent through the pipeline.
+
+  Body: `{ "kind": "action"|"inquiry"|"maintenance", "source": { "type": "...", "id": "..." }, "summary": "...", "payload": {...}, ... }`
+  """
+  def create(conn, %{"kind" => kind} = params) when kind in @valid_kinds do
+    with {:ok, source} <- parse_source(params),
+         {:ok, intent} <- build_intent(kind, source, params),
+         {:ok, result} <- Pipeline.propose(intent) do
+      conn
+      |> put_status(200)
+      |> json(%{
+        data: serialize_intent(result),
+        timestamp: DateTime.utc_now()
+      })
+    else
+      {:error, {:missing_field, field}} ->
+        conn
+        |> put_status(422)
+        |> json(%{
+          error: "Missing required field: #{field}",
+          code: "MISSING_FIELD"
+        })
+
+      {:error, {:missing_payload_field, field}} ->
+        conn
+        |> put_status(422)
+        |> json(%{
+          error: "Missing required payload field: #{field}",
+          code: "MISSING_FIELD"
+        })
+
+      {:error, {:invalid_source_type, type}} ->
+        conn
+        |> put_status(422)
+        |> json(%{
+          error: "Invalid source type: #{type}. Allowed: #{inspect(@valid_source_types)}",
+          code: "INVALID_SOURCE_TYPE"
+        })
+
+      {:error, {:invalid_source, :bad_format}} ->
+        conn
+        |> put_status(422)
+        |> json(%{
+          error: "Invalid source format. Required: {\"type\": \"...\", \"id\": \"...\"}",
+          code: "MISSING_FIELD"
+        })
+
+      {:error, reason} ->
+        conn
+        |> put_status(422)
+        |> json(%{
+          error: "Failed to create intent: #{inspect(reason)}",
+          code: "INVALID_KIND"
+        })
+    end
+  end
+
+  def create(conn, %{"kind" => invalid_kind}) do
+    conn
+    |> put_status(422)
+    |> json(%{
+      error: "Invalid kind: #{inspect(invalid_kind)}. Allowed: #{inspect(@valid_kinds)}",
+      code: "INVALID_KIND"
+    })
+  end
+
+  def create(conn, _params) do
+    conn
+    |> put_status(422)
+    |> json(%{
+      error: "Missing required field: kind",
+      code: "MISSING_FIELD"
+    })
+  end
+
+  # ── POST /api/intents/:id/approve ─────────────────────────────────
+
+  @doc """
+  POST /api/intents/:id/approve — approve an awaiting intent.
+
+  Body: `{ "actor": "..." }`
+  """
+  def approve(conn, %{"id" => intent_id, "actor" => actor}) do
+    case Pipeline.approve(intent_id, actor: actor) do
+      {:ok, approved} ->
+        conn
+        |> put_status(200)
+        |> json(%{
+          data: serialize_intent(approved),
+          timestamp: DateTime.utc_now()
+        })
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "Intent not found", code: "INTENT_NOT_FOUND"})
+
+      {:error, {:invalid_transition, _} = reason} ->
+        conn
+        |> put_status(422)
+        |> json(%{
+          error: "Invalid state transition: #{inspect(reason)}",
+          code: "INVALID_TRANSITION"
+        })
+    end
+  end
+
+  def approve(conn, %{"id" => _intent_id}) do
+    conn
+    |> put_status(422)
+    |> json(%{
+      error: "Missing required field: actor",
+      code: "MISSING_FIELD"
+    })
+  end
+
+  # ── POST /api/intents/:id/reject ──────────────────────────────────
+
+  @doc """
+  POST /api/intents/:id/reject — reject an awaiting intent.
+
+  Body: `{ "actor": "...", "reason": "..." }`
+  """
+  def reject(conn, %{"id" => intent_id, "actor" => actor} = params) do
+    reason = Map.get(params, "reason", "rejected")
+
+    case Pipeline.reject(intent_id, actor: actor, reason: reason) do
+      {:ok, rejected} ->
+        conn
+        |> put_status(200)
+        |> json(%{
+          data: serialize_intent(rejected),
+          timestamp: DateTime.utc_now()
+        })
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "Intent not found", code: "INTENT_NOT_FOUND"})
+
+      {:error, {:invalid_transition, _} = reason_err} ->
+        conn
+        |> put_status(422)
+        |> json(%{
+          error: "Invalid state transition: #{inspect(reason_err)}",
+          code: "INVALID_TRANSITION"
+        })
+    end
+  end
+
+  def reject(conn, %{"id" => _intent_id}) do
+    conn
+    |> put_status(422)
+    |> json(%{
+      error: "Missing required field: actor",
+      code: "MISSING_FIELD"
+    })
+  end
+
+  # ── POST /api/intents/:id/cancel ──────────────────────────────────
+
+  @doc """
+  POST /api/intents/:id/cancel — cancel an intent from any pre-execution state.
+
+  Body: `{ "actor": "...", "reason": "..." }`
+  """
+  def cancel(conn, %{"id" => intent_id, "actor" => actor} = params) do
+    reason = Map.get(params, "reason", "canceled")
+
+    case Pipeline.cancel(intent_id, actor: actor, reason: reason) do
+      {:ok, canceled} ->
+        conn
+        |> put_status(200)
+        |> json(%{
+          data: serialize_intent(canceled),
+          timestamp: DateTime.utc_now()
+        })
+
+      {:error, :not_found} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "Intent not found", code: "INTENT_NOT_FOUND"})
+
+      {:error, {:invalid_transition, _} = reason_err} ->
+        conn
+        |> put_status(422)
+        |> json(%{
+          error: "Invalid state transition: #{inspect(reason_err)}",
+          code: "INVALID_TRANSITION"
+        })
+    end
+  end
+
+  def cancel(conn, %{"id" => _intent_id}) do
+    conn
+    |> put_status(422)
+    |> json(%{
+      error: "Missing required field: actor",
+      code: "MISSING_FIELD"
+    })
+  end
+
+  # ── Private: Filters ──────────────────────────────────────────────
+
+  defp build_filters(params) do
+    %{}
+    |> maybe_add_filter(params, "kind", &parse_kind/1)
+    |> maybe_add_filter(params, "state", &parse_state/1)
+    |> maybe_add_filter(params, "source_type", &parse_source_type/1)
+  end
+
+  defp maybe_add_filter(filters, params, key, parser) do
+    case Map.fetch(params, key) do
+      {:ok, value} ->
+        case parser.(value) do
+          {:ok, parsed} -> Map.put(filters, String.to_existing_atom(key), parsed)
+          :error -> filters
+        end
+
+      :error ->
+        filters
+    end
+  end
+
+  defp parse_kind(kind) when kind in @valid_kinds, do: {:ok, String.to_existing_atom(kind)}
+  defp parse_kind(_), do: :error
+
+  defp parse_state(state) when state in @valid_filter_states,
+    do: {:ok, String.to_existing_atom(state)}
+
+  defp parse_state(_), do: :error
+
+  defp parse_source_type(type) when type in @valid_source_types,
+    do: {:ok, String.to_existing_atom(type)}
+
+  defp parse_source_type(_), do: :error
+
+  # ── Private: Intent Construction ──────────────────────────────────
+
+  defp parse_source(%{"source" => %{"type" => type, "id" => id}})
+       when is_binary(type) and is_binary(id) do
+    {:ok, %{type: safe_to_atom(type), id: id}}
+  end
+
+  defp parse_source(%{"source" => _}), do: {:error, {:invalid_source, :bad_format}}
+  defp parse_source(_), do: {:error, {:missing_field, :source}}
+
+  defp safe_to_atom(str) do
+    String.to_existing_atom(str)
+  rescue
+    ArgumentError -> str
+  end
+
+  defp build_intent("action", source, params) do
+    Intent.new_action(source,
+      summary: Map.get(params, "summary", ""),
+      payload: Map.get(params, "payload", %{}),
+      affected_resources: Map.get(params, "affected_resources", []),
+      expected_side_effects: Map.get(params, "expected_side_effects", []),
+      rollback_strategy: Map.get(params, "rollback_strategy")
+    )
+  end
+
+  defp build_intent("inquiry", source, params) do
+    Intent.new_inquiry(source,
+      summary: Map.get(params, "summary", ""),
+      payload: Map.get(params, "payload", %{})
+    )
+  end
+
+  defp build_intent("maintenance", source, params) do
+    Intent.new_maintenance(source,
+      summary: Map.get(params, "summary", ""),
+      payload: Map.get(params, "payload", %{})
+    )
+  end
+
+  # ── Private: Serialization ────────────────────────────────────────
+
+  defp serialize_intent(%Intent{} = intent) do
+    %{
+      id: intent.id,
+      kind: intent.kind,
+      state: intent.state,
+      source: intent.source,
+      summary: intent.summary,
+      classification: intent.classification,
+      inserted_at: intent.inserted_at,
+      updated_at: intent.updated_at
+    }
+  end
+
+  defp serialize_intent_detail(%Intent{} = intent, history) do
+    %{
+      id: intent.id,
+      kind: intent.kind,
+      state: intent.state,
+      source: intent.source,
+      summary: intent.summary,
+      payload: intent.payload,
+      classification: intent.classification,
+      result: intent.result,
+      metadata: intent.metadata,
+      affected_resources: intent.affected_resources,
+      expected_side_effects: intent.expected_side_effects,
+      rollback_strategy: intent.rollback_strategy,
+      transition_log: Enum.map(history, &serialize_transition/1),
+      inserted_at: intent.inserted_at,
+      updated_at: intent.updated_at,
+      classified_at: intent.classified_at,
+      approved_at: intent.approved_at,
+      started_at: intent.started_at,
+      completed_at: intent.completed_at
+    }
+  end
+
+  defp serialize_transition(entry) do
+    %{
+      from: entry.from,
+      to: entry.to,
+      timestamp: entry.timestamp,
+      actor: entry.actor,
+      reason: entry.reason
+    }
+  end
+end

--- a/lib/lattice_web/router.ex
+++ b/lib/lattice_web/router.ex
@@ -50,6 +50,13 @@ defmodule LatticeWeb.Router do
     get "/sprites/:id", SpriteController, :show
     put "/sprites/:id/desired", SpriteController, :update_desired
     post "/sprites/:id/reconcile", SpriteController, :reconcile
+
+    get "/intents", IntentController, :index
+    get "/intents/:id", IntentController, :show
+    post "/intents", IntentController, :create
+    post "/intents/:id/approve", IntentController, :approve
+    post "/intents/:id/reject", IntentController, :reject
+    post "/intents/:id/cancel", IntentController, :cancel
   end
 
   # Authenticated LiveView routes

--- a/test/lattice_web/controllers/api/intent_controller_test.exs
+++ b/test/lattice_web/controllers/api/intent_controller_test.exs
@@ -1,0 +1,672 @@
+defmodule LatticeWeb.Api.IntentControllerTest do
+  use LatticeWeb.ConnCase
+
+  alias Lattice.Intents.Store.ETS, as: StoreETS
+
+  @moduletag :unit
+
+  setup do
+    StoreETS.reset()
+    :ok
+  end
+
+  # ── Helpers ──────────────────────────────────────────────────────────
+
+  defp authenticated(conn) do
+    put_req_header(conn, "authorization", "Bearer test-token")
+  end
+
+  defp valid_action_params do
+    %{
+      "kind" => "action",
+      "source" => %{"type" => "sprite", "id" => "sprite-001"},
+      "summary" => "List all sprites",
+      "payload" => %{"capability" => "sprites", "operation" => "list_sprites"},
+      "affected_resources" => ["sprites"],
+      "expected_side_effects" => ["none"]
+    }
+  end
+
+  defp valid_inquiry_params do
+    %{
+      "kind" => "inquiry",
+      "source" => %{"type" => "operator", "id" => "op-001"},
+      "summary" => "Need API key",
+      "payload" => %{
+        "what_requested" => "API key",
+        "why_needed" => "Integration",
+        "scope_of_impact" => "single service",
+        "expiration" => "2026-03-01"
+      }
+    }
+  end
+
+  defp valid_maintenance_params do
+    %{
+      "kind" => "maintenance",
+      "source" => %{"type" => "sprite", "id" => "sprite-001"},
+      "summary" => "Update base image",
+      "payload" => %{"image" => "elixir:1.18"}
+    }
+  end
+
+  defp propose_awaiting_intent(conn) do
+    previous = Application.get_env(:lattice, :guardrails, [])
+
+    Application.put_env(:lattice, :guardrails,
+      allow_controlled: true,
+      require_approval_for_controlled: true
+    )
+
+    params = %{
+      "kind" => "action",
+      "source" => %{"type" => "sprite", "id" => "sprite-001"},
+      "summary" => "Wake a sprite",
+      "payload" => %{"capability" => "sprites", "operation" => "wake"},
+      "affected_resources" => ["sprite-001"],
+      "expected_side_effects" => ["sprite wakes"]
+    }
+
+    resp =
+      conn
+      |> authenticated()
+      |> post("/api/intents", params)
+
+    body = json_response(resp, 200)
+
+    on_exit(fn ->
+      Application.put_env(:lattice, :guardrails, previous)
+    end)
+
+    body["data"]
+  end
+
+  defp with_guardrails(config, fun) do
+    previous = Application.get_env(:lattice, :guardrails, [])
+    Application.put_env(:lattice, :guardrails, config)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:lattice, :guardrails, previous)
+    end
+  end
+
+  # ── GET /api/intents ─────────────────────────────────────────────
+
+  describe "GET /api/intents" do
+    test "returns empty list when no intents", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/intents")
+
+      body = json_response(conn, 200)
+
+      assert body["data"] == []
+      assert is_binary(body["timestamp"])
+    end
+
+    test "lists all intents", %{conn: conn} do
+      # Propose two intents
+      conn
+      |> authenticated()
+      |> post("/api/intents", valid_action_params())
+
+      conn
+      |> authenticated()
+      |> post("/api/intents", valid_maintenance_params())
+
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/intents")
+
+      body = json_response(conn, 200)
+
+      assert length(body["data"]) == 2
+    end
+
+    test "filters by kind", %{conn: conn} do
+      conn
+      |> authenticated()
+      |> post("/api/intents", valid_action_params())
+
+      conn
+      |> authenticated()
+      |> post("/api/intents", valid_maintenance_params())
+
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/intents", %{"kind" => "action"})
+
+      body = json_response(conn, 200)
+
+      assert length(body["data"]) == 1
+      assert hd(body["data"])["kind"] == "action"
+    end
+
+    test "filters by state", %{conn: conn} do
+      # Safe action auto-advances to approved
+      conn
+      |> authenticated()
+      |> post("/api/intents", valid_action_params())
+
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/intents", %{"state" => "approved"})
+
+      body = json_response(conn, 200)
+
+      assert length(body["data"]) == 1
+      assert hd(body["data"])["state"] == "approved"
+    end
+
+    test "filters by source_type", %{conn: conn} do
+      conn
+      |> authenticated()
+      |> post("/api/intents", valid_action_params())
+
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/intents", %{"source_type" => "sprite"})
+
+      body = json_response(conn, 200)
+
+      assert length(body["data"]) == 1
+      assert hd(body["data"])["source"]["type"] == "sprite"
+    end
+
+    test "ignores invalid filter values", %{conn: conn} do
+      conn
+      |> authenticated()
+      |> post("/api/intents", valid_action_params())
+
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/intents", %{"kind" => "invalid"})
+
+      body = json_response(conn, 200)
+
+      # Invalid filter is ignored, returns all intents
+      assert length(body["data"]) == 1
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = get(conn, "/api/intents")
+
+      assert json_response(conn, 401)
+    end
+  end
+
+  # ── GET /api/intents/:id ─────────────────────────────────────────
+
+  describe "GET /api/intents/:id" do
+    test "returns intent detail with history", %{conn: conn} do
+      resp =
+        conn
+        |> authenticated()
+        |> post("/api/intents", valid_action_params())
+
+      created = json_response(resp, 200)["data"]
+
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/intents/#{created["id"]}")
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["id"] == created["id"]
+      assert body["data"]["kind"] == "action"
+      assert body["data"]["state"] == "approved"
+      assert body["data"]["summary"] == "List all sprites"
+      assert is_map(body["data"]["payload"])
+      assert [_ | _] = body["data"]["transition_log"]
+      assert is_binary(body["data"]["inserted_at"])
+      assert is_binary(body["data"]["updated_at"])
+      assert is_binary(body["timestamp"])
+    end
+
+    test "returns 404 for unknown intent", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> get("/api/intents/nonexistent")
+
+      body = json_response(conn, 404)
+
+      assert body["error"] == "Intent not found"
+      assert body["code"] == "INTENT_NOT_FOUND"
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = get(conn, "/api/intents/some-id")
+
+      assert json_response(conn, 401)
+    end
+  end
+
+  # ── POST /api/intents ────────────────────────────────────────────
+
+  describe "POST /api/intents" do
+    test "proposes an action intent (safe auto-approves)", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents", valid_action_params())
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["kind"] == "action"
+      assert body["data"]["state"] == "approved"
+      assert body["data"]["classification"] == "safe"
+      assert is_binary(body["data"]["id"])
+      assert is_binary(body["timestamp"])
+    end
+
+    test "proposes a maintenance intent", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents", valid_maintenance_params())
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["kind"] == "maintenance"
+      assert body["data"]["state"] == "approved"
+      assert body["data"]["classification"] == "safe"
+    end
+
+    test "proposes an inquiry intent (controlled, awaits approval)", %{conn: conn} do
+      with_guardrails(
+        [allow_controlled: true, require_approval_for_controlled: true],
+        fn ->
+          conn =
+            conn
+            |> authenticated()
+            |> post("/api/intents", valid_inquiry_params())
+
+          body = json_response(conn, 200)
+
+          assert body["data"]["kind"] == "inquiry"
+          assert body["data"]["state"] == "awaiting_approval"
+          assert body["data"]["classification"] == "controlled"
+        end
+      )
+    end
+
+    test "returns 422 for invalid kind", %{conn: conn} do
+      params = %{valid_action_params() | "kind" => "invalid"}
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents", params)
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "INVALID_KIND"
+    end
+
+    test "returns 422 when kind is missing", %{conn: conn} do
+      params = Map.delete(valid_action_params(), "kind")
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents", params)
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 422 when source is missing", %{conn: conn} do
+      params = Map.delete(valid_action_params(), "source")
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents", params)
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 422 for action intent missing affected_resources", %{conn: conn} do
+      params = Map.delete(valid_action_params(), "affected_resources")
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents", params)
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 422 for action intent missing expected_side_effects", %{conn: conn} do
+      params = Map.delete(valid_action_params(), "expected_side_effects")
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents", params)
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 422 for inquiry missing required payload fields", %{conn: conn} do
+      params = %{
+        valid_inquiry_params()
+        | "payload" => %{"what_requested" => "API key"}
+      }
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents", params)
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = post(conn, "/api/intents", valid_action_params())
+
+      assert json_response(conn, 401)
+    end
+  end
+
+  # ── POST /api/intents/:id/approve ────────────────────────────────
+
+  describe "POST /api/intents/:id/approve" do
+    test "approves an awaiting intent", %{conn: conn} do
+      intent_data = propose_awaiting_intent(conn)
+      assert intent_data["state"] == "awaiting_approval"
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/#{intent_data["id"]}/approve", %{"actor" => "human-reviewer"})
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["id"] == intent_data["id"]
+      assert body["data"]["state"] == "approved"
+    end
+
+    test "returns 404 for unknown intent", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/nonexistent/approve", %{"actor" => "human"})
+
+      body = json_response(conn, 404)
+
+      assert body["code"] == "INTENT_NOT_FOUND"
+    end
+
+    test "returns 422 for invalid transition", %{conn: conn} do
+      # Create a safe intent that auto-approves
+      resp =
+        conn
+        |> authenticated()
+        |> post("/api/intents", valid_action_params())
+
+      created = json_response(resp, 200)["data"]
+      assert created["state"] == "approved"
+
+      # Trying to approve an already-approved intent
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/#{created["id"]}/approve", %{"actor" => "human"})
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "INVALID_TRANSITION"
+    end
+
+    test "returns 422 when actor is missing", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/some-id/approve", %{})
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = post(conn, "/api/intents/some-id/approve", %{"actor" => "human"})
+
+      assert json_response(conn, 401)
+    end
+  end
+
+  # ── POST /api/intents/:id/reject ─────────────────────────────────
+
+  describe "POST /api/intents/:id/reject" do
+    test "rejects an awaiting intent", %{conn: conn} do
+      intent_data = propose_awaiting_intent(conn)
+      assert intent_data["state"] == "awaiting_approval"
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/#{intent_data["id"]}/reject", %{
+          "actor" => "reviewer",
+          "reason" => "too risky"
+        })
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["id"] == intent_data["id"]
+      assert body["data"]["state"] == "rejected"
+    end
+
+    test "returns 404 for unknown intent", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/nonexistent/reject", %{"actor" => "human"})
+
+      body = json_response(conn, 404)
+
+      assert body["code"] == "INTENT_NOT_FOUND"
+    end
+
+    test "returns 422 for invalid transition", %{conn: conn} do
+      resp =
+        conn
+        |> authenticated()
+        |> post("/api/intents", valid_action_params())
+
+      created = json_response(resp, 200)["data"]
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/#{created["id"]}/reject", %{"actor" => "human"})
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "INVALID_TRANSITION"
+    end
+
+    test "returns 422 when actor is missing", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/some-id/reject", %{})
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = post(conn, "/api/intents/some-id/reject", %{"actor" => "human"})
+
+      assert json_response(conn, 401)
+    end
+  end
+
+  # ── POST /api/intents/:id/cancel ─────────────────────────────────
+
+  describe "POST /api/intents/:id/cancel" do
+    test "cancels an awaiting intent", %{conn: conn} do
+      intent_data = propose_awaiting_intent(conn)
+      assert intent_data["state"] == "awaiting_approval"
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/#{intent_data["id"]}/cancel", %{
+          "actor" => "operator",
+          "reason" => "no longer needed"
+        })
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["id"] == intent_data["id"]
+      assert body["data"]["state"] == "canceled"
+    end
+
+    test "cancels an approved intent", %{conn: conn} do
+      resp =
+        conn
+        |> authenticated()
+        |> post("/api/intents", valid_action_params())
+
+      created = json_response(resp, 200)["data"]
+      assert created["state"] == "approved"
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/#{created["id"]}/cancel", %{"actor" => "operator"})
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["state"] == "canceled"
+    end
+
+    test "returns 404 for unknown intent", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/nonexistent/cancel", %{"actor" => "operator"})
+
+      body = json_response(conn, 404)
+
+      assert body["code"] == "INTENT_NOT_FOUND"
+    end
+
+    test "returns 422 for invalid transition (terminal state)", %{conn: conn} do
+      intent_data = propose_awaiting_intent(conn)
+
+      # First reject it
+      conn
+      |> authenticated()
+      |> post("/api/intents/#{intent_data["id"]}/reject", %{"actor" => "reviewer"})
+
+      # Then try to cancel the rejected intent
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/#{intent_data["id"]}/cancel", %{"actor" => "operator"})
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "INVALID_TRANSITION"
+    end
+
+    test "returns 422 when actor is missing", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/intents/some-id/cancel", %{})
+
+      body = json_response(conn, 422)
+
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = post(conn, "/api/intents/some-id/cancel", %{"actor" => "operator"})
+
+      assert json_response(conn, 401)
+    end
+  end
+
+  # ── Full Lifecycle ───────────────────────────────────────────────
+
+  describe "full lifecycle via API" do
+    test "propose -> list -> approve -> verify state change", %{conn: conn} do
+      with_guardrails(
+        [allow_controlled: true, require_approval_for_controlled: true],
+        fn ->
+          # Step 1: Propose a controlled intent
+          params = %{
+            "kind" => "action",
+            "source" => %{"type" => "sprite", "id" => "sprite-001"},
+            "summary" => "Wake a sprite",
+            "payload" => %{"capability" => "sprites", "operation" => "wake"},
+            "affected_resources" => ["sprite-001"],
+            "expected_side_effects" => ["sprite wakes"]
+          }
+
+          resp =
+            conn
+            |> authenticated()
+            |> post("/api/intents", params)
+
+          proposed = json_response(resp, 200)["data"]
+          assert proposed["state"] == "awaiting_approval"
+
+          # Step 2: List and verify the intent appears
+          resp =
+            conn
+            |> authenticated()
+            |> get("/api/intents")
+
+          intents = json_response(resp, 200)["data"]
+          assert length(intents) == 1
+          assert hd(intents)["id"] == proposed["id"]
+
+          # Step 3: Approve the intent
+          resp =
+            conn
+            |> authenticated()
+            |> post("/api/intents/#{proposed["id"]}/approve", %{"actor" => "human-reviewer"})
+
+          approved = json_response(resp, 200)["data"]
+          assert approved["state"] == "approved"
+
+          # Step 4: Verify state via detail endpoint
+          resp =
+            conn
+            |> authenticated()
+            |> get("/api/intents/#{proposed["id"]}")
+
+          detail = json_response(resp, 200)["data"]
+          assert detail["state"] == "approved"
+          assert [_ | _] = detail["transition_log"]
+        end
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `LatticeWeb.Api.IntentController` with 6 REST endpoints: list, show, create (propose), approve, reject, and cancel intents
- Wire intent routes into the existing authenticated `/api` scope in the router, protected by bearer token auth
- Include 37 tests covering all endpoints, auth enforcement, validation errors, kind-specific validation, and a full lifecycle integration test (propose -> list -> approve -> verify)

## Test plan

- [x] `GET /api/intents` lists intents with optional filters (kind, state, source_type)
- [x] `GET /api/intents/:id` returns intent detail with full transition history
- [x] `POST /api/intents` proposes action/inquiry/maintenance intents through the pipeline
- [x] `POST /api/intents/:id/approve` approves awaiting intents with actor tracking
- [x] `POST /api/intents/:id/reject` rejects awaiting intents with actor and reason
- [x] `POST /api/intents/:id/cancel` cancels intents from any pre-execution state
- [x] 401 responses for all endpoints without authentication
- [x] 422 responses for invalid kind, missing fields, invalid transitions
- [x] Kind-specific validation (action requires affected_resources/expected_side_effects, inquiry requires payload fields)
- [x] Full lifecycle test: propose -> list -> approve -> verify state change via detail endpoint
- [x] `mix credo --strict` passes with no issues
- [x] `mix format --check-formatted` passes for all changed files

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)