### PR TITLE
Add OpenAPI spec and Swagger UI

### DIFF
--- a/lib/lattice_web/api_spec.ex
+++ b/lib/lattice_web/api_spec.ex
@@ -1,0 +1,41 @@
+defmodule LatticeWeb.ApiSpec do
+  @moduledoc """
+  OpenAPI 3.0 specification for the Lattice REST API.
+
+  Aggregates operation specs from all API controllers and serves as the
+  single source of truth for the machine-readable API contract.
+  """
+
+  alias OpenApiSpex.{Components, Info, OpenApi, Paths, SecurityScheme, Server}
+
+  @behaviour OpenApi
+
+  @impl OpenApi
+  def spec do
+    %OpenApi{
+      info: %Info{
+        title: "Lattice API",
+        version: "0.1.0",
+        description: """
+        REST API for the Lattice control plane. Provides endpoints for managing
+        Sprites (AI coding agents), fleet operations, and intent lifecycle workflows.
+        """
+      },
+      servers: [
+        %Server{url: "/", description: "Current server"}
+      ],
+      paths: Paths.from_router(LatticeWeb.Router),
+      components: %Components{
+        securitySchemes: %{
+          "BearerAuth" => %SecurityScheme{
+            type: "http",
+            scheme: "bearer",
+            description:
+              "Bearer token authentication. Pass your API token in the Authorization header."
+          }
+        }
+      }
+    }
+    |> OpenApiSpex.resolve_schema_modules()
+  end
+end

--- a/lib/lattice_web/controllers/api/fleet_controller.ex
+++ b/lib/lattice_web/controllers/api/fleet_controller.ex
@@ -7,8 +7,21 @@ defmodule LatticeWeb.Api.FleetController do
   """
 
   use LatticeWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Lattice.Sprites.FleetManager
+
+  tags(["Fleet"])
+  security([%{"BearerAuth" => []}])
+
+  operation(:index,
+    summary: "Fleet summary",
+    description: "Returns fleet summary with sprite counts by state and overall health.",
+    responses: [
+      ok: {"Fleet summary", "application/json", LatticeWeb.Schemas.FleetSummaryResponse},
+      unauthorized: {"Unauthorized", "application/json", LatticeWeb.Schemas.UnauthorizedResponse}
+    ]
+  )
 
   @doc """
   GET /api/fleet — fleet summary with sprite counts by state and overall health.
@@ -26,6 +39,15 @@ defmodule LatticeWeb.Api.FleetController do
       timestamp: DateTime.utc_now()
     })
   end
+
+  operation(:audit,
+    summary: "Trigger fleet audit",
+    description: "Triggers a fleet-wide reconciliation audit across all sprites.",
+    responses: [
+      ok: {"Audit triggered", "application/json", LatticeWeb.Schemas.AuditTriggeredResponse},
+      unauthorized: {"Unauthorized", "application/json", LatticeWeb.Schemas.UnauthorizedResponse}
+    ]
+  )
 
   @doc """
   POST /api/fleet/audit — trigger a fleet-wide reconciliation audit.

--- a/lib/lattice_web/schemas.ex
+++ b/lib/lattice_web/schemas.ex
@@ -1,0 +1,757 @@
+defmodule LatticeWeb.Schemas do
+  @moduledoc """
+  OpenAPI schema definitions for the Lattice REST API.
+
+  Each nested module defines one reusable schema via `OpenApiSpex.schema/1`.
+  Controllers reference these schemas in their `operation/2` specs.
+  """
+
+  alias OpenApiSpex.Schema
+
+  # ── Error Responses ──────────────────────────────────────────────
+
+  defmodule ErrorResponse do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "ErrorResponse",
+      description: "Standard error envelope returned by all endpoints on failure.",
+      type: :object,
+      properties: %{
+        error: %Schema{type: :string, description: "Human-readable error message"},
+        code: %Schema{
+          type: :string,
+          description: "Machine-readable error code",
+          enum: [
+            "SPRITE_NOT_FOUND",
+            "INTENT_NOT_FOUND",
+            "MISSING_FIELD",
+            "INVALID_STATE",
+            "INVALID_KIND",
+            "INVALID_SOURCE_TYPE",
+            "INVALID_STATE_TRANSITION",
+            "INVALID_TRANSITION"
+          ]
+        }
+      },
+      required: [:error, :code],
+      example: %{
+        "error" => "Sprite not found",
+        "code" => "SPRITE_NOT_FOUND"
+      }
+    })
+  end
+
+  defmodule UnauthorizedResponse do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "UnauthorizedResponse",
+      description: "Returned when the Authorization header is missing or invalid.",
+      type: :object,
+      properties: %{
+        error: %Schema{type: :string, description: "Error message"}
+      },
+      required: [:error],
+      example: %{
+        "error" => "Missing or invalid authorization"
+      }
+    })
+  end
+
+  # ── Health ───────────────────────────────────────────────────────
+
+  defmodule InstanceIdentity do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "InstanceIdentity",
+      description: "Instance metadata included in health checks.",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string, description: "Instance name"},
+        environment: %Schema{type: :string, description: "Runtime environment"},
+        resources: %Schema{
+          type: :object,
+          description: "Bound resource identifiers (secrets redacted)",
+          additionalProperties: %Schema{type: :string, nullable: true}
+        }
+      },
+      example: %{
+        "name" => "lattice-dev",
+        "environment" => "dev",
+        "resources" => %{
+          "github_repo" => "plattegruber/lattice",
+          "fly_org" => "lattice-org"
+        }
+      }
+    })
+  end
+
+  defmodule HealthResponse do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "HealthResponse",
+      description: "Health check response.",
+      type: :object,
+      properties: %{
+        status: %Schema{type: :string, description: "Service status", enum: ["ok"]},
+        timestamp: %Schema{type: :string, format: :datetime, description: "ISO 8601 timestamp"},
+        instance: LatticeWeb.Schemas.InstanceIdentity
+      },
+      required: [:status, :timestamp, :instance],
+      example: %{
+        "status" => "ok",
+        "timestamp" => "2026-01-15T12:00:00Z",
+        "instance" => %{
+          "name" => "lattice-dev",
+          "environment" => "dev",
+          "resources" => %{}
+        }
+      }
+    })
+  end
+
+  # ── Fleet ────────────────────────────────────────────────────────
+
+  defmodule FleetSummary do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "FleetSummary",
+      description: "Fleet-wide summary with sprite counts by state.",
+      type: :object,
+      properties: %{
+        total: %Schema{type: :integer, description: "Total number of sprites in the fleet"},
+        by_state: %Schema{
+          type: :object,
+          description: "Sprite count grouped by observed state",
+          additionalProperties: %Schema{type: :integer}
+        }
+      },
+      required: [:total, :by_state],
+      example: %{
+        "total" => 5,
+        "by_state" => %{"ready" => 3, "hibernating" => 2}
+      }
+    })
+  end
+
+  defmodule FleetSummaryResponse do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "FleetSummaryResponse",
+      description: "Fleet summary response envelope.",
+      type: :object,
+      properties: %{
+        data: LatticeWeb.Schemas.FleetSummary,
+        timestamp: %Schema{type: :string, format: :datetime, description: "ISO 8601 timestamp"}
+      },
+      required: [:data, :timestamp]
+    })
+  end
+
+  defmodule AuditTriggeredResponse do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "AuditTriggeredResponse",
+      description: "Response after triggering a fleet-wide audit.",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            status: %Schema{type: :string, enum: ["audit_triggered"]}
+          },
+          required: [:status]
+        },
+        timestamp: %Schema{type: :string, format: :datetime, description: "ISO 8601 timestamp"}
+      },
+      required: [:data, :timestamp],
+      example: %{
+        "data" => %{"status" => "audit_triggered"},
+        "timestamp" => "2026-01-15T12:00:00Z"
+      }
+    })
+  end
+
+  # ── Sprites ──────────────────────────────────────────────────────
+
+  defmodule SpriteSummary do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "SpriteSummary",
+      description: "Abbreviated sprite representation used in list responses.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, description: "Sprite identifier"},
+        observed_state: %Schema{
+          type: :string,
+          description: "Current observed lifecycle state",
+          enum: ["hibernating", "waking", "ready", "busy", "error"]
+        },
+        desired_state: %Schema{
+          type: :string,
+          description: "Operator-set target state",
+          enum: ["hibernating", "waking", "ready", "busy", "error"]
+        },
+        health: %Schema{
+          type: :string,
+          description: "Current health status",
+          enum: ["ok", "converging", "degraded", "error", "healthy", "unhealthy", "unknown"]
+        }
+      },
+      required: [:id, :observed_state, :desired_state, :health],
+      example: %{
+        "id" => "sprite-abc123",
+        "observed_state" => "ready",
+        "desired_state" => "ready",
+        "health" => "ok"
+      }
+    })
+  end
+
+  defmodule SpriteDetail do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "SpriteDetail",
+      description: "Full sprite representation with timestamps and failure tracking.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, description: "Sprite identifier"},
+        observed_state: %Schema{
+          type: :string,
+          description: "Current observed lifecycle state",
+          enum: ["hibernating", "waking", "ready", "busy", "error"]
+        },
+        desired_state: %Schema{
+          type: :string,
+          description: "Operator-set target state",
+          enum: ["hibernating", "waking", "ready", "busy", "error"]
+        },
+        health: %Schema{
+          type: :string,
+          description: "Current health status",
+          enum: ["ok", "converging", "degraded", "error", "healthy", "unhealthy", "unknown"]
+        },
+        failure_count: %Schema{
+          type: :integer,
+          description: "Number of consecutive failures"
+        },
+        last_observed_at: %Schema{
+          type: :string,
+          format: :datetime,
+          nullable: true,
+          description: "When the sprite was last observed"
+        },
+        started_at: %Schema{
+          type: :string,
+          format: :datetime,
+          description: "When the sprite process started"
+        },
+        updated_at: %Schema{
+          type: :string,
+          format: :datetime,
+          description: "When the sprite state was last updated"
+        }
+      },
+      required: [:id, :observed_state, :desired_state, :health],
+      example: %{
+        "id" => "sprite-abc123",
+        "observed_state" => "ready",
+        "desired_state" => "ready",
+        "health" => "ok",
+        "failure_count" => 0,
+        "last_observed_at" => "2026-01-15T12:00:00Z",
+        "started_at" => "2026-01-15T11:00:00Z",
+        "updated_at" => "2026-01-15T12:00:00Z"
+      }
+    })
+  end
+
+  defmodule SpriteListResponse do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "SpriteListResponse",
+      description: "List of sprites response envelope.",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :array,
+          items: LatticeWeb.Schemas.SpriteSummary,
+          description: "Array of sprite summaries"
+        },
+        timestamp: %Schema{type: :string, format: :datetime, description: "ISO 8601 timestamp"}
+      },
+      required: [:data, :timestamp]
+    })
+  end
+
+  defmodule SpriteDetailResponse do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "SpriteDetailResponse",
+      description: "Single sprite detail response envelope.",
+      type: :object,
+      properties: %{
+        data: LatticeWeb.Schemas.SpriteDetail,
+        timestamp: %Schema{type: :string, format: :datetime, description: "ISO 8601 timestamp"}
+      },
+      required: [:data, :timestamp]
+    })
+  end
+
+  defmodule UpdateDesiredStateRequest do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "UpdateDesiredStateRequest",
+      description: "Request body for updating a sprite's desired state.",
+      type: :object,
+      properties: %{
+        state: %Schema{
+          type: :string,
+          description: "Target desired state",
+          enum: ["ready", "hibernating"]
+        }
+      },
+      required: [:state],
+      example: %{
+        "state" => "ready"
+      }
+    })
+  end
+
+  defmodule ReconcileTriggeredResponse do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "ReconcileTriggeredResponse",
+      description: "Response after triggering sprite reconciliation.",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            sprite_id: %Schema{type: :string, description: "The sprite that was reconciled"},
+            status: %Schema{type: :string, enum: ["reconciliation_triggered"]}
+          },
+          required: [:sprite_id, :status]
+        },
+        timestamp: %Schema{type: :string, format: :datetime, description: "ISO 8601 timestamp"}
+      },
+      required: [:data, :timestamp],
+      example: %{
+        "data" => %{
+          "sprite_id" => "sprite-abc123",
+          "status" => "reconciliation_triggered"
+        },
+        "timestamp" => "2026-01-15T12:00:00Z"
+      }
+    })
+  end
+
+  # ── Intents ──────────────────────────────────────────────────────
+
+  defmodule IntentSource do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "IntentSource",
+      description: "The originator of an intent.",
+      type: :object,
+      properties: %{
+        type: %Schema{
+          type: :string,
+          description: "Source type",
+          enum: ["sprite", "agent", "cron", "operator"]
+        },
+        id: %Schema{type: :string, description: "Source identifier"}
+      },
+      required: [:type, :id],
+      example: %{
+        "type" => "sprite",
+        "id" => "sprite-abc123"
+      }
+    })
+  end
+
+  defmodule TransitionEntry do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "TransitionEntry",
+      description: "A single state transition in the intent lifecycle.",
+      type: :object,
+      properties: %{
+        from: %Schema{type: :string, description: "Previous state"},
+        to: %Schema{type: :string, description: "New state"},
+        timestamp: %Schema{
+          type: :string,
+          format: :datetime,
+          description: "When the transition occurred"
+        },
+        actor: %Schema{type: :string, nullable: true, description: "Who triggered the transition"},
+        reason: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Reason for the transition"
+        }
+      },
+      required: [:from, :to, :timestamp],
+      example: %{
+        "from" => "proposed",
+        "to" => "classified",
+        "timestamp" => "2026-01-15T12:00:00Z",
+        "actor" => "system",
+        "reason" => nil
+      }
+    })
+  end
+
+  defmodule IntentSummary do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "IntentSummary",
+      description: "Abbreviated intent representation used in list responses.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, description: "Intent identifier"},
+        kind: %Schema{
+          type: :string,
+          description: "Intent kind",
+          enum: ["action", "inquiry", "maintenance"]
+        },
+        state: %Schema{
+          type: :string,
+          description: "Current lifecycle state",
+          enum: [
+            "proposed",
+            "classified",
+            "awaiting_approval",
+            "approved",
+            "running",
+            "completed",
+            "failed",
+            "rejected",
+            "canceled"
+          ]
+        },
+        source: LatticeWeb.Schemas.IntentSource,
+        summary: %Schema{type: :string, description: "Human-readable summary"},
+        classification: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Safety classification",
+          enum: ["safe", "controlled", "dangerous"]
+        },
+        inserted_at: %Schema{
+          type: :string,
+          format: :datetime,
+          description: "When the intent was created"
+        },
+        updated_at: %Schema{
+          type: :string,
+          format: :datetime,
+          description: "When the intent was last updated"
+        }
+      },
+      required: [:id, :kind, :state, :source, :summary, :inserted_at, :updated_at],
+      example: %{
+        "id" => "intent-abc123",
+        "kind" => "action",
+        "state" => "proposed",
+        "source" => %{"type" => "sprite", "id" => "sprite-abc123"},
+        "summary" => "Deploy new version of the application",
+        "classification" => nil,
+        "inserted_at" => "2026-01-15T12:00:00Z",
+        "updated_at" => "2026-01-15T12:00:00Z"
+      }
+    })
+  end
+
+  defmodule IntentDetail do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "IntentDetail",
+      description: "Full intent representation with payload, metadata, and transition history.",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, description: "Intent identifier"},
+        kind: %Schema{
+          type: :string,
+          description: "Intent kind",
+          enum: ["action", "inquiry", "maintenance"]
+        },
+        state: %Schema{
+          type: :string,
+          description: "Current lifecycle state",
+          enum: [
+            "proposed",
+            "classified",
+            "awaiting_approval",
+            "approved",
+            "running",
+            "completed",
+            "failed",
+            "rejected",
+            "canceled"
+          ]
+        },
+        source: LatticeWeb.Schemas.IntentSource,
+        summary: %Schema{type: :string, description: "Human-readable summary"},
+        payload: %Schema{
+          type: :object,
+          description: "Intent-specific payload data",
+          additionalProperties: true
+        },
+        classification: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Safety classification",
+          enum: ["safe", "controlled", "dangerous"]
+        },
+        result: %Schema{
+          type: :object,
+          nullable: true,
+          description: "Execution result (if completed or failed)",
+          additionalProperties: true
+        },
+        metadata: %Schema{
+          type: :object,
+          nullable: true,
+          description: "Arbitrary metadata",
+          additionalProperties: true
+        },
+        affected_resources: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          description: "Resources affected by this intent"
+        },
+        expected_side_effects: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          description: "Expected side effects"
+        },
+        rollback_strategy: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Rollback strategy if the intent fails"
+        },
+        transition_log: %Schema{
+          type: :array,
+          items: LatticeWeb.Schemas.TransitionEntry,
+          description: "Full state transition history"
+        },
+        inserted_at: %Schema{
+          type: :string,
+          format: :datetime,
+          description: "When the intent was created"
+        },
+        updated_at: %Schema{
+          type: :string,
+          format: :datetime,
+          description: "When the intent was last updated"
+        },
+        classified_at: %Schema{
+          type: :string,
+          format: :datetime,
+          nullable: true,
+          description: "When the intent was classified"
+        },
+        approved_at: %Schema{
+          type: :string,
+          format: :datetime,
+          nullable: true,
+          description: "When the intent was approved"
+        },
+        started_at: %Schema{
+          type: :string,
+          format: :datetime,
+          nullable: true,
+          description: "When execution started"
+        },
+        completed_at: %Schema{
+          type: :string,
+          format: :datetime,
+          nullable: true,
+          description: "When execution completed"
+        }
+      },
+      required: [:id, :kind, :state, :source, :summary, :inserted_at, :updated_at]
+    })
+  end
+
+  defmodule IntentListResponse do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "IntentListResponse",
+      description: "List of intents response envelope.",
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :array,
+          items: LatticeWeb.Schemas.IntentSummary,
+          description: "Array of intent summaries"
+        },
+        timestamp: %Schema{type: :string, format: :datetime, description: "ISO 8601 timestamp"}
+      },
+      required: [:data, :timestamp]
+    })
+  end
+
+  defmodule IntentDetailResponse do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "IntentDetailResponse",
+      description: "Single intent detail response envelope.",
+      type: :object,
+      properties: %{
+        data: LatticeWeb.Schemas.IntentDetail,
+        timestamp: %Schema{type: :string, format: :datetime, description: "ISO 8601 timestamp"}
+      },
+      required: [:data, :timestamp]
+    })
+  end
+
+  defmodule IntentSummaryResponse do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "IntentSummaryResponse",
+      description: "Single intent summary response envelope (used after mutations).",
+      type: :object,
+      properties: %{
+        data: LatticeWeb.Schemas.IntentSummary,
+        timestamp: %Schema{type: :string, format: :datetime, description: "ISO 8601 timestamp"}
+      },
+      required: [:data, :timestamp]
+    })
+  end
+
+  defmodule CreateIntentRequest do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "CreateIntentRequest",
+      description: "Request body for proposing a new intent.",
+      type: :object,
+      properties: %{
+        kind: %Schema{
+          type: :string,
+          description: "Intent kind",
+          enum: ["action", "inquiry", "maintenance"]
+        },
+        source: LatticeWeb.Schemas.IntentSource,
+        summary: %Schema{type: :string, description: "Human-readable summary of the intent"},
+        payload: %Schema{
+          type: :object,
+          description: "Intent-specific payload data",
+          additionalProperties: true
+        },
+        affected_resources: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          description: "Resources affected by this intent (action kind only)"
+        },
+        expected_side_effects: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          description: "Expected side effects (action kind only)"
+        },
+        rollback_strategy: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Rollback strategy if the intent fails (action kind only)"
+        }
+      },
+      required: [:kind, :source],
+      example: %{
+        "kind" => "action",
+        "source" => %{"type" => "sprite", "id" => "sprite-abc123"},
+        "summary" => "Deploy new version of the application",
+        "payload" => %{"version" => "1.2.3"},
+        "affected_resources" => ["fly-app:lattice"],
+        "expected_side_effects" => ["app restart"],
+        "rollback_strategy" => "redeploy previous version"
+      }
+    })
+  end
+
+  defmodule IntentActorRequest do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "IntentActorRequest",
+      description: "Request body for approve/reject/cancel operations.",
+      type: :object,
+      properties: %{
+        actor: %Schema{type: :string, description: "Identity of the actor performing the action"},
+        reason: %Schema{
+          type: :string,
+          description: "Optional reason (used for reject and cancel)"
+        }
+      },
+      required: [:actor],
+      example: %{
+        "actor" => "operator:jane",
+        "reason" => "Not safe to proceed at this time"
+      }
+    })
+  end
+end


### PR DESCRIPTION
## Summary
- Integrate `open_api_spex` (~> 3.21) to generate an OpenAPI 3.0 specification from controller annotations
- Document all 16 REST API endpoints across Health, Fleet, Sprites, and Intents controllers with typed request/response schemas, query parameters, path parameters, and Bearer token auth
- Serve Swagger UI at `/api/docs` and raw OpenAPI JSON at `/api/openapi` (both unauthenticated)
- Define 20+ reusable schema modules in `LatticeWeb.Schemas` covering all request/response shapes, error envelopes, and domain objects

## Test plan
- [x] `mix compile --warnings-as-errors` passes with zero warnings
- [x] `mix credo --strict` passes with zero issues
- [x] `mix test` passes all 873 tests with zero failures
- [x] `mix format` produces no changes
- [ ] Visit `/api/docs` in browser and verify Swagger UI renders with all endpoints
- [ ] Verify `/api/openapi` returns valid OpenAPI 3.0 JSON
- [ ] Test "Try it out" in Swagger UI with a valid Bearer token

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)