### PR TITLE
Add executor framework for intent fulfillment

### DIFF
--- a/lib/lattice/intents/execution_result.ex
+++ b/lib/lattice/intents/execution_result.ex
@@ -1,0 +1,108 @@
+defmodule Lattice.Intents.ExecutionResult do
+  @moduledoc """
+  The outcome of executing an approved intent.
+
+  Every executor returns an `%ExecutionResult{}` that captures what happened,
+  how long it took, and any artifacts produced. The result is stored on the
+  intent record for audit and debugging.
+
+  ## Fields
+
+  - `:status` -- `:success` or `:failure`
+  - `:output` -- free-form output from the executor (e.g., API response)
+  - `:error` -- error details when status is `:failure`
+  - `:artifacts` -- list of artifact maps produced during execution
+  - `:duration_ms` -- wall-clock execution time in milliseconds
+  - `:started_at` -- when execution began
+  - `:completed_at` -- when execution finished
+  - `:executor` -- which executor module ran this intent
+  """
+
+  @type status :: :success | :failure
+
+  @type t :: %__MODULE__{
+          status: status(),
+          output: term(),
+          error: term(),
+          artifacts: [map()],
+          duration_ms: non_neg_integer(),
+          started_at: DateTime.t(),
+          completed_at: DateTime.t(),
+          executor: module() | nil
+        }
+
+  @enforce_keys [:status, :duration_ms, :started_at, :completed_at]
+  defstruct [
+    :status,
+    :duration_ms,
+    :started_at,
+    :completed_at,
+    :executor,
+    output: nil,
+    error: nil,
+    artifacts: []
+  ]
+
+  @valid_statuses [:success, :failure]
+
+  # ── Constructors ─────────────────────────────────────────────────────
+
+  @doc """
+  Create a successful execution result.
+
+  ## Options
+
+  - `:output` -- execution output (default: `nil`)
+  - `:artifacts` -- list of artifact maps (default: `[]`)
+  - `:executor` -- executor module that ran the intent
+  """
+  @spec success(non_neg_integer(), DateTime.t(), DateTime.t(), keyword()) :: {:ok, t()}
+  def success(duration_ms, started_at, completed_at, opts \\ [])
+      when is_integer(duration_ms) and duration_ms >= 0 do
+    {:ok,
+     %__MODULE__{
+       status: :success,
+       output: Keyword.get(opts, :output),
+       artifacts: Keyword.get(opts, :artifacts, []),
+       duration_ms: duration_ms,
+       started_at: started_at,
+       completed_at: completed_at,
+       executor: Keyword.get(opts, :executor)
+     }}
+  end
+
+  @doc """
+  Create a failed execution result.
+
+  ## Options
+
+  - `:error` -- error details (default: `nil`)
+  - `:output` -- any partial output before failure (default: `nil`)
+  - `:artifacts` -- any artifacts produced before failure (default: `[]`)
+  - `:executor` -- executor module that ran the intent
+  """
+  @spec failure(non_neg_integer(), DateTime.t(), DateTime.t(), keyword()) :: {:ok, t()}
+  def failure(duration_ms, started_at, completed_at, opts \\ [])
+      when is_integer(duration_ms) and duration_ms >= 0 do
+    {:ok,
+     %__MODULE__{
+       status: :failure,
+       error: Keyword.get(opts, :error),
+       output: Keyword.get(opts, :output),
+       artifacts: Keyword.get(opts, :artifacts, []),
+       duration_ms: duration_ms,
+       started_at: started_at,
+       completed_at: completed_at,
+       executor: Keyword.get(opts, :executor)
+     }}
+  end
+
+  @doc "Returns the list of valid result statuses."
+  @spec valid_statuses() :: [status()]
+  def valid_statuses, do: @valid_statuses
+
+  @doc "Returns `true` if the result represents a successful execution."
+  @spec success?(t()) :: boolean()
+  def success?(%__MODULE__{status: :success}), do: true
+  def success?(%__MODULE__{}), do: false
+end

--- a/lib/lattice/intents/executor.ex
+++ b/lib/lattice/intents/executor.ex
@@ -1,0 +1,44 @@
+defmodule Lattice.Intents.Executor do
+  @moduledoc """
+  Behaviour for intent executors.
+
+  Executors fulfill approved intents and report outcomes. They do not invent
+  work. They do not negotiate scope. They report success, failure, and artifacts.
+
+  The contract is simple and uniform regardless of executor type:
+
+      execute(intent) :: {:ok, ExecutionResult.t()} | {:error, term()}
+
+  Executor type is an implementation detail. Sprites are the primary executor,
+  but some intents (infrastructure changes, direct API calls) may be fulfilled
+  by the control plane itself. The behaviour boundary keeps this extensible.
+
+  ## Implementations
+
+  - `Lattice.Intents.Executor.Sprite` -- routes to Sprite process via capabilities
+  - `Lattice.Intents.Executor.ControlPlane` -- executes directly in the control plane
+  """
+
+  alias Lattice.Intents.ExecutionResult
+  alias Lattice.Intents.Intent
+
+  @doc """
+  Execute an approved intent and return the outcome.
+
+  The intent must be in `:approved` or `:running` state. The executor should
+  invoke the appropriate capability and return an `ExecutionResult` capturing
+  what happened.
+
+  Returns `{:ok, result}` on both success and handled failure (the result's
+  `status` field distinguishes them). Returns `{:error, reason}` only for
+  executor-level errors (e.g., intent not executable, capability not found).
+  """
+  @callback execute(Intent.t()) :: {:ok, ExecutionResult.t()} | {:error, term()}
+
+  @doc """
+  Returns `true` if this executor can handle the given intent.
+
+  Used by the Router to select the appropriate executor.
+  """
+  @callback can_execute?(Intent.t()) :: boolean()
+end

--- a/lib/lattice/intents/executor/control_plane.ex
+++ b/lib/lattice/intents/executor/control_plane.ex
@@ -1,0 +1,129 @@
+defmodule Lattice.Intents.Executor.ControlPlane do
+  @moduledoc """
+  Executor that fulfills intents directly in the control plane process.
+
+  The Control Plane executor handles intents that do not require routing to a
+  Sprite process. This includes:
+
+  - Infrastructure intents (Fly capability operations)
+  - Direct API calls from operators or cron jobs
+  - Maintenance intents that the control plane can handle itself
+
+  Like the Sprite executor, it resolves capability and operation from the intent
+  payload and invokes the capability module's public API directly.
+  """
+
+  @behaviour Lattice.Intents.Executor
+
+  alias Lattice.Intents.ExecutionResult
+  alias Lattice.Intents.Intent
+
+  @capability_modules %{
+    "sprites" => :sprites,
+    "github" => :github,
+    "fly" => :fly,
+    "secret_store" => :secret_store
+  }
+
+  # ── Executor Callbacks ─────────────────────────────────────────────
+
+  @impl Lattice.Intents.Executor
+  def can_execute?(%Intent{kind: :action, source: %{type: source_type}} = intent)
+      when source_type in [:operator, :cron, :agent] do
+    has_capability?(intent)
+  end
+
+  def can_execute?(%Intent{kind: :maintenance} = intent) do
+    has_capability?(intent)
+  end
+
+  def can_execute?(%Intent{}), do: false
+
+  @impl Lattice.Intents.Executor
+  def execute(%Intent{} = intent) do
+    started_at = DateTime.utc_now()
+    start_mono = System.monotonic_time(:millisecond)
+
+    case invoke_capability(intent) do
+      {:ok, output} ->
+        duration_ms = System.monotonic_time(:millisecond) - start_mono
+        completed_at = DateTime.utc_now()
+
+        ExecutionResult.success(duration_ms, started_at, completed_at,
+          output: output,
+          executor: __MODULE__
+        )
+
+      {:error, reason} ->
+        duration_ms = System.monotonic_time(:millisecond) - start_mono
+        completed_at = DateTime.utc_now()
+
+        ExecutionResult.failure(duration_ms, started_at, completed_at,
+          error: reason,
+          executor: __MODULE__
+        )
+    end
+  end
+
+  # ── Private ────────────────────────────────────────────────────────
+
+  defp invoke_capability(%Intent{payload: payload}) do
+    capability_key = Map.get(payload, "capability", "")
+    operation_str = Map.get(payload, "operation", "")
+    args = Map.get(payload, "args", [])
+
+    with {:ok, cap_config_key} <- resolve_capability_key(capability_key),
+         {:ok, module} <- get_capability_module(cap_config_key),
+         {:ok, operation} <- resolve_operation(operation_str),
+         :ok <- validate_exported(module, operation, args) do
+      apply_capability(module, operation, args)
+    end
+  end
+
+  defp resolve_capability_key(key) when is_binary(key) do
+    case Map.get(@capability_modules, key) do
+      nil -> {:error, {:unknown_capability, key}}
+      config_key -> {:ok, config_key}
+    end
+  end
+
+  defp resolve_capability_key(key) when is_atom(key) do
+    resolve_capability_key(Atom.to_string(key))
+  end
+
+  defp resolve_capability_key(key), do: {:error, {:invalid_capability, key}}
+
+  defp get_capability_module(config_key) do
+    case Application.get_env(:lattice, :capabilities, %{})[config_key] do
+      nil -> {:error, {:capability_not_configured, config_key}}
+      module -> {:ok, module}
+    end
+  end
+
+  defp resolve_operation(operation) when is_binary(operation) do
+    {:ok, String.to_existing_atom(operation)}
+  rescue
+    ArgumentError -> {:error, {:unknown_operation, operation}}
+  end
+
+  defp resolve_operation(operation) when is_atom(operation), do: {:ok, operation}
+  defp resolve_operation(operation), do: {:error, {:invalid_operation, operation}}
+
+  defp validate_exported(module, operation, args) do
+    arity = length(args)
+
+    if function_exported?(module, operation, arity) do
+      :ok
+    else
+      {:error, {:function_not_exported, {module, operation, arity}}}
+    end
+  end
+
+  defp apply_capability(module, operation, args) do
+    apply(module, operation, args)
+  end
+
+  defp has_capability?(%Intent{payload: payload}) do
+    Map.has_key?(payload, "capability") and Map.has_key?(payload, "operation")
+  end
+end

--- a/lib/lattice/intents/executor/router.ex
+++ b/lib/lattice/intents/executor/router.ex
@@ -1,0 +1,45 @@
+defmodule Lattice.Intents.Executor.Router do
+  @moduledoc """
+  Routes approved intents to the appropriate executor.
+
+  The Router examines the intent's kind, source, and payload to select the
+  correct executor module. The routing logic is:
+
+  - Action intents from sprites -> `Executor.Sprite`
+  - Action intents from operators/cron/agents -> `Executor.ControlPlane`
+  - Maintenance intents -> `Executor.ControlPlane`
+  - Inquiry intents -> not executable (inquiries await human response)
+
+  ## Extensibility
+
+  The executor list is ordered by priority. The first executor that returns
+  `true` from `can_execute?/1` wins. New executors can be added by extending
+  the `@executors` list.
+  """
+
+  alias Lattice.Intents.Executor.ControlPlane
+  alias Lattice.Intents.Executor.Sprite
+  alias Lattice.Intents.Intent
+
+  @executors [Sprite, ControlPlane]
+
+  @doc """
+  Select the executor module for a given intent.
+
+  Returns `{:ok, executor_module}` if an executor can handle the intent,
+  or `{:error, :no_executor}` if none of the registered executors accept it.
+  """
+  @spec route(Intent.t()) :: {:ok, module()} | {:error, :no_executor}
+  def route(%Intent{} = intent) do
+    case Enum.find(@executors, & &1.can_execute?(intent)) do
+      nil -> {:error, :no_executor}
+      executor -> {:ok, executor}
+    end
+  end
+
+  @doc """
+  Returns the list of registered executor modules, in priority order.
+  """
+  @spec executors() :: [module()]
+  def executors, do: @executors
+end

--- a/lib/lattice/intents/executor/runner.ex
+++ b/lib/lattice/intents/executor/runner.ex
@@ -1,0 +1,233 @@
+defmodule Lattice.Intents.Executor.Runner do
+  @moduledoc """
+  Orchestrates intent execution: transition, dispatch, and outcome recording.
+
+  The Runner is the integration point between the Pipeline (which approves
+  intents) and the Executor (which fulfills them). It:
+
+  1. Transitions the intent from `:approved` to `:running`
+  2. Routes to the correct executor via `Executor.Router`
+  3. Invokes the executor's `execute/1` callback
+  4. Records the outcome (result + artifacts) on the intent
+  5. Transitions to `:completed` or `:failed`
+  6. Emits telemetry and PubSub events at each stage
+
+  ## Error Isolation
+
+  Execution is wrapped in error handling. If the executor raises an exception,
+  the intent is marked `:failed` with the error details. The Runner never
+  propagates executor crashes -- intents fail gracefully.
+
+  ## Usage
+
+      {:ok, intent} = Lattice.Intents.Executor.Runner.run(intent_id)
+  """
+
+  require Logger
+
+  alias Lattice.Intents.ExecutionResult
+  alias Lattice.Intents.Executor.Router
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Store
+
+  # ── Public API ───────────────────────────────────────────────────────
+
+  @doc """
+  Execute an approved intent by ID.
+
+  Fetches the intent from the store, transitions it to `:running`, routes it
+  to the appropriate executor, and records the outcome.
+
+  Returns `{:ok, intent}` with the intent in its terminal state (`:completed`
+  or `:failed`).
+
+  ## Errors
+
+  - `{:error, :not_found}` -- intent does not exist
+  - `{:error, {:not_approved, state}}` -- intent is not in `:approved` state
+  - `{:error, {:invalid_transition, _}}` -- state machine violation
+  """
+  @spec run(String.t()) :: {:ok, Intent.t()} | {:error, term()}
+  def run(intent_id) when is_binary(intent_id) do
+    with {:ok, intent} <- Store.get(intent_id),
+         :ok <- validate_approved(intent),
+         {:ok, running} <- transition_to_running(intent_id) do
+      emit_started(running)
+
+      case Router.route(running) do
+        {:ok, executor} ->
+          execute_and_record(intent_id, running, executor)
+
+        {:error, :no_executor} ->
+          record_crash(intent_id, {:no_executor, running.kind})
+      end
+    end
+  end
+
+  @doc """
+  Execute an approved intent by ID with a specific executor module.
+
+  Bypasses the Router and uses the provided executor directly. Useful for
+  testing or when the caller knows which executor to use.
+  """
+  @spec run(String.t(), module()) :: {:ok, Intent.t()} | {:error, term()}
+  def run(intent_id, executor) when is_binary(intent_id) and is_atom(executor) do
+    with {:ok, intent} <- Store.get(intent_id),
+         :ok <- validate_approved(intent),
+         {:ok, running} <- transition_to_running(intent_id) do
+      emit_started(running)
+      execute_and_record(intent_id, running, executor)
+    end
+  end
+
+  # ── Private ────────────────────────────────────────────────────────
+
+  defp validate_approved(%Intent{state: :approved}), do: :ok
+  defp validate_approved(%Intent{state: state}), do: {:error, {:not_approved, state}}
+
+  defp transition_to_running(intent_id) do
+    Store.update(intent_id, %{
+      state: :running,
+      actor: :executor,
+      reason: "execution started"
+    })
+  end
+
+  defp execute_and_record(intent_id, intent, executor) do
+    case safe_execute(executor, intent) do
+      {:ok, %ExecutionResult{status: :success} = result} ->
+        record_success(intent_id, result)
+
+      {:ok, %ExecutionResult{status: :failure} = result} ->
+        record_failure(intent_id, result)
+
+      {:error, reason} ->
+        record_crash(intent_id, reason)
+    end
+  end
+
+  defp safe_execute(executor, intent) do
+    executor.execute(intent)
+  rescue
+    exception ->
+      {:error, {:executor_crash, Exception.message(exception)}}
+  catch
+    kind, reason ->
+      {:error, {:executor_crash, {kind, reason}}}
+  end
+
+  defp record_success(intent_id, %ExecutionResult{} = result) do
+    record_artifacts(intent_id, result.artifacts)
+
+    case Store.update(intent_id, %{
+           state: :completed,
+           result: result_to_map(result),
+           actor: :executor,
+           reason: "execution completed successfully"
+         }) do
+      {:ok, completed} ->
+        emit_completed(completed, result)
+        {:ok, completed}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp record_failure(intent_id, %ExecutionResult{} = result) do
+    record_artifacts(intent_id, result.artifacts)
+
+    case Store.update(intent_id, %{
+           state: :failed,
+           result: result_to_map(result),
+           actor: :executor,
+           reason: "execution failed: #{inspect(result.error)}"
+         }) do
+      {:ok, failed} ->
+        emit_failed(failed, result.error)
+        {:ok, failed}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp record_crash(intent_id, reason) do
+    now = DateTime.utc_now()
+
+    {:ok, crash_result} =
+      ExecutionResult.failure(0, now, now, error: reason, executor: :crashed)
+
+    case Store.update(intent_id, %{
+           state: :failed,
+           result: result_to_map(crash_result),
+           actor: :executor,
+           reason: "executor crashed: #{inspect(reason)}"
+         }) do
+      {:ok, failed} ->
+        emit_failed(failed, reason)
+        {:ok, failed}
+
+      {:error, _} = error ->
+        Logger.error("Failed to record executor crash for intent #{intent_id}: #{inspect(error)}")
+        error
+    end
+  end
+
+  defp record_artifacts(intent_id, artifacts) when is_list(artifacts) do
+    Enum.each(artifacts, fn artifact ->
+      Store.add_artifact(intent_id, artifact)
+    end)
+  end
+
+  defp result_to_map(%ExecutionResult{} = result) do
+    %{
+      status: result.status,
+      output: result.output,
+      error: result.error,
+      duration_ms: result.duration_ms,
+      started_at: result.started_at,
+      completed_at: result.completed_at,
+      executor: result.executor,
+      artifact_count: length(result.artifacts)
+    }
+  end
+
+  # ── Event Emission ────────────────────────────────────────────────
+
+  defp emit_started(%Intent{} = intent) do
+    emit_telemetry([:lattice, :intent, :execution, :started], %{intent: intent})
+    broadcast(intent, {:intent_execution_started, intent})
+  end
+
+  defp emit_completed(%Intent{} = intent, %ExecutionResult{} = result) do
+    emit_telemetry([:lattice, :intent, :execution, :completed], %{
+      intent: intent,
+      result: result
+    })
+
+    broadcast(intent, {:intent_execution_completed, intent, result})
+  end
+
+  defp emit_failed(%Intent{} = intent, error) do
+    emit_telemetry([:lattice, :intent, :execution, :failed], %{
+      intent: intent,
+      error: error
+    })
+
+    broadcast(intent, {:intent_execution_failed, intent, error})
+  end
+
+  defp emit_telemetry(event_name, metadata) do
+    :telemetry.execute(
+      event_name,
+      %{system_time: System.system_time()},
+      metadata
+    )
+  end
+
+  defp broadcast(%Intent{} = intent, message) do
+    Phoenix.PubSub.broadcast(Lattice.PubSub, "intents:#{intent.id}", message)
+    Phoenix.PubSub.broadcast(Lattice.PubSub, "intents:all", message)
+  end
+end

--- a/lib/lattice/intents/executor/sprite.ex
+++ b/lib/lattice/intents/executor/sprite.ex
@@ -1,0 +1,132 @@
+defmodule Lattice.Intents.Executor.Sprite do
+  @moduledoc """
+  Executor that routes intents to Sprite processes via capability modules.
+
+  The Sprite executor handles intents that originate from or target a specific
+  Sprite. It resolves the capability and operation from the intent payload,
+  invokes the capability module's public API, and collects the outcome.
+
+  ## Routing
+
+  The intent payload must contain `"capability"` and `"operation"` fields
+  (string keys) that map to a registered capability module and function.
+
+  ## Capability Resolution
+
+  Capabilities are resolved from the application config:
+
+      config :lattice, :capabilities,
+        sprites: Lattice.Capabilities.Sprites.Live,
+        github: Lattice.Capabilities.GitHub.Live,
+        fly: Lattice.Capabilities.Fly.Live
+  """
+
+  @behaviour Lattice.Intents.Executor
+
+  alias Lattice.Intents.ExecutionResult
+  alias Lattice.Intents.Intent
+
+  @capability_modules %{
+    "sprites" => :sprites,
+    "github" => :github,
+    "fly" => :fly,
+    "secret_store" => :secret_store
+  }
+
+  # ── Executor Callbacks ─────────────────────────────────────────────
+
+  @impl Lattice.Intents.Executor
+  def can_execute?(%Intent{kind: :action, source: %{type: :sprite}} = intent) do
+    has_capability?(intent)
+  end
+
+  def can_execute?(%Intent{}), do: false
+
+  @impl Lattice.Intents.Executor
+  def execute(%Intent{} = intent) do
+    started_at = DateTime.utc_now()
+    start_mono = System.monotonic_time(:millisecond)
+
+    case invoke_capability(intent) do
+      {:ok, output} ->
+        duration_ms = System.monotonic_time(:millisecond) - start_mono
+        completed_at = DateTime.utc_now()
+
+        ExecutionResult.success(duration_ms, started_at, completed_at,
+          output: output,
+          executor: __MODULE__
+        )
+
+      {:error, reason} ->
+        duration_ms = System.monotonic_time(:millisecond) - start_mono
+        completed_at = DateTime.utc_now()
+
+        ExecutionResult.failure(duration_ms, started_at, completed_at,
+          error: reason,
+          executor: __MODULE__
+        )
+    end
+  end
+
+  # ── Private ────────────────────────────────────────────────────────
+
+  defp invoke_capability(%Intent{payload: payload}) do
+    capability_key = Map.get(payload, "capability", "")
+    operation_str = Map.get(payload, "operation", "")
+    args = Map.get(payload, "args", [])
+
+    with {:ok, cap_config_key} <- resolve_capability_key(capability_key),
+         {:ok, module} <- get_capability_module(cap_config_key),
+         {:ok, operation} <- resolve_operation(operation_str),
+         :ok <- validate_exported(module, operation, args) do
+      apply_capability(module, operation, args)
+    end
+  end
+
+  defp resolve_capability_key(key) when is_binary(key) do
+    case Map.get(@capability_modules, key) do
+      nil -> {:error, {:unknown_capability, key}}
+      config_key -> {:ok, config_key}
+    end
+  end
+
+  defp resolve_capability_key(key) when is_atom(key) do
+    resolve_capability_key(Atom.to_string(key))
+  end
+
+  defp resolve_capability_key(key), do: {:error, {:invalid_capability, key}}
+
+  defp get_capability_module(config_key) do
+    case Application.get_env(:lattice, :capabilities, %{})[config_key] do
+      nil -> {:error, {:capability_not_configured, config_key}}
+      module -> {:ok, module}
+    end
+  end
+
+  defp resolve_operation(operation) when is_binary(operation) do
+    {:ok, String.to_existing_atom(operation)}
+  rescue
+    ArgumentError -> {:error, {:unknown_operation, operation}}
+  end
+
+  defp resolve_operation(operation) when is_atom(operation), do: {:ok, operation}
+  defp resolve_operation(operation), do: {:error, {:invalid_operation, operation}}
+
+  defp validate_exported(module, operation, args) do
+    arity = length(args)
+
+    if function_exported?(module, operation, arity) do
+      :ok
+    else
+      {:error, {:function_not_exported, {module, operation, arity}}}
+    end
+  end
+
+  defp apply_capability(module, operation, args) do
+    apply(module, operation, args)
+  end
+
+  defp has_capability?(%Intent{payload: payload}) do
+    Map.has_key?(payload, "capability") and Map.has_key?(payload, "operation")
+  end
+end

--- a/test/lattice/intents/execution_result_test.exs
+++ b/test/lattice/intents/execution_result_test.exs
@@ -1,0 +1,109 @@
+defmodule Lattice.Intents.ExecutionResultTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Intents.ExecutionResult
+
+  @now DateTime.utc_now()
+  @later DateTime.add(@now, 1, :second)
+
+  describe "success/4" do
+    test "creates a success result with required fields" do
+      assert {:ok, result} = ExecutionResult.success(150, @now, @later)
+
+      assert result.status == :success
+      assert result.duration_ms == 150
+      assert result.started_at == @now
+      assert result.completed_at == @later
+      assert result.output == nil
+      assert result.artifacts == []
+      assert result.error == nil
+      assert result.executor == nil
+    end
+
+    test "accepts optional output" do
+      {:ok, result} = ExecutionResult.success(100, @now, @later, output: %{data: "hello"})
+
+      assert result.output == %{data: "hello"}
+    end
+
+    test "accepts optional artifacts" do
+      artifacts = [%{type: "log", data: "output"}]
+      {:ok, result} = ExecutionResult.success(100, @now, @later, artifacts: artifacts)
+
+      assert result.artifacts == artifacts
+    end
+
+    test "accepts optional executor" do
+      {:ok, result} = ExecutionResult.success(100, @now, @later, executor: SomeModule)
+
+      assert result.executor == SomeModule
+    end
+
+    test "rejects negative duration" do
+      assert_raise FunctionClauseError, fn ->
+        ExecutionResult.success(-1, @now, @later)
+      end
+    end
+  end
+
+  describe "failure/4" do
+    test "creates a failure result with required fields" do
+      assert {:ok, result} = ExecutionResult.failure(200, @now, @later)
+
+      assert result.status == :failure
+      assert result.duration_ms == 200
+      assert result.started_at == @now
+      assert result.completed_at == @later
+      assert result.error == nil
+      assert result.output == nil
+      assert result.artifacts == []
+    end
+
+    test "accepts optional error details" do
+      {:ok, result} = ExecutionResult.failure(100, @now, @later, error: :timeout)
+
+      assert result.error == :timeout
+    end
+
+    test "accepts optional partial output" do
+      {:ok, result} = ExecutionResult.failure(100, @now, @later, output: "partial data")
+
+      assert result.output == "partial data"
+    end
+
+    test "accepts optional artifacts produced before failure" do
+      artifacts = [%{type: "partial", data: "before crash"}]
+      {:ok, result} = ExecutionResult.failure(100, @now, @later, artifacts: artifacts)
+
+      assert result.artifacts == artifacts
+    end
+
+    test "accepts optional executor" do
+      {:ok, result} = ExecutionResult.failure(100, @now, @later, executor: AnotherModule)
+
+      assert result.executor == AnotherModule
+    end
+  end
+
+  describe "success?/1" do
+    test "returns true for success results" do
+      {:ok, result} = ExecutionResult.success(100, @now, @later)
+
+      assert ExecutionResult.success?(result) == true
+    end
+
+    test "returns false for failure results" do
+      {:ok, result} = ExecutionResult.failure(100, @now, @later)
+
+      assert ExecutionResult.success?(result) == false
+    end
+  end
+
+  describe "valid_statuses/0" do
+    test "returns success and failure" do
+      assert ExecutionResult.valid_statuses() == [:success, :failure]
+    end
+  end
+end

--- a/test/lattice/intents/executor/control_plane_test.exs
+++ b/test/lattice/intents/executor/control_plane_test.exs
@@ -1,0 +1,167 @@
+defmodule Lattice.Intents.Executor.ControlPlaneTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  import Mox
+
+  alias Lattice.Intents.ExecutionResult
+  alias Lattice.Intents.Executor.ControlPlane
+  alias Lattice.Intents.Intent
+
+  setup :verify_on_exit!
+
+  # ── Helpers ──────────────────────────────────────────────────────────
+
+  defp operator_action_intent(capability \\ "sprites", operation \\ "list_sprites", args \\ []) do
+    {:ok, intent} =
+      Intent.new_action(
+        %{type: :operator, id: "op-001"},
+        summary: "Operator action",
+        payload: %{
+          "capability" => capability,
+          "operation" => operation,
+          "args" => args
+        },
+        affected_resources: ["sprites"],
+        expected_side_effects: ["none"]
+      )
+
+    intent
+  end
+
+  defp cron_action_intent do
+    {:ok, intent} =
+      Intent.new_action(
+        %{type: :cron, id: "cron-001"},
+        summary: "Scheduled action",
+        payload: %{
+          "capability" => "sprites",
+          "operation" => "list_sprites",
+          "args" => []
+        },
+        affected_resources: ["sprites"],
+        expected_side_effects: ["none"]
+      )
+
+    intent
+  end
+
+  defp maintenance_intent do
+    {:ok, intent} =
+      Intent.new_maintenance(
+        %{type: :sprite, id: "sprite-001"},
+        summary: "Update base image",
+        payload: %{
+          "capability" => "fly",
+          "operation" => "machine_status",
+          "args" => ["machine-1"]
+        }
+      )
+
+    intent
+  end
+
+  defp sprite_action_intent do
+    {:ok, intent} =
+      Intent.new_action(
+        %{type: :sprite, id: "sprite-001"},
+        summary: "Sprite action",
+        payload: %{"capability" => "sprites", "operation" => "list_sprites"},
+        affected_resources: ["sprites"],
+        expected_side_effects: ["none"]
+      )
+
+    intent
+  end
+
+  # ── can_execute?/1 ──────────────────────────────────────────────────
+
+  describe "can_execute?/1" do
+    test "returns true for operator-sourced action with capability" do
+      intent = operator_action_intent()
+
+      assert ControlPlane.can_execute?(intent) == true
+    end
+
+    test "returns true for cron-sourced action with capability" do
+      intent = cron_action_intent()
+
+      assert ControlPlane.can_execute?(intent) == true
+    end
+
+    test "returns true for maintenance intent with capability" do
+      intent = maintenance_intent()
+
+      assert ControlPlane.can_execute?(intent) == true
+    end
+
+    test "returns false for sprite-sourced action" do
+      intent = sprite_action_intent()
+
+      assert ControlPlane.can_execute?(intent) == false
+    end
+
+    test "returns false for inquiry intents" do
+      {:ok, intent} =
+        Intent.new_inquiry(
+          %{type: :operator, id: "op-001"},
+          summary: "Need key",
+          payload: %{
+            "what_requested" => "API key",
+            "why_needed" => "Integration",
+            "scope_of_impact" => "single service",
+            "expiration" => "2026-03-01"
+          }
+        )
+
+      assert ControlPlane.can_execute?(intent) == false
+    end
+  end
+
+  # ── execute/1 ──────────────────────────────────────────────────────
+
+  describe "execute/1" do
+    test "successful execution returns success result" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:ok, [%{id: "s1"}, %{id: "s2"}]} end)
+
+      intent = operator_action_intent("sprites", "list_sprites")
+
+      assert {:ok, %ExecutionResult{status: :success} = result} = ControlPlane.execute(intent)
+      assert result.output == [%{id: "s1"}, %{id: "s2"}]
+      assert result.duration_ms >= 0
+      assert result.executor == Lattice.Intents.Executor.ControlPlane
+    end
+
+    test "capability error yields failure result" do
+      intent = operator_action_intent("nonexistent", "op")
+
+      assert {:ok, %ExecutionResult{status: :failure} = result} = ControlPlane.execute(intent)
+      assert result.error == {:unknown_capability, "nonexistent"}
+    end
+
+    test "passes args to capability function" do
+      Lattice.Capabilities.MockFly
+      |> expect(:machine_status, fn "machine-1" -> {:ok, %{state: "running"}} end)
+
+      intent = operator_action_intent("fly", "machine_status", ["machine-1"])
+
+      assert {:ok, %ExecutionResult{status: :success} = result} = ControlPlane.execute(intent)
+      assert result.output == %{state: "running"}
+    end
+
+    test "tracks execution timing" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn ->
+        Process.sleep(10)
+        {:ok, []}
+      end)
+
+      intent = operator_action_intent("sprites", "list_sprites")
+
+      assert {:ok, %ExecutionResult{} = result} = ControlPlane.execute(intent)
+      assert result.duration_ms >= 10
+    end
+  end
+end

--- a/test/lattice/intents/executor/router_test.exs
+++ b/test/lattice/intents/executor/router_test.exs
@@ -1,0 +1,140 @@
+defmodule Lattice.Intents.Executor.RouterTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Intents.Executor.ControlPlane
+  alias Lattice.Intents.Executor.Router
+  alias Lattice.Intents.Executor.Sprite
+  alias Lattice.Intents.Intent
+
+  # ── Helpers ──────────────────────────────────────────────────────────
+
+  defp action_intent_from_sprite do
+    {:ok, intent} =
+      Intent.new_action(
+        %{type: :sprite, id: "sprite-001"},
+        summary: "List all sprites",
+        payload: %{"capability" => "sprites", "operation" => "list_sprites"},
+        affected_resources: ["sprites"],
+        expected_side_effects: ["none"]
+      )
+
+    intent
+  end
+
+  defp action_intent_from_operator do
+    {:ok, intent} =
+      Intent.new_action(
+        %{type: :operator, id: "op-001"},
+        summary: "Deploy app",
+        payload: %{"capability" => "fly", "operation" => "deploy"},
+        affected_resources: ["fly-app"],
+        expected_side_effects: ["app restarted"]
+      )
+
+    intent
+  end
+
+  defp action_intent_from_cron do
+    {:ok, intent} =
+      Intent.new_action(
+        %{type: :cron, id: "cron-001"},
+        summary: "Scheduled deploy",
+        payload: %{"capability" => "fly", "operation" => "deploy"},
+        affected_resources: ["fly-app"],
+        expected_side_effects: ["app restarted"]
+      )
+
+    intent
+  end
+
+  defp maintenance_intent do
+    {:ok, intent} =
+      Intent.new_maintenance(
+        %{type: :sprite, id: "sprite-001"},
+        summary: "Update base image",
+        payload: %{"capability" => "fly", "operation" => "deploy"}
+      )
+
+    intent
+  end
+
+  defp inquiry_intent do
+    {:ok, intent} =
+      Intent.new_inquiry(
+        %{type: :operator, id: "op-001"},
+        summary: "Need API key",
+        payload: %{
+          "what_requested" => "API key",
+          "why_needed" => "Integration",
+          "scope_of_impact" => "single service",
+          "expiration" => "2026-03-01"
+        }
+      )
+
+    intent
+  end
+
+  defp action_intent_without_capability do
+    {:ok, intent} =
+      Intent.new_action(
+        %{type: :sprite, id: "sprite-001"},
+        summary: "Do something",
+        payload: %{"data" => "value"},
+        affected_resources: ["something"],
+        expected_side_effects: ["effect"]
+      )
+
+    intent
+  end
+
+  # ── route/1 ─────────────────────────────────────────────────────────
+
+  describe "route/1" do
+    test "routes sprite-sourced action to Sprite executor" do
+      intent = action_intent_from_sprite()
+
+      assert {:ok, Sprite} = Router.route(intent)
+    end
+
+    test "routes operator-sourced action to ControlPlane executor" do
+      intent = action_intent_from_operator()
+
+      assert {:ok, ControlPlane} = Router.route(intent)
+    end
+
+    test "routes cron-sourced action to ControlPlane executor" do
+      intent = action_intent_from_cron()
+
+      assert {:ok, ControlPlane} = Router.route(intent)
+    end
+
+    test "routes maintenance intent to ControlPlane executor" do
+      intent = maintenance_intent()
+
+      assert {:ok, ControlPlane} = Router.route(intent)
+    end
+
+    test "returns no_executor for inquiry intents" do
+      intent = inquiry_intent()
+
+      assert {:error, :no_executor} = Router.route(intent)
+    end
+
+    test "returns no_executor when intent lacks capability/operation" do
+      intent = action_intent_without_capability()
+
+      assert {:error, :no_executor} = Router.route(intent)
+    end
+  end
+
+  describe "executors/0" do
+    test "returns the registered executor modules" do
+      executors = Router.executors()
+
+      assert Sprite in executors
+      assert ControlPlane in executors
+    end
+  end
+end

--- a/test/lattice/intents/executor/runner_test.exs
+++ b/test/lattice/intents/executor/runner_test.exs
@@ -1,0 +1,420 @@
+defmodule Lattice.Intents.Executor.RunnerTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  import Mox
+
+  alias Lattice.Intents.ExecutionResult
+  alias Lattice.Intents.Executor.Runner
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Store
+  alias Lattice.Intents.Store.ETS, as: StoreETS
+
+  setup :verify_on_exit!
+
+  setup do
+    StoreETS.reset()
+    :ok
+  end
+
+  # ── Helpers ──────────────────────────────────────────────────────────
+
+  defp create_approved_intent(opts \\ []) do
+    capability = Keyword.get(opts, :capability, "sprites")
+    operation = Keyword.get(opts, :operation, "list_sprites")
+    args = Keyword.get(opts, :args, [])
+    source = Keyword.get(opts, :source, %{type: :sprite, id: "sprite-001"})
+
+    {:ok, intent} =
+      Intent.new_action(
+        source,
+        summary: "Test action",
+        payload: %{
+          "capability" => capability,
+          "operation" => operation,
+          "args" => args
+        },
+        affected_resources: ["test"],
+        expected_side_effects: ["test effect"]
+      )
+
+    # Manually advance to approved via store operations to avoid
+    # pipeline classification/gating interfering with test setup
+    {:ok, _stored} = Store.create(intent)
+    {:ok, _classified} = Store.update(intent.id, %{state: :classified, classification: :safe})
+    {:ok, approved} = Store.update(intent.id, %{state: :approved, actor: :test})
+    assert approved.state == :approved
+
+    approved
+  end
+
+  defp create_approved_operator_intent(opts \\ []) do
+    capability = Keyword.get(opts, :capability, "sprites")
+    operation = Keyword.get(opts, :operation, "list_sprites")
+    args = Keyword.get(opts, :args, [])
+
+    {:ok, intent} =
+      Intent.new_action(
+        %{type: :operator, id: "op-001"},
+        summary: "Operator action",
+        payload: %{
+          "capability" => capability,
+          "operation" => operation,
+          "args" => args
+        },
+        affected_resources: ["test"],
+        expected_side_effects: ["test effect"]
+      )
+
+    {:ok, _stored} = Store.create(intent)
+    {:ok, _classified} = Store.update(intent.id, %{state: :classified, classification: :safe})
+    {:ok, approved} = Store.update(intent.id, %{state: :approved, actor: :test})
+    assert approved.state == :approved
+
+    approved
+  end
+
+  # ── Successful Execution ────────────────────────────────────────────
+
+  describe "run/1 -- success flow" do
+    test "transitions approved intent to completed on success" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:ok, [%{id: "s1"}]} end)
+
+      approved = create_approved_intent()
+
+      assert {:ok, completed} = Runner.run(approved.id)
+      assert completed.state == :completed
+      assert completed.result != nil
+      assert completed.result.status == :success
+      assert %DateTime{} = completed.completed_at
+    end
+
+    test "records execution result with timing" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn ->
+        Process.sleep(5)
+        {:ok, []}
+      end)
+
+      approved = create_approved_intent()
+
+      assert {:ok, completed} = Runner.run(approved.id)
+      assert completed.result.duration_ms >= 5
+      assert %DateTime{} = completed.result.started_at
+      assert %DateTime{} = completed.result.completed_at
+    end
+
+    test "records executor module in result" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:ok, []} end)
+
+      approved = create_approved_intent()
+
+      assert {:ok, completed} = Runner.run(approved.id)
+      assert completed.result.executor == Lattice.Intents.Executor.Sprite
+    end
+
+    test "stores result in intent store" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:ok, [%{id: "s1"}]} end)
+
+      approved = create_approved_intent()
+      {:ok, _completed} = Runner.run(approved.id)
+
+      {:ok, fetched} = Store.get(approved.id)
+      assert fetched.state == :completed
+      assert fetched.result.status == :success
+    end
+
+    test "builds full transition log through execution" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:ok, []} end)
+
+      approved = create_approved_intent()
+      {:ok, completed} = Runner.run(approved.id)
+
+      {:ok, history} = Store.get_history(completed.id)
+      states = Enum.map(history, & &1.to)
+
+      # classified -> approved -> running -> completed
+      assert :running in states
+      assert :completed in states
+    end
+
+    test "sets started_at on intent when transitioning to running" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:ok, []} end)
+
+      approved = create_approved_intent()
+      {:ok, completed} = Runner.run(approved.id)
+
+      assert %DateTime{} = completed.started_at
+    end
+  end
+
+  # ── Failed Execution ───────────────────────────────────────────────
+
+  describe "run/1 -- failure flow" do
+    test "transitions intent to failed when capability returns error" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:error, :api_timeout} end)
+
+      approved = create_approved_intent()
+
+      assert {:ok, result} = Runner.run(approved.id)
+      assert result.state == :failed
+      assert result.result.status == :failure
+    end
+
+    test "records failure result when executor fails with unknown capability" do
+      approved = create_approved_intent(capability: "nonexistent", operation: "op")
+
+      assert {:ok, failed} = Runner.run(approved.id)
+      assert failed.state == :failed
+      assert failed.result.status == :failure
+    end
+
+    test "marks intent failed when executor raises" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> raise "boom!" end)
+
+      approved = create_approved_intent()
+
+      assert {:ok, failed} = Runner.run(approved.id)
+      assert failed.state == :failed
+      assert failed.result != nil
+    end
+
+    test "failure records error details in result" do
+      approved = create_approved_intent(capability: "nonexistent", operation: "op")
+
+      assert {:ok, failed} = Runner.run(approved.id)
+      assert failed.result.error != nil
+    end
+  end
+
+  # ── Edge Cases ─────────────────────────────────────────────────────
+
+  describe "run/1 -- edge cases" do
+    test "returns not_found for missing intent" do
+      assert {:error, :not_found} = Runner.run("nonexistent-id")
+    end
+
+    test "returns not_approved for proposed intent" do
+      {:ok, intent} =
+        Intent.new_action(
+          %{type: :sprite, id: "sprite-001"},
+          summary: "Test",
+          payload: %{"capability" => "sprites", "operation" => "list_sprites", "args" => []},
+          affected_resources: ["test"],
+          expected_side_effects: ["test"]
+        )
+
+      {:ok, stored} = Store.create(intent)
+
+      assert {:error, {:not_approved, :proposed}} = Runner.run(stored.id)
+    end
+
+    test "marks intent failed when no executor can handle it" do
+      # Create an inquiry and manually advance it to approved
+      {:ok, intent} =
+        Intent.new_inquiry(
+          %{type: :operator, id: "op-001"},
+          summary: "Need API key",
+          payload: %{
+            "what_requested" => "API key",
+            "why_needed" => "Integration",
+            "scope_of_impact" => "single service",
+            "expiration" => "2026-03-01"
+          }
+        )
+
+      {:ok, _stored} = Store.create(intent)
+      {:ok, _classified} = Store.update(intent.id, %{state: :classified, classification: :safe})
+      {:ok, _approved} = Store.update(intent.id, %{state: :approved, actor: :test})
+
+      assert {:ok, failed} = Runner.run(intent.id)
+      assert failed.state == :failed
+    end
+  end
+
+  # ── run/2 with explicit executor ───────────────────────────────────
+
+  describe "run/2 -- explicit executor" do
+    test "uses the specified executor bypassing the router" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:ok, []} end)
+
+      approved = create_approved_operator_intent()
+
+      assert {:ok, completed} =
+               Runner.run(approved.id, Lattice.Intents.Executor.ControlPlane)
+
+      assert completed.state == :completed
+    end
+  end
+
+  # ── Telemetry Events ───────────────────────────────────────────────
+
+  describe "telemetry" do
+    setup do
+      test_pid = self()
+      ref = make_ref()
+      handler_id = "runner-telemetry-test-#{inspect(ref)}"
+
+      events = [
+        [:lattice, :intent, :execution, :started],
+        [:lattice, :intent, :execution, :completed],
+        [:lattice, :intent, :execution, :failed]
+      ]
+
+      :telemetry.attach_many(
+        handler_id,
+        events,
+        fn event_name, measurements, metadata, _config ->
+          send(test_pid, {:telemetry, ref, event_name, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      %{ref: ref}
+    end
+
+    test "emits :started and :completed for successful execution", %{ref: ref} do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:ok, []} end)
+
+      approved = create_approved_intent()
+      {:ok, _} = Runner.run(approved.id)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :intent, :execution, :started], _,
+                      %{intent: started}}
+
+      assert started.state == :running
+
+      assert_receive {:telemetry, ^ref, [:lattice, :intent, :execution, :completed], _,
+                      %{intent: completed, result: result}}
+
+      assert completed.state == :completed
+      assert %ExecutionResult{status: :success} = result
+    end
+
+    test "emits :started and :failed for failed execution", %{ref: ref} do
+      approved = create_approved_intent(capability: "nonexistent", operation: "op")
+      {:ok, _} = Runner.run(approved.id)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :intent, :execution, :started], _,
+                      %{intent: _started}}
+
+      assert_receive {:telemetry, ^ref, [:lattice, :intent, :execution, :failed], _,
+                      %{intent: failed, error: _error}}
+
+      assert failed.state == :failed
+    end
+
+    test "emits :started and :failed when executor crashes", %{ref: ref} do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> raise "kaboom!" end)
+
+      approved = create_approved_intent()
+      {:ok, _} = Runner.run(approved.id)
+
+      assert_receive {:telemetry, ^ref, [:lattice, :intent, :execution, :started], _, _}
+
+      assert_receive {:telemetry, ^ref, [:lattice, :intent, :execution, :failed], _,
+                      %{intent: failed, error: error}}
+
+      assert failed.state == :failed
+      assert is_tuple(error) and elem(error, 0) == :executor_crash
+    end
+  end
+
+  # ── PubSub Broadcasts ──────────────────────────────────────────────
+
+  describe "PubSub" do
+    test "broadcasts execution events on intent-specific topic" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:ok, []} end)
+
+      approved = create_approved_intent()
+      Phoenix.PubSub.subscribe(Lattice.PubSub, "intents:#{approved.id}")
+
+      {:ok, _} = Runner.run(approved.id)
+
+      assert_receive {:intent_execution_started, started}
+      assert started.state == :running
+
+      assert_receive {:intent_execution_completed, completed, _result}
+      assert completed.state == :completed
+    end
+
+    test "broadcasts execution events on all-intents topic" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:ok, []} end)
+
+      approved = create_approved_intent()
+      Phoenix.PubSub.subscribe(Lattice.PubSub, "intents:all")
+
+      {:ok, _} = Runner.run(approved.id)
+
+      assert_receive {:intent_execution_started, _}
+      assert_receive {:intent_execution_completed, _, _}
+    end
+
+    test "broadcasts failure events" do
+      approved = create_approved_intent(capability: "nonexistent", operation: "op")
+      Phoenix.PubSub.subscribe(Lattice.PubSub, "intents:#{approved.id}")
+
+      {:ok, _} = Runner.run(approved.id)
+
+      assert_receive {:intent_execution_started, _}
+      assert_receive {:intent_execution_failed, failed, _error}
+      assert failed.state == :failed
+    end
+  end
+
+  # ── Artifact Recording ─────────────────────────────────────────────
+
+  describe "artifacts" do
+    test "records artifacts from execution result" do
+      # Use a custom executor that returns artifacts
+      defmodule ArtifactExecutor do
+        @behaviour Lattice.Intents.Executor
+
+        alias Lattice.Intents.ExecutionResult
+
+        @impl true
+        def can_execute?(_intent), do: true
+
+        @impl true
+        def execute(_intent) do
+          now = DateTime.utc_now()
+
+          ExecutionResult.success(10, now, now,
+            output: "done",
+            artifacts: [
+              %{type: "log", data: "execution output"},
+              %{type: "diff", data: "+line1\n-line2"}
+            ]
+          )
+        end
+      end
+
+      approved = create_approved_intent()
+
+      assert {:ok, completed} = Runner.run(approved.id, ArtifactExecutor)
+      assert completed.state == :completed
+
+      # Check artifacts were stored
+      {:ok, fetched} = Store.get(approved.id)
+      artifacts = Map.get(fetched.metadata, :artifacts, [])
+      assert length(artifacts) == 2
+      assert Enum.any?(artifacts, fn a -> a.type == "log" end)
+      assert Enum.any?(artifacts, fn a -> a.type == "diff" end)
+    end
+  end
+end

--- a/test/lattice/intents/executor/sprite_test.exs
+++ b/test/lattice/intents/executor/sprite_test.exs
@@ -1,0 +1,165 @@
+defmodule Lattice.Intents.Executor.SpriteTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  import Mox
+
+  alias Lattice.Intents.ExecutionResult
+  alias Lattice.Intents.Executor.Sprite
+  alias Lattice.Intents.Intent
+
+  setup :verify_on_exit!
+
+  # ── Helpers ──────────────────────────────────────────────────────────
+
+  defp sprite_action_intent(capability \\ "sprites", operation \\ "list_sprites", args \\ []) do
+    {:ok, intent} =
+      Intent.new_action(
+        %{type: :sprite, id: "sprite-001"},
+        summary: "Test action",
+        payload: %{
+          "capability" => capability,
+          "operation" => operation,
+          "args" => args
+        },
+        affected_resources: ["sprites"],
+        expected_side_effects: ["none"]
+      )
+
+    intent
+  end
+
+  defp operator_action_intent do
+    {:ok, intent} =
+      Intent.new_action(
+        %{type: :operator, id: "op-001"},
+        summary: "Operator action",
+        payload: %{"capability" => "sprites", "operation" => "list_sprites"},
+        affected_resources: ["sprites"],
+        expected_side_effects: ["none"]
+      )
+
+    intent
+  end
+
+  defp intent_without_capability do
+    {:ok, intent} =
+      Intent.new_action(
+        %{type: :sprite, id: "sprite-001"},
+        summary: "No capability",
+        payload: %{"data" => "value"},
+        affected_resources: ["something"],
+        expected_side_effects: ["effect"]
+      )
+
+    intent
+  end
+
+  # ── can_execute?/1 ──────────────────────────────────────────────────
+
+  describe "can_execute?/1" do
+    test "returns true for sprite-sourced action with capability and operation" do
+      intent = sprite_action_intent()
+
+      assert Sprite.can_execute?(intent) == true
+    end
+
+    test "returns false for operator-sourced action" do
+      intent = operator_action_intent()
+
+      assert Sprite.can_execute?(intent) == false
+    end
+
+    test "returns false when payload lacks capability" do
+      intent = intent_without_capability()
+
+      assert Sprite.can_execute?(intent) == false
+    end
+
+    test "returns false for maintenance intents" do
+      {:ok, intent} =
+        Intent.new_maintenance(
+          %{type: :sprite, id: "sprite-001"},
+          summary: "Update image",
+          payload: %{"capability" => "fly", "operation" => "deploy"}
+        )
+
+      assert Sprite.can_execute?(intent) == false
+    end
+  end
+
+  # ── execute/1 ──────────────────────────────────────────────────────
+
+  describe "execute/1" do
+    test "successful execution returns success result" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:ok, [%{id: "sprite-001"}]} end)
+
+      intent = sprite_action_intent("sprites", "list_sprites")
+
+      assert {:ok, %ExecutionResult{status: :success} = result} = Sprite.execute(intent)
+      assert result.output == [%{id: "sprite-001"}]
+      assert result.duration_ms >= 0
+      assert %DateTime{} = result.started_at
+      assert %DateTime{} = result.completed_at
+      assert result.executor == Lattice.Intents.Executor.Sprite
+    end
+
+    test "capability returning error yields failure result" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn -> {:error, :api_timeout} end)
+
+      intent = sprite_action_intent("sprites", "list_sprites")
+
+      # The capability returned {:error, :api_timeout} which the executor
+      # recognizes as a failure (tagged tuple convention)
+      assert {:ok, %ExecutionResult{status: :failure} = result} = Sprite.execute(intent)
+      assert result.error == :api_timeout
+    end
+
+    test "unknown capability returns error" do
+      intent = sprite_action_intent("nonexistent", "some_op")
+
+      assert {:ok, %ExecutionResult{status: :failure} = result} = Sprite.execute(intent)
+      assert result.error == {:unknown_capability, "nonexistent"}
+    end
+
+    test "unconfigured capability returns error" do
+      previous = Application.get_env(:lattice, :capabilities)
+      Application.put_env(:lattice, :capabilities, Keyword.delete(previous, :sprites))
+
+      try do
+        intent = sprite_action_intent("sprites", "list_sprites")
+        assert {:ok, %ExecutionResult{status: :failure} = result} = Sprite.execute(intent)
+        assert result.error == {:capability_not_configured, :sprites}
+      after
+        Application.put_env(:lattice, :capabilities, previous)
+      end
+    end
+
+    test "passes args to capability function" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:get_sprite, fn "sprite-001" -> {:ok, %{id: "sprite-001", status: "running"}} end)
+
+      intent = sprite_action_intent("sprites", "get_sprite", ["sprite-001"])
+
+      assert {:ok, %ExecutionResult{status: :success} = result} = Sprite.execute(intent)
+      assert result.output == %{id: "sprite-001", status: "running"}
+    end
+
+    test "tracks execution timing" do
+      Lattice.Capabilities.MockSprites
+      |> expect(:list_sprites, fn ->
+        Process.sleep(10)
+        {:ok, []}
+      end)
+
+      intent = sprite_action_intent("sprites", "list_sprites")
+
+      assert {:ok, %ExecutionResult{} = result} = Sprite.execute(intent)
+      assert result.duration_ms >= 10
+      assert DateTime.compare(result.completed_at, result.started_at) in [:gt, :eq]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add Executor behaviour, ExecutionResult struct, and concrete executors (Sprite and ControlPlane) that fulfill approved intents by invoking capability modules
- Add Router for executor selection based on intent kind/source, and Runner that orchestrates the full lifecycle: approved -> running -> completed/failed with error isolation
- Emit telemetry events and PubSub broadcasts at each execution stage (started, completed, failed) with 60 tests covering success flows, failure flows, crash recovery, and edge cases

## Test plan
- [x] ExecutionResult struct creation (success/failure constructors, field validation, negative duration rejection)
- [x] Sprite executor can_execute? routing (sprite-sourced actions accepted, others rejected)
- [x] Sprite executor execute/1 (successful capability invocation, error handling, arg passing, timing)
- [x] ControlPlane executor can_execute? routing (operator/cron/maintenance accepted, sprites rejected)
- [x] ControlPlane executor execute/1 (successful invocation, unknown capability handling, arg passing)
- [x] Router routes intents to correct executor based on kind and source type
- [x] Router returns no_executor for inquiry intents and intents without capability
- [x] Runner transitions approved -> running -> completed on success
- [x] Runner transitions approved -> running -> failed on capability error
- [x] Runner marks intent failed when executor raises (crash isolation)
- [x] Runner records execution result with timing, executor module, and error details
- [x] Runner returns not_found, not_approved for invalid intents
- [x] Runner marks intent failed when no executor can handle it
- [x] Runner run/2 bypasses router with explicit executor
- [x] Telemetry events emitted for started, completed, and failed execution
- [x] PubSub broadcasts on intent-specific and all-intents topics
- [x] Artifact recording from execution results into intent metadata
- [x] Full test suite passes (833 tests, 0 failures)
- [x] mix format, mix compile --warnings-as-errors, mix credo --strict all pass clean

Closes #48

Generated with [Claude Code](https://claude.com/claude-code)