### PR TITLE
Add GitHub governance for intent approval workflows

### DIFF
--- a/lib/lattice/intents/governance.ex
+++ b/lib/lattice/intents/governance.ex
@@ -1,0 +1,427 @@
+defmodule Lattice.Intents.Governance do
+  @moduledoc """
+  Bridges the intent pipeline with GitHub Issues for human-in-the-loop governance.
+
+  When an intent requires approval (`:awaiting_approval`), this module creates a
+  structured GitHub issue with all relevant details. Humans review the issue and
+  apply labels to approve or reject. The sync flow reads those labels and drives
+  intent state transitions.
+
+  ## Flow
+
+  1. Intent enters `:awaiting_approval` via Pipeline
+  2. `create_governance_issue/1` creates a GitHub issue with structured body
+  3. Human reviews and applies `intent-approved` or `intent-rejected` label
+  4. `sync_from_github/1` reads labels and calls Pipeline.approve/reject
+  5. After execution, `post_outcome/2` posts results as a comment
+  6. On terminal state, `close_governance_issue/1` closes the issue
+
+  ## Labels
+
+  See `Lattice.Intents.Governance.Labels` for the label definitions.
+
+  ## GitHub Capability
+
+  All GitHub interactions go through the `Lattice.Capabilities.GitHub` behaviour,
+  so this works with the stub in dev and the live implementation in prod.
+  """
+
+  alias Lattice.Capabilities.GitHub
+  alias Lattice.Intents.Governance.Labels, as: GovLabels
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Pipeline
+  alias Lattice.Intents.Store
+  alias Lattice.Safety.Audit
+
+  # ── Public API ────────────────────────────────────────────────────
+
+  @doc """
+  Create a GitHub governance issue for an intent awaiting approval.
+
+  The issue includes structured sections for the intent kind, summary,
+  classification, payload, affected resources, expected side effects,
+  and rollback strategy. The issue is labeled with `intent-awaiting-approval`.
+
+  The governance issue number is stored in the intent's metadata under
+  the key `:governance_issue`.
+
+  Returns `{:ok, intent}` with updated metadata, or `{:error, reason}`.
+  """
+  @spec create_governance_issue(Intent.t()) :: {:ok, Intent.t()} | {:error, term()}
+  def create_governance_issue(%Intent{state: :awaiting_approval} = intent) do
+    title = governance_issue_title(intent)
+    body = format_issue_body(intent)
+
+    attrs = %{
+      body: body,
+      labels: [GovLabels.awaiting_approval()]
+    }
+
+    case GitHub.create_issue(title, attrs) do
+      {:ok, issue} ->
+        metadata = Map.put(intent.metadata, :governance_issue, issue.number)
+
+        case Store.update(intent.id, %{metadata: metadata}) do
+          {:ok, updated} ->
+            Audit.log(:governance, :create_issue, :controlled, :ok, :system,
+              args: [intent.id, issue.number]
+            )
+
+            {:ok, updated}
+
+          {:error, _} = error ->
+            error
+        end
+
+      {:error, reason} = error ->
+        Audit.log(:governance, :create_issue, :controlled, error, :system, args: [intent.id])
+
+        {:error, reason}
+    end
+  end
+
+  def create_governance_issue(%Intent{state: state}) do
+    {:error, {:wrong_state, state}}
+  end
+
+  @doc """
+  Sync an intent's state from its governance GitHub issue.
+
+  Reads the governance issue's labels and transitions the intent if a human
+  has applied `intent-approved` or `intent-rejected`.
+
+  Returns `{:ok, intent}` with the updated state, `{:ok, :no_change}` if
+  no actionable label was found, or `{:error, reason}`.
+  """
+  @spec sync_from_github(Intent.t()) :: {:ok, Intent.t() | :no_change} | {:error, term()}
+  def sync_from_github(%Intent{state: :awaiting_approval, metadata: metadata} = intent) do
+    case Map.fetch(metadata, :governance_issue) do
+      {:ok, issue_number} ->
+        check_and_transition(intent, issue_number)
+
+      :error ->
+        {:error, :no_governance_issue}
+    end
+  end
+
+  def sync_from_github(%Intent{state: state}) do
+    {:error, {:wrong_state, state}}
+  end
+
+  @doc """
+  Post an execution outcome as a comment on the governance issue.
+
+  Formats the result into a structured comment and posts it to the
+  GitHub issue linked to the intent.
+
+  Returns `{:ok, comment}` or `{:error, reason}`.
+  """
+  @spec post_outcome(Intent.t(), map()) :: {:ok, map()} | {:error, term()}
+  def post_outcome(%Intent{metadata: metadata} = intent, result) do
+    case Map.fetch(metadata, :governance_issue) do
+      {:ok, issue_number} ->
+        body = format_outcome_comment(intent, result)
+
+        case GitHub.create_comment(issue_number, body) do
+          {:ok, comment} ->
+            Audit.log(:governance, :post_outcome, :safe, :ok, :system,
+              args: [intent.id, issue_number]
+            )
+
+            {:ok, comment}
+
+          {:error, _} = error ->
+            error
+        end
+
+      :error ->
+        {:error, :no_governance_issue}
+    end
+  end
+
+  @doc """
+  Close the governance issue when the intent reaches a terminal state.
+
+  Updates the issue state to closed and applies the appropriate terminal
+  label if the intent was approved or rejected.
+
+  Returns `{:ok, issue}` or `{:error, reason}`.
+  """
+  @spec close_governance_issue(Intent.t()) :: {:ok, map()} | {:error, term()}
+  def close_governance_issue(%Intent{state: state, metadata: metadata} = intent)
+      when state in [:completed, :failed, :rejected, :canceled] do
+    case Map.fetch(metadata, :governance_issue) do
+      {:ok, issue_number} ->
+        # Add terminal state label if applicable
+        case GovLabels.for_state(state) do
+          {:ok, label} -> GitHub.add_label(issue_number, label)
+          {:error, :no_label} -> :ok
+        end
+
+        case GitHub.update_issue(issue_number, %{state: "closed"}) do
+          {:ok, issue} ->
+            Audit.log(:governance, :close_issue, :controlled, :ok, :system,
+              args: [intent.id, issue_number]
+            )
+
+            {:ok, issue}
+
+          {:error, _} = error ->
+            error
+        end
+
+      :error ->
+        {:error, :no_governance_issue}
+    end
+  end
+
+  def close_governance_issue(%Intent{state: state}) do
+    {:error, {:not_terminal, state}}
+  end
+
+  @doc """
+  Format the GitHub issue body for a governance issue.
+
+  Includes structured sections for intent kind, summary, classification,
+  payload, affected resources, expected side effects, and rollback strategy.
+  Inquiry intents include additional fields: what is requested, why it is
+  needed, scope of impact, and expiration.
+  """
+  @spec format_issue_body(Intent.t()) :: String.t()
+  def format_issue_body(%Intent{} = intent) do
+    sections = [
+      intent_header(intent),
+      classification_section(intent),
+      payload_section(intent),
+      resources_section(intent),
+      side_effects_section(intent),
+      rollback_section(intent),
+      inquiry_section(intent),
+      source_section(intent),
+      approval_instructions(intent),
+      traceability_footer(intent)
+    ]
+
+    sections
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n\n")
+  end
+
+  # ── Private: GitHub Sync ──────────────────────────────────────────
+
+  defp check_and_transition(intent, issue_number) do
+    case GitHub.get_issue(issue_number) do
+      {:ok, issue} ->
+        labels = Map.get(issue, :labels, [])
+        resolve_label_action(intent, labels, issue)
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp resolve_label_action(intent, labels, issue) do
+    cond do
+      GovLabels.approved() in labels ->
+        comments = extract_comments(issue)
+
+        case Pipeline.approve(intent.id,
+               actor: :github,
+               reason: "approved via GitHub issue ##{intent.metadata[:governance_issue]}"
+             ) do
+          {:ok, approved} ->
+            store_comments_as_metadata(approved, comments)
+
+          {:error, _} = error ->
+            error
+        end
+
+      GovLabels.rejected() in labels ->
+        comments = extract_comments(issue)
+
+        case Pipeline.reject(intent.id,
+               actor: :github,
+               reason: "rejected via GitHub issue ##{intent.metadata[:governance_issue]}"
+             ) do
+          {:ok, rejected} ->
+            store_comments_as_metadata(rejected, comments)
+
+          {:error, _} = error ->
+            error
+        end
+
+      true ->
+        {:ok, :no_change}
+    end
+  end
+
+  defp extract_comments(%{comments: comments}) when is_list(comments) do
+    Enum.map(comments, fn comment ->
+      %{body: Map.get(comment, :body, "")}
+    end)
+  end
+
+  defp extract_comments(_), do: []
+
+  defp store_comments_as_metadata(intent, []), do: {:ok, intent}
+
+  defp store_comments_as_metadata(intent, comments) do
+    metadata = Map.put(intent.metadata, :github_comments, comments)
+    Store.update(intent.id, %{metadata: metadata})
+  end
+
+  # ── Private: Issue Formatting ────────────────────────────────────
+
+  defp governance_issue_title(%Intent{kind: kind, summary: summary}) do
+    kind_label = kind |> to_string() |> String.capitalize()
+    "[Intent/#{kind_label}] #{summary}"
+  end
+
+  defp intent_header(%Intent{kind: kind, summary: summary}) do
+    """
+    ## Intent Summary
+
+    **Kind:** #{kind}
+    **Summary:** #{summary}\
+    """
+  end
+
+  defp classification_section(%Intent{classification: nil}), do: nil
+
+  defp classification_section(%Intent{classification: classification}) do
+    emoji =
+      case classification do
+        :safe -> "green"
+        :controlled -> "yellow"
+        :dangerous -> "red"
+      end
+
+    """
+    ## Classification
+
+    **Level:** #{classification} (#{emoji})\
+    """
+  end
+
+  defp payload_section(%Intent{payload: payload}) when map_size(payload) == 0, do: nil
+
+  defp payload_section(%Intent{payload: payload}) do
+    formatted =
+      payload
+      |> Enum.map_join("\n", fn {key, value} -> "- **#{key}:** #{inspect(value)}" end)
+
+    """
+    ## Payload
+
+    #{formatted}\
+    """
+  end
+
+  defp resources_section(%Intent{affected_resources: []}), do: nil
+
+  defp resources_section(%Intent{affected_resources: resources}) do
+    formatted = Enum.map_join(resources, "\n", fn r -> "- #{r}" end)
+
+    """
+    ## Affected Resources
+
+    #{formatted}\
+    """
+  end
+
+  defp side_effects_section(%Intent{expected_side_effects: []}), do: nil
+
+  defp side_effects_section(%Intent{expected_side_effects: effects}) do
+    formatted = Enum.map_join(effects, "\n", fn e -> "- #{e}" end)
+
+    """
+    ## Expected Side Effects
+
+    #{formatted}\
+    """
+  end
+
+  defp rollback_section(%Intent{rollback_strategy: nil}), do: nil
+
+  defp rollback_section(%Intent{rollback_strategy: strategy}) do
+    """
+    ## Rollback Strategy
+
+    #{strategy}\
+    """
+  end
+
+  defp inquiry_section(%Intent{kind: :inquiry, payload: payload}) do
+    what = Map.get(payload, "what_requested", "N/A")
+    why = Map.get(payload, "why_needed", "N/A")
+    scope = Map.get(payload, "scope_of_impact", "N/A")
+    expiration = Map.get(payload, "expiration", "N/A")
+
+    """
+    ## Inquiry Details
+
+    **What is requested:** #{what}
+    **Why it is needed:** #{why}
+    **Scope of impact:** #{scope}
+    **Expiration:** #{expiration}\
+    """
+  end
+
+  defp inquiry_section(_intent), do: nil
+
+  defp source_section(%Intent{source: source}) do
+    """
+    ## Source
+
+    **Type:** #{source.type}
+    **ID:** `#{source.id}`\
+    """
+  end
+
+  defp approval_instructions(%Intent{}) do
+    """
+    ## Approval
+
+    To approve this intent, add the `#{GovLabels.approved()}` label.
+    To reject this intent, add the `#{GovLabels.rejected()}` label.
+
+    ---
+    _Created by Lattice governance. Do not modify the intent payload directly._\
+    """
+  end
+
+  defp traceability_footer(%Intent{id: id}) do
+    """
+    <!-- lattice:intent_id=#{id} -->\
+    """
+  end
+
+  # ── Private: Outcome Formatting ──────────────────────────────────
+
+  defp format_outcome_comment(%Intent{} = intent, result) do
+    status = Map.get(result, :status, :unknown)
+    output = Map.get(result, :output)
+    error = Map.get(result, :error)
+    duration_ms = Map.get(result, :duration_ms)
+
+    status_emoji =
+      case status do
+        :success -> "Completed"
+        :failure -> "Failed"
+        _ -> "Unknown"
+      end
+
+    sections = [
+      "## Execution Outcome: #{status_emoji}",
+      "**Intent:** #{intent.id}",
+      if(duration_ms, do: "**Duration:** #{duration_ms}ms"),
+      if(output, do: "**Output:** #{inspect(output)}"),
+      if(error, do: "**Error:** #{inspect(error)}"),
+      "\n---\n_Posted by Lattice governance._"
+    ]
+
+    sections
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+end

--- a/lib/lattice/intents/governance/labels.ex
+++ b/lib/lattice/intents/governance/labels.ex
@@ -1,0 +1,110 @@
+defmodule Lattice.Intents.Governance.Labels do
+  @moduledoc """
+  Intent governance labels for GitHub issue-based approval workflows.
+
+  Maps intent lifecycle states to GitHub labels. These labels are applied to
+  governance issues created when intents require human approval.
+
+  ## Labels
+
+  - `intent-awaiting-approval` — intent is waiting for human review
+  - `intent-approved` — human has approved the intent
+  - `intent-rejected` — human has rejected the intent
+  """
+
+  @awaiting_approval "intent-awaiting-approval"
+  @approved "intent-approved"
+  @rejected "intent-rejected"
+
+  @all_labels [@awaiting_approval, @approved, @rejected]
+
+  @state_to_label %{
+    awaiting_approval: @awaiting_approval,
+    approved: @approved,
+    rejected: @rejected
+  }
+
+  @label_to_state %{
+    @approved => :approved,
+    @rejected => :rejected
+  }
+
+  # ── Public API ────────────────────────────────────────────────────
+
+  @doc "Returns all intent governance labels."
+  @spec all() :: [String.t()]
+  def all, do: @all_labels
+
+  @doc "Returns the label for the `awaiting_approval` state."
+  @spec awaiting_approval() :: String.t()
+  def awaiting_approval, do: @awaiting_approval
+
+  @doc "Returns the label for the `approved` state."
+  @spec approved() :: String.t()
+  def approved, do: @approved
+
+  @doc "Returns the label for the `rejected` state."
+  @spec rejected() :: String.t()
+  def rejected, do: @rejected
+
+  @doc """
+  Returns the GitHub label for a given intent state.
+
+  Returns `{:ok, label}` for states that have a corresponding label, or
+  `{:error, :no_label}` for states without governance labels.
+
+  ## Examples
+
+      iex> Lattice.Intents.Governance.Labels.for_state(:awaiting_approval)
+      {:ok, "intent-awaiting-approval"}
+
+      iex> Lattice.Intents.Governance.Labels.for_state(:running)
+      {:error, :no_label}
+
+  """
+  @spec for_state(atom()) :: {:ok, String.t()} | {:error, :no_label}
+  def for_state(state) do
+    case Map.fetch(@state_to_label, state) do
+      {:ok, label} -> {:ok, label}
+      :error -> {:error, :no_label}
+    end
+  end
+
+  @doc """
+  Returns the intent state for a given governance label.
+
+  Returns `{:ok, state}` for recognized governance labels, or
+  `{:error, :unknown_label}` for unrecognized labels.
+
+  ## Examples
+
+      iex> Lattice.Intents.Governance.Labels.to_state("intent-approved")
+      {:ok, :approved}
+
+      iex> Lattice.Intents.Governance.Labels.to_state("some-other-label")
+      {:error, :unknown_label}
+
+  """
+  @spec to_state(String.t()) :: {:ok, atom()} | {:error, :unknown_label}
+  def to_state(label) do
+    case Map.fetch(@label_to_state, label) do
+      {:ok, state} -> {:ok, state}
+      :error -> {:error, :unknown_label}
+    end
+  end
+
+  @doc """
+  Returns `true` if the given label is a recognized intent governance label.
+
+  ## Examples
+
+      iex> Lattice.Intents.Governance.Labels.valid?("intent-approved")
+      true
+
+      iex> Lattice.Intents.Governance.Labels.valid?("bug")
+      false
+
+  """
+  @spec valid?(String.t()) :: boolean()
+  def valid?(label) when is_binary(label), do: label in @all_labels
+end

--- a/lib/lattice/intents/governance/listener.ex
+++ b/lib/lattice/intents/governance/listener.ex
@@ -1,0 +1,168 @@
+defmodule Lattice.Intents.Governance.Listener do
+  @moduledoc """
+  GenServer that listens for intent pipeline events and triggers governance actions.
+
+  Subscribes to the `"intents:all"` PubSub topic on start. When an intent
+  transitions to `:awaiting_approval`, it creates a GitHub governance issue.
+  When an intent execution completes or fails, it posts the outcome to the
+  governance issue. When an intent reaches a terminal state, it closes the
+  governance issue.
+
+  Also runs a periodic sync that checks all awaiting-approval intents against
+  their governance issues to pick up label changes made by humans on GitHub.
+
+  ## Configuration
+
+  The sync interval defaults to 30 seconds and can be overridden via the
+  `:sync_interval_ms` option at start.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Lattice.Intents.Governance
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Store
+
+  @default_sync_interval_ms 30_000
+
+  # ── Client API ────────────────────────────────────────────────────
+
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  # ── GenServer Callbacks ──────────────────────────────────────────
+
+  @impl true
+  def init(opts) do
+    sync_interval = Keyword.get(opts, :sync_interval_ms, @default_sync_interval_ms)
+
+    Phoenix.PubSub.subscribe(Lattice.PubSub, "intents:all")
+
+    schedule_sync(sync_interval)
+
+    {:ok, %{sync_interval_ms: sync_interval}}
+  end
+
+  @impl true
+  def handle_info({:intent_awaiting_approval, %Intent{} = intent}, state) do
+    handle_awaiting_approval(intent)
+    {:noreply, state}
+  end
+
+  def handle_info({:intent_execution_completed, %Intent{} = intent, result}, state) do
+    handle_execution_outcome(intent, result_to_map(result))
+    {:noreply, state}
+  end
+
+  def handle_info({:intent_execution_failed, %Intent{} = intent, error}, state) do
+    handle_execution_outcome(intent, %{status: :failure, error: error})
+    {:noreply, state}
+  end
+
+  def handle_info({:intent_rejected, %Intent{} = intent}, state) do
+    handle_terminal(intent)
+    {:noreply, state}
+  end
+
+  def handle_info({:intent_canceled, %Intent{} = intent}, state) do
+    handle_terminal(intent)
+    {:noreply, state}
+  end
+
+  def handle_info(:sync_governance, state) do
+    sync_all_awaiting_intents()
+    schedule_sync(state.sync_interval_ms)
+    {:noreply, state}
+  end
+
+  # Catch-all for other PubSub events
+  def handle_info(_event, state) do
+    {:noreply, state}
+  end
+
+  # ── Private: Event Handlers ──────────────────────────────────────
+
+  defp handle_awaiting_approval(%Intent{} = intent) do
+    case Governance.create_governance_issue(intent) do
+      {:ok, _updated} ->
+        Logger.info("Created governance issue for intent #{intent.id}")
+
+      {:error, reason} ->
+        Logger.error(
+          "Failed to create governance issue for intent #{intent.id}: #{inspect(reason)}"
+        )
+    end
+  end
+
+  defp handle_execution_outcome(%Intent{} = intent, result) do
+    case Governance.post_outcome(intent, result) do
+      {:ok, _comment} ->
+        Logger.debug("Posted outcome for intent #{intent.id}")
+
+      {:error, :no_governance_issue} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("Failed to post outcome for intent #{intent.id}: #{inspect(reason)}")
+    end
+
+    handle_terminal(intent)
+  end
+
+  defp handle_terminal(%Intent{state: state} = intent)
+       when state in [:completed, :failed, :rejected, :canceled] do
+    case Governance.close_governance_issue(intent) do
+      {:ok, _issue} ->
+        Logger.debug("Closed governance issue for intent #{intent.id}")
+
+      {:error, :no_governance_issue} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "Failed to close governance issue for intent #{intent.id}: #{inspect(reason)}"
+        )
+    end
+  end
+
+  defp handle_terminal(_intent), do: :ok
+
+  # ── Private: Periodic Sync ───────────────────────────────────────
+
+  defp sync_all_awaiting_intents do
+    {:ok, intents} = Store.list(%{state: :awaiting_approval})
+
+    Enum.each(intents, fn intent ->
+      case Governance.sync_from_github(intent) do
+        {:ok, :no_change} ->
+          :ok
+
+        {:ok, %Intent{}} ->
+          Logger.info("Synced governance state for intent #{intent.id}")
+
+        {:error, :no_governance_issue} ->
+          :ok
+
+        {:error, reason} ->
+          Logger.error("Failed to sync governance for intent #{intent.id}: #{inspect(reason)}")
+      end
+    end)
+  end
+
+  defp schedule_sync(interval_ms) do
+    Process.send_after(self(), :sync_governance, interval_ms)
+  end
+
+  defp result_to_map(%{status: _} = result), do: result
+
+  defp result_to_map(result) when is_struct(result) do
+    Map.from_struct(result)
+  end
+
+  defp result_to_map(result) when is_map(result), do: result
+  defp result_to_map(result), do: %{output: result}
+end

--- a/test/lattice/intents/governance/labels_test.exs
+++ b/test/lattice/intents/governance/labels_test.exs
@@ -1,0 +1,80 @@
+defmodule Lattice.Intents.Governance.LabelsTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Intents.Governance.Labels
+
+  describe "all/0" do
+    test "returns all governance labels" do
+      labels = Labels.all()
+      assert "intent-awaiting-approval" in labels
+      assert "intent-approved" in labels
+      assert "intent-rejected" in labels
+      assert length(labels) == 3
+    end
+  end
+
+  describe "for_state/1" do
+    test "maps awaiting_approval to its label" do
+      assert {:ok, "intent-awaiting-approval"} = Labels.for_state(:awaiting_approval)
+    end
+
+    test "maps approved to its label" do
+      assert {:ok, "intent-approved"} = Labels.for_state(:approved)
+    end
+
+    test "maps rejected to its label" do
+      assert {:ok, "intent-rejected"} = Labels.for_state(:rejected)
+    end
+
+    test "returns error for states without labels" do
+      assert {:error, :no_label} = Labels.for_state(:running)
+      assert {:error, :no_label} = Labels.for_state(:completed)
+      assert {:error, :no_label} = Labels.for_state(:proposed)
+    end
+  end
+
+  describe "to_state/1" do
+    test "maps intent-approved to :approved" do
+      assert {:ok, :approved} = Labels.to_state("intent-approved")
+    end
+
+    test "maps intent-rejected to :rejected" do
+      assert {:ok, :rejected} = Labels.to_state("intent-rejected")
+    end
+
+    test "returns error for unknown labels" do
+      assert {:error, :unknown_label} = Labels.to_state("bug")
+      assert {:error, :unknown_label} = Labels.to_state("intent-awaiting-approval")
+    end
+  end
+
+  describe "valid?/1" do
+    test "returns true for valid governance labels" do
+      assert Labels.valid?("intent-awaiting-approval")
+      assert Labels.valid?("intent-approved")
+      assert Labels.valid?("intent-rejected")
+    end
+
+    test "returns false for invalid labels" do
+      refute Labels.valid?("bug")
+      refute Labels.valid?("proposed")
+      refute Labels.valid?("approved")
+    end
+  end
+
+  describe "accessor functions" do
+    test "awaiting_approval/0" do
+      assert Labels.awaiting_approval() == "intent-awaiting-approval"
+    end
+
+    test "approved/0" do
+      assert Labels.approved() == "intent-approved"
+    end
+
+    test "rejected/0" do
+      assert Labels.rejected() == "intent-rejected"
+    end
+  end
+end

--- a/test/lattice/intents/governance/listener_test.exs
+++ b/test/lattice/intents/governance/listener_test.exs
@@ -1,0 +1,143 @@
+defmodule Lattice.Intents.Governance.ListenerTest do
+  use ExUnit.Case
+
+  import Mox
+
+  @moduletag :unit
+
+  alias Lattice.Intents.Governance.Labels, as: GovLabels
+  alias Lattice.Intents.Governance.Listener
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Pipeline
+  alias Lattice.Intents.Store
+  alias Lattice.Intents.Store.ETS, as: StoreETS
+
+  @valid_source %{type: :sprite, id: "sprite-001"}
+
+  setup :verify_on_exit!
+
+  setup do
+    StoreETS.reset()
+    :ok
+  end
+
+  # ── Helpers ──────────────────────────────────────────────────────
+
+  defp new_action_intent(opts \\ []) do
+    source = Keyword.get(opts, :source, @valid_source)
+
+    {:ok, intent} =
+      Intent.new_action(source,
+        summary: Keyword.get(opts, :summary, "Wake sprite"),
+        payload: %{"capability" => "sprites", "operation" => "wake"},
+        affected_resources: ["sprite-001"],
+        expected_side_effects: ["sprite wakes"]
+      )
+
+    intent
+  end
+
+  defp with_guardrails(config, fun) do
+    previous = Application.get_env(:lattice, :guardrails, [])
+    Application.put_env(:lattice, :guardrails, config)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:lattice, :guardrails, previous)
+    end
+  end
+
+  # ── Listener creates governance issue on awaiting_approval ──────
+
+  describe "handle_info/2 for awaiting_approval" do
+    test "creates governance issue when intent enters awaiting_approval" do
+      intent = new_action_intent()
+
+      awaiting =
+        with_guardrails(
+          [allow_controlled: true, require_approval_for_controlled: true],
+          fn ->
+            {:ok, awaiting} = Pipeline.propose(intent)
+            awaiting
+          end
+        )
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_issue, fn _title, attrs ->
+        assert GovLabels.awaiting_approval() in attrs.labels
+
+        {:ok,
+         %{
+           number: 42,
+           title: "test",
+           body: "",
+           state: "open",
+           labels: attrs.labels,
+           comments: []
+         }}
+      end)
+
+      # Simulate the PubSub message the Listener would receive
+      state = %{sync_interval_ms: 60_000}
+
+      assert {:noreply, ^state} =
+               Listener.handle_info({:intent_awaiting_approval, awaiting}, state)
+
+      # Verify the governance issue was stored in metadata
+      {:ok, updated} = Store.get(awaiting.id)
+      assert updated.metadata[:governance_issue] == 42
+    end
+  end
+
+  # ── Listener syncs on periodic tick ─────────────────────────────
+
+  describe "handle_info/2 for sync_governance" do
+    test "syncs awaiting intents from GitHub on periodic tick" do
+      intent = new_action_intent()
+
+      awaiting =
+        with_guardrails(
+          [allow_controlled: true, require_approval_for_controlled: true],
+          fn ->
+            {:ok, awaiting} = Pipeline.propose(intent)
+            awaiting
+          end
+        )
+
+      # Add governance issue to metadata
+      metadata = Map.put(awaiting.metadata, :governance_issue, 42)
+      {:ok, _with_issue} = Store.update(awaiting.id, %{metadata: metadata})
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 42 ->
+        {:ok,
+         %{
+           number: 42,
+           title: "test",
+           body: "",
+           state: "open",
+           labels: [GovLabels.approved()],
+           comments: []
+         }}
+      end)
+
+      state = %{sync_interval_ms: 60_000}
+
+      assert {:noreply, ^state} =
+               Listener.handle_info(:sync_governance, state)
+
+      {:ok, updated} = Store.get(awaiting.id)
+      assert updated.state == :approved
+    end
+  end
+
+  # ── Catch-all ───────────────────────────────────────────────────
+
+  describe "handle_info/2 catch-all" do
+    test "ignores unknown events" do
+      state = %{sync_interval_ms: 60_000}
+      assert {:noreply, ^state} = Listener.handle_info(:unknown_event, state)
+    end
+  end
+end

--- a/test/lattice/intents/governance_test.exs
+++ b/test/lattice/intents/governance_test.exs
@@ -1,0 +1,540 @@
+defmodule Lattice.Intents.GovernanceTest do
+  use ExUnit.Case
+
+  import Mox
+
+  @moduletag :unit
+
+  alias Lattice.Intents.Governance
+  alias Lattice.Intents.Governance.Labels, as: GovLabels
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Pipeline
+  alias Lattice.Intents.Store
+  alias Lattice.Intents.Store.ETS, as: StoreETS
+
+  @valid_source %{type: :sprite, id: "sprite-001"}
+  @cron_source %{type: :cron, id: "daily-health-audit"}
+
+  setup :verify_on_exit!
+
+  setup do
+    StoreETS.reset()
+    :ok
+  end
+
+  # ── Helpers ──────────────────────────────────────────────────────
+
+  defp new_action_intent(opts \\ []) do
+    source = Keyword.get(opts, :source, @valid_source)
+    capability = Keyword.get(opts, :capability, "sprites")
+    operation = Keyword.get(opts, :operation, "wake")
+
+    {:ok, intent} =
+      Intent.new_action(source,
+        summary: Keyword.get(opts, :summary, "Wake sprite for deployment"),
+        payload: %{"capability" => capability, "operation" => operation},
+        affected_resources: Keyword.get(opts, :affected_resources, ["sprite-001"]),
+        expected_side_effects: Keyword.get(opts, :expected_side_effects, ["sprite wakes"]),
+        rollback_strategy: Keyword.get(opts, :rollback_strategy, "Sleep the sprite again")
+      )
+
+    intent
+  end
+
+  defp new_inquiry_intent(opts \\ []) do
+    source = Keyword.get(opts, :source, %{type: :operator, id: "op-001"})
+
+    {:ok, intent} =
+      Intent.new_inquiry(source,
+        summary: Keyword.get(opts, :summary, "Need API key for integration"),
+        payload: %{
+          "what_requested" => "Production API key",
+          "why_needed" => "Integration with external service",
+          "scope_of_impact" => "single service",
+          "expiration" => "2026-03-01"
+        }
+      )
+
+    intent
+  end
+
+  defp propose_to_awaiting(intent) do
+    with_guardrails(
+      [allow_controlled: true, require_approval_for_controlled: true],
+      fn -> Pipeline.propose(intent) end
+    )
+  end
+
+  defp with_guardrails(config, fun) do
+    previous = Application.get_env(:lattice, :guardrails, [])
+    Application.put_env(:lattice, :guardrails, config)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:lattice, :guardrails, previous)
+    end
+  end
+
+  defp stub_issue_for(issue_number, labels \\ [], comments \\ []) do
+    %{
+      number: issue_number,
+      title: "Governance issue",
+      body: "test",
+      state: "open",
+      labels: labels,
+      comments: comments
+    }
+  end
+
+  # ── create_governance_issue/1 ────────────────────────────────────
+
+  describe "create_governance_issue/1" do
+    test "creates a GitHub issue when intent is awaiting_approval" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_issue, fn title, attrs ->
+        assert title =~ "[Intent/Action]"
+        assert title =~ "Wake sprite for deployment"
+        assert GovLabels.awaiting_approval() in attrs.labels
+        assert attrs.body =~ "Intent Summary"
+        assert attrs.body =~ "Classification"
+        assert attrs.body =~ "Affected Resources"
+        assert attrs.body =~ "sprite-001"
+        assert attrs.body =~ "Expected Side Effects"
+        assert attrs.body =~ "Rollback Strategy"
+        assert attrs.body =~ awaiting.id
+
+        {:ok, stub_issue_for(42)}
+      end)
+
+      assert {:ok, updated} = Governance.create_governance_issue(awaiting)
+      assert updated.metadata[:governance_issue] == 42
+    end
+
+    test "issue body contains all required structured fields" do
+      intent =
+        new_action_intent(
+          summary: "Deploy to staging",
+          affected_resources: ["fly-app-staging"],
+          expected_side_effects: ["app restarts"],
+          rollback_strategy: "Rollback to previous release"
+        )
+
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_issue, fn _title, attrs ->
+        body = attrs.body
+
+        # Verify all structured sections
+        assert body =~ "## Intent Summary"
+        assert body =~ "**Kind:** action"
+        assert body =~ "Deploy to staging"
+        assert body =~ "## Classification"
+        assert body =~ "controlled"
+        assert body =~ "## Payload"
+        assert body =~ "capability"
+        assert body =~ "## Affected Resources"
+        assert body =~ "fly-app-staging"
+        assert body =~ "## Expected Side Effects"
+        assert body =~ "app restarts"
+        assert body =~ "## Rollback Strategy"
+        assert body =~ "Rollback to previous release"
+        assert body =~ "## Source"
+        assert body =~ "sprite"
+        assert body =~ "## Approval"
+        assert body =~ GovLabels.approved()
+        assert body =~ GovLabels.rejected()
+        # Traceability
+        assert body =~ "lattice:intent_id="
+
+        {:ok, stub_issue_for(100)}
+      end)
+
+      assert {:ok, _} = Governance.create_governance_issue(awaiting)
+    end
+
+    test "inquiry intent issues include required inquiry fields" do
+      intent = new_inquiry_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_issue, fn title, attrs ->
+        assert title =~ "[Intent/Inquiry]"
+        body = attrs.body
+        assert body =~ "## Inquiry Details"
+        assert body =~ "**What is requested:** Production API key"
+        assert body =~ "**Why it is needed:** Integration with external service"
+        assert body =~ "**Scope of impact:** single service"
+        assert body =~ "**Expiration:** 2026-03-01"
+
+        {:ok, stub_issue_for(43)}
+      end)
+
+      assert {:ok, _} = Governance.create_governance_issue(awaiting)
+    end
+
+    test "returns error when intent is not awaiting_approval" do
+      intent = new_action_intent(capability: "sprites", operation: "list_sprites")
+      {:ok, approved} = Pipeline.propose(intent)
+      assert approved.state == :approved
+
+      assert {:error, {:wrong_state, :approved}} =
+               Governance.create_governance_issue(approved)
+    end
+
+    test "returns error when GitHub API fails" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_issue, fn _title, _attrs ->
+        {:error, :rate_limited}
+      end)
+
+      assert {:error, :rate_limited} = Governance.create_governance_issue(awaiting)
+    end
+
+    test "stores governance issue number in intent metadata" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_issue, fn _title, _attrs ->
+        {:ok, stub_issue_for(99)}
+      end)
+
+      {:ok, updated} = Governance.create_governance_issue(awaiting)
+      {:ok, fetched} = Store.get(updated.id)
+      assert fetched.metadata[:governance_issue] == 99
+    end
+  end
+
+  # ── sync_from_github/1 ──────────────────────────────────────────
+
+  describe "sync_from_github/1" do
+    test "approves intent when intent-approved label is present" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      # Add governance issue to metadata
+      metadata = Map.put(awaiting.metadata, :governance_issue, 42)
+      {:ok, with_issue} = Store.update(awaiting.id, %{metadata: metadata})
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 42 ->
+        {:ok, stub_issue_for(42, [GovLabels.approved()])}
+      end)
+
+      assert {:ok, %Intent{state: :approved}} = Governance.sync_from_github(with_issue)
+
+      {:ok, fetched} = Store.get(with_issue.id)
+      assert fetched.state == :approved
+    end
+
+    test "rejects intent when intent-rejected label is present" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      metadata = Map.put(awaiting.metadata, :governance_issue, 42)
+      {:ok, with_issue} = Store.update(awaiting.id, %{metadata: metadata})
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 42 ->
+        {:ok, stub_issue_for(42, [GovLabels.rejected()])}
+      end)
+
+      assert {:ok, %Intent{state: :rejected}} = Governance.sync_from_github(with_issue)
+
+      {:ok, fetched} = Store.get(with_issue.id)
+      assert fetched.state == :rejected
+    end
+
+    test "returns :no_change when no actionable label is found" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      metadata = Map.put(awaiting.metadata, :governance_issue, 42)
+      {:ok, with_issue} = Store.update(awaiting.id, %{metadata: metadata})
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 42 ->
+        {:ok, stub_issue_for(42, [GovLabels.awaiting_approval()])}
+      end)
+
+      assert {:ok, :no_change} = Governance.sync_from_github(with_issue)
+    end
+
+    test "returns error when no governance issue is linked" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      assert {:error, :no_governance_issue} = Governance.sync_from_github(awaiting)
+    end
+
+    test "captures GitHub comments as metadata on approval" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      metadata = Map.put(awaiting.metadata, :governance_issue, 42)
+      {:ok, with_issue} = Store.update(awaiting.id, %{metadata: metadata})
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 42 ->
+        {:ok,
+         stub_issue_for(42, [GovLabels.approved()], [
+           %{id: 1, body: "Looks good to me"},
+           %{id: 2, body: "Approved for deployment"}
+         ])}
+      end)
+
+      assert {:ok, %Intent{}} = Governance.sync_from_github(with_issue)
+
+      {:ok, fetched} = Store.get(with_issue.id)
+      assert is_list(fetched.metadata[:github_comments])
+      assert length(fetched.metadata[:github_comments]) == 2
+    end
+
+    test "returns error when intent is not awaiting_approval" do
+      intent = new_action_intent(capability: "sprites", operation: "list_sprites")
+      {:ok, approved} = Pipeline.propose(intent)
+
+      assert {:error, {:wrong_state, :approved}} = Governance.sync_from_github(approved)
+    end
+  end
+
+  # ── post_outcome/2 ──────────────────────────────────────────────
+
+  describe "post_outcome/2" do
+    test "posts execution outcome as a comment on the governance issue" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      metadata = Map.put(awaiting.metadata, :governance_issue, 42)
+      {:ok, with_issue} = Store.update(awaiting.id, %{metadata: metadata})
+
+      result = %{status: :success, output: "deployed", duration_ms: 1500}
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_comment, fn 42, body ->
+        assert body =~ "Execution Outcome"
+        assert body =~ "Completed"
+        assert body =~ "1500ms"
+        assert body =~ "deployed"
+
+        {:ok, %{id: 1, body: body, issue_number: 42}}
+      end)
+
+      assert {:ok, _comment} = Governance.post_outcome(with_issue, result)
+    end
+
+    test "posts failure outcome with error details" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      metadata = Map.put(awaiting.metadata, :governance_issue, 42)
+      {:ok, with_issue} = Store.update(awaiting.id, %{metadata: metadata})
+
+      result = %{status: :failure, error: :timeout, duration_ms: 30_000}
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_comment, fn 42, body ->
+        assert body =~ "Failed"
+        assert body =~ "timeout"
+
+        {:ok, %{id: 2, body: body, issue_number: 42}}
+      end)
+
+      assert {:ok, _comment} = Governance.post_outcome(with_issue, result)
+    end
+
+    test "returns error when no governance issue is linked" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      assert {:error, :no_governance_issue} =
+               Governance.post_outcome(awaiting, %{status: :success})
+    end
+  end
+
+  # ── close_governance_issue/1 ────────────────────────────────────
+
+  describe "close_governance_issue/1" do
+    test "closes the issue when intent is completed" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      metadata = Map.put(awaiting.metadata, :governance_issue, 42)
+      {:ok, with_issue} = Store.update(awaiting.id, %{metadata: metadata})
+
+      # Manually transition to approved -> running -> completed for test
+      {:ok, approved} =
+        Store.update(with_issue.id, %{state: :approved, actor: :test, reason: "test"})
+
+      {:ok, running} =
+        Store.update(approved.id, %{state: :running, actor: :test, reason: "test"})
+
+      {:ok, completed} =
+        Store.update(running.id, %{state: :completed, actor: :test, reason: "test"})
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:update_issue, fn 42, %{state: "closed"} ->
+        {:ok, stub_issue_for(42)}
+      end)
+
+      assert {:ok, _issue} = Governance.close_governance_issue(completed)
+    end
+
+    test "closes and labels the issue when intent is rejected" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      metadata = Map.put(awaiting.metadata, :governance_issue, 42)
+      {:ok, with_issue} = Store.update(awaiting.id, %{metadata: metadata})
+
+      {:ok, rejected} =
+        Store.update(with_issue.id, %{state: :rejected, actor: :test, reason: "test"})
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:add_label, fn 42, label ->
+        assert label == GovLabels.rejected()
+        {:ok, [label]}
+      end)
+      |> expect(:update_issue, fn 42, %{state: "closed"} ->
+        {:ok, stub_issue_for(42)}
+      end)
+
+      assert {:ok, _issue} = Governance.close_governance_issue(rejected)
+    end
+
+    test "returns error when intent is not in terminal state" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      assert {:error, {:not_terminal, :awaiting_approval}} =
+               Governance.close_governance_issue(awaiting)
+    end
+
+    test "returns error when no governance issue is linked" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      {:ok, rejected} =
+        Store.update(awaiting.id, %{state: :rejected, actor: :test, reason: "test"})
+
+      assert {:error, :no_governance_issue} = Governance.close_governance_issue(rejected)
+    end
+  end
+
+  # ── Cron-proposed intents ───────────────────────────────────────
+
+  describe "cron-proposed intents" do
+    test "cron intents flow through full pipeline and create governance issues" do
+      intent = new_action_intent(source: @cron_source, summary: "Daily health audit")
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      assert awaiting.state == :awaiting_approval
+      assert awaiting.source.type == :cron
+      assert awaiting.source.id == "daily-health-audit"
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_issue, fn title, attrs ->
+        assert title =~ "[Intent/Action]"
+        assert title =~ "Daily health audit"
+        assert attrs.body =~ "cron"
+        assert attrs.body =~ "daily-health-audit"
+
+        {:ok, stub_issue_for(50)}
+      end)
+
+      assert {:ok, updated} = Governance.create_governance_issue(awaiting)
+      assert updated.metadata[:governance_issue] == 50
+    end
+  end
+
+  # ── Immutability ────────────────────────────────────────────────
+
+  describe "immutability" do
+    test "GitHub interactions cannot mutate approved intent payload" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      metadata = Map.put(awaiting.metadata, :governance_issue, 42)
+      {:ok, with_issue} = Store.update(awaiting.id, %{metadata: metadata})
+
+      # Approve the intent
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 42 ->
+        {:ok, stub_issue_for(42, [GovLabels.approved()])}
+      end)
+
+      {:ok, %Intent{state: :approved}} = Governance.sync_from_github(with_issue)
+
+      # Verify payload is frozen
+      {:ok, approved} = Store.get(with_issue.id)
+      assert approved.state == :approved
+
+      # Attempt to mutate frozen fields should fail
+      assert {:error, :immutable} =
+               Store.update(approved.id, %{payload: %{"changed" => true}})
+
+      assert {:error, :immutable} =
+               Store.update(approved.id, %{affected_resources: ["new-resource"]})
+    end
+  end
+
+  # ── format_issue_body/1 ─────────────────────────────────────────
+
+  describe "format_issue_body/1" do
+    test "formats action intent body with all sections" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      body = Governance.format_issue_body(awaiting)
+
+      assert body =~ "## Intent Summary"
+      assert body =~ "**Kind:** action"
+      assert body =~ "Wake sprite for deployment"
+      assert body =~ "## Classification"
+      assert body =~ "controlled"
+      assert body =~ "## Payload"
+      assert body =~ "## Affected Resources"
+      assert body =~ "sprite-001"
+      assert body =~ "## Expected Side Effects"
+      assert body =~ "sprite wakes"
+      assert body =~ "## Rollback Strategy"
+      assert body =~ "Sleep the sprite again"
+      assert body =~ "## Source"
+      assert body =~ "sprite"
+      assert body =~ "sprite-001"
+      assert body =~ "## Approval"
+      assert body =~ GovLabels.approved()
+      assert body =~ GovLabels.rejected()
+    end
+
+    test "formats inquiry intent body with inquiry details" do
+      intent = new_inquiry_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      body = Governance.format_issue_body(awaiting)
+
+      assert body =~ "## Inquiry Details"
+      assert body =~ "**What is requested:** Production API key"
+      assert body =~ "**Why it is needed:** Integration with external service"
+      assert body =~ "**Scope of impact:** single service"
+      assert body =~ "**Expiration:** 2026-03-01"
+    end
+
+    test "includes traceability footer with intent ID" do
+      intent = new_action_intent()
+      {:ok, awaiting} = propose_to_awaiting(intent)
+
+      body = Governance.format_issue_body(awaiting)
+
+      assert body =~ "lattice:intent_id=#{awaiting.id}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Lattice.Intents.Governance` module that bridges the intent pipeline with GitHub Issues for human-in-the-loop governance: creates structured governance issues when intents reach `:awaiting_approval`, syncs label changes (`intent-approved`/`intent-rejected`) back to intent state transitions, posts execution outcomes as comments, and closes issues on terminal states
- Add `Lattice.Intents.Governance.Labels` module defining intent-specific GitHub labels (`intent-awaiting-approval`, `intent-approved`, `intent-rejected`) with bidirectional state/label mapping
- Add `Lattice.Intents.Governance.Listener` GenServer that subscribes to PubSub for real-time governance issue creation and runs periodic sync to pick up human label changes from GitHub

## Test plan

- [x] Intent creates GitHub Issue on entering `:awaiting_approval`
- [x] Issue body contains all required structured fields (kind, summary, classification, payload, affected resources, side effects, rollback strategy)
- [x] Inquiry intent issues include required fields (what, why, scope, expiration)
- [x] Label changes trigger correct intent transitions (approve via `intent-approved`, reject via `intent-rejected`)
- [x] Returns `:no_change` when no actionable label found
- [x] Cron-proposed intents flow through full pipeline with governance (tagged with source type/id)
- [x] Immutability respected -- approved intent payload cannot be mutated via GitHub interactions
- [x] Execution outcomes posted back to governance issue (success and failure)
- [x] Governance issue closed on terminal states (completed, rejected, canceled)
- [x] GitHub comments captured as metadata on intent record
- [x] Error handling for missing governance issue, wrong state, API failures
- [x] Listener creates governance issue on PubSub `:intent_awaiting_approval` event
- [x] Listener periodic sync picks up label changes from GitHub
- [x] Labels module: bidirectional state/label mapping, validation
- [x] All tests use MockGitHub via Mox (40 new tests, 873 total pass)

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)