### PR TITLE
Add create_sprite capability and fix exec query params

### DIFF
--- a/lib/lattice/capabilities/sprites.ex
+++ b/lib/lattice/capabilities/sprites.ex
@@ -36,6 +36,10 @@ defmodule Lattice.Capabilities.Sprites do
   @doc "Execute a command on a Sprite."
   @callback exec(sprite_id(), command()) :: {:ok, map()} | {:error, term()}
 
+  @doc "Create a new Sprite with the given name."
+  @callback create_sprite(name :: String.t(), opts :: keyword()) ::
+              {:ok, sprite()} | {:error, term()}
+
   @doc "Fetch logs for a Sprite. Options may include `:since`, `:limit`, etc."
   @callback fetch_logs(sprite_id(), log_opts()) :: {:ok, [String.t()]} | {:error, term()}
 
@@ -53,6 +57,9 @@ defmodule Lattice.Capabilities.Sprites do
 
   @doc "Execute a command on a Sprite."
   def exec(id, command), do: impl().exec(id, command)
+
+  @doc "Create a new Sprite with the given name."
+  def create_sprite(name, opts \\ []), do: impl().create_sprite(name, opts)
 
   @doc "Fetch logs for a Sprite."
   def fetch_logs(id, opts \\ []), do: impl().fetch_logs(id, opts)

--- a/lib/lattice/capabilities/sprites/live.ex
+++ b/lib/lattice/capabilities/sprites/live.ex
@@ -29,6 +29,19 @@ defmodule Lattice.Capabilities.Sprites.Live do
   # ── Callbacks ──────────────────────────────────────────────────────────
 
   @impl true
+  def create_sprite(name, _opts \\ []) do
+    body = %{"name" => name}
+
+    case post("/#{@api_version}/sprites", body) do
+      {:ok, sprite} when is_map(sprite) ->
+        {:ok, parse_sprite(sprite)}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @impl true
   def list_sprites do
     case get("/#{@api_version}/sprites") do
       {:ok, sprites} when is_list(sprites) ->
@@ -80,9 +93,10 @@ defmodule Lattice.Capabilities.Sprites.Live do
 
   @impl true
   def exec(id, command) do
-    body = %{cmd: command}
+    query = URI.encode_query([{"cmd", command}])
+    path = "/#{@api_version}/sprites/#{URI.encode(id)}/exec?#{query}"
 
-    case post("/#{@api_version}/sprites/#{URI.encode(id)}/exec", body) do
+    case post(path, nil) do
       {:ok, result} when is_map(result) ->
         {:ok, parse_exec_result(id, command, result)}
 

--- a/lib/lattice/capabilities/sprites/stub.ex
+++ b/lib/lattice/capabilities/sprites/stub.ex
@@ -37,6 +37,19 @@ defmodule Lattice.Capabilities.Sprites.Stub do
   ]
 
   @impl true
+  def create_sprite(name, _opts \\ []) do
+    {:ok,
+     %{
+       id: name,
+       name: name,
+       status: "running",
+       task: nil,
+       repo: nil,
+       started_at: DateTime.to_iso8601(DateTime.utc_now())
+     }}
+  end
+
+  @impl true
   def list_sprites do
     {:ok, @stub_sprites}
   end

--- a/test/lattice/capabilities/sprites_stub_test.exs
+++ b/test/lattice/capabilities/sprites_stub_test.exs
@@ -5,6 +5,24 @@ defmodule Lattice.Capabilities.Sprites.StubTest do
 
   alias Lattice.Capabilities.Sprites.Stub
 
+  describe "create_sprite/2" do
+    test "returns a new sprite with the given name" do
+      assert {:ok, sprite} = Stub.create_sprite("test-sprite")
+      assert sprite.id == "test-sprite"
+      assert sprite.name == "test-sprite"
+      assert sprite.status == "running"
+      assert sprite.started_at != nil
+    end
+
+    test "returns a sprite with required fields" do
+      {:ok, sprite} = Stub.create_sprite("my-sprite")
+
+      assert Map.has_key?(sprite, :id)
+      assert Map.has_key?(sprite, :name)
+      assert Map.has_key?(sprite, :status)
+    end
+  end
+
   describe "list_sprites/0" do
     test "returns a list of sprites" do
       assert {:ok, [_ | _]} = Stub.list_sprites()


### PR DESCRIPTION
## Summary

- Add `create_sprite/2` callback to the `Lattice.Capabilities.Sprites` behaviour with implementations in both `Sprites.Live` (POST /v1/sprites with JSON body) and `Sprites.Stub` (canned response)
- Fix `exec/2` in `Sprites.Live` to send commands via query params (`?cmd=...`) instead of a JSON body, aligning with the real Sprites API v1
- Add public delegate `create_sprite/2` on the behaviour module for capability auto-dispatch

## Test plan

- [x] `Sprites.Stub.create_sprite/2` returns a sprite map with the given name, id, status, and started_at
- [x] `Sprites.Stub.create_sprite/2` response includes all required fields (id, name, status)
- [x] All existing stub tests pass (list, get, wake, sleep, exec, fetch_logs)
- [x] All existing Live parse unit tests pass (parse_sprite, parse_status)
- [x] `mix compile --warnings-as-errors` passes with zero warnings
- [x] `mix credo --strict` passes with no issues
- [x] `mix test` — 875 tests, 0 failures

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)