### PR TITLE
Add Task intent kind with allowlist gating

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -29,6 +29,9 @@ config :lattice, :guardrails,
   allow_dangerous: false,
   require_approval_for_controlled: true
 
+# Task allowlist — repos that auto-approve task intents
+config :lattice, :task_allowlist, auto_approve_repos: []
+
 # Configure the endpoint
 config :lattice, LatticeWeb.Endpoint,
   url: [host: "localhost"],

--- a/lib/lattice/safety/classifier.ex
+++ b/lib/lattice/safety/classifier.ex
@@ -46,6 +46,7 @@ defmodule Lattice.Safety.Classifier do
     {:sprites, :wake} => :controlled,
     {:sprites, :sleep} => :controlled,
     {:sprites, :exec} => :controlled,
+    {:sprites, :run_task} => :controlled,
     # GitHub
     {:github, :list_issues} => :safe,
     {:github, :get_issue} => :safe,

--- a/lib/lattice_web/live/intent_live/show.ex
+++ b/lib/lattice_web/live/intent_live/show.ex
@@ -191,6 +191,8 @@ defmodule LatticeWeb.IntentLive.Show do
           <.classification_panel intent={@intent} />
         </div>
 
+        <.task_details_panel :if={Intent.task?(@intent)} intent={@intent} />
+
         <.payload_panel intent={@intent} />
 
         <.lifecycle_timeline intent={@intent} />
@@ -398,6 +400,91 @@ defmodule LatticeWeb.IntentLive.Show do
             Rollback Strategy
           </div>
           <p class="text-xs text-base-content/70">{@intent.rollback_strategy}</p>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :intent, Intent, required: true
+
+  defp task_details_panel(assigns) do
+    payload = assigns.intent.payload
+    artifacts = Map.get(assigns.intent.metadata, :artifacts, [])
+
+    pr_artifact =
+      Enum.find(artifacts, fn a ->
+        Map.get(a, :type) in ["pr_url", :pr_url]
+      end)
+
+    pr_url =
+      if pr_artifact,
+        do: get_in(pr_artifact, [:data, "url"]) || get_in(pr_artifact, [:data, :url])
+
+    assigns =
+      assigns
+      |> assign(:task_payload, payload)
+      |> assign(:pr_url, pr_url)
+
+    ~H"""
+    <div class="card bg-base-200 shadow-sm">
+      <div class="card-body">
+        <h2 class="card-title text-base">
+          <.icon name="hero-command-line" class="size-5" /> Task Details
+        </h2>
+
+        <div class="grid grid-cols-2 lg:grid-cols-3 gap-4 mt-2">
+          <div :if={@task_payload["sprite_name"]}>
+            <div class="text-xs font-medium text-base-content/60 uppercase tracking-wide">
+              Sprite
+            </div>
+            <div class="mt-1 text-sm font-mono">{@task_payload["sprite_name"]}</div>
+          </div>
+          <div :if={@task_payload["repo"]}>
+            <div class="text-xs font-medium text-base-content/60 uppercase tracking-wide">
+              Repository
+            </div>
+            <div class="mt-1 text-sm font-mono">{@task_payload["repo"]}</div>
+          </div>
+          <div :if={@task_payload["task_kind"]}>
+            <div class="text-xs font-medium text-base-content/60 uppercase tracking-wide">
+              Task Kind
+            </div>
+            <div class="mt-1">
+              <span class="badge badge-sm badge-outline">{@task_payload["task_kind"]}</span>
+            </div>
+          </div>
+          <div :if={@task_payload["base_branch"]}>
+            <div class="text-xs font-medium text-base-content/60 uppercase tracking-wide">
+              Base Branch
+            </div>
+            <div class="mt-1 text-sm font-mono">{@task_payload["base_branch"]}</div>
+          </div>
+          <div :if={@task_payload["pr_title"]}>
+            <div class="text-xs font-medium text-base-content/60 uppercase tracking-wide">
+              PR Title
+            </div>
+            <div class="mt-1 text-sm">{@task_payload["pr_title"]}</div>
+          </div>
+        </div>
+
+        <div :if={@task_payload["instructions"]} class="mt-4">
+          <div class="text-xs font-medium text-base-content/60 uppercase tracking-wide mb-1">
+            Instructions
+          </div>
+          <div class="bg-base-300 rounded-lg p-3">
+            <p class="text-sm whitespace-pre-wrap">{@task_payload["instructions"]}</p>
+          </div>
+        </div>
+
+        <div :if={@pr_url} class="mt-4">
+          <div class="text-xs font-medium text-base-content/60 uppercase tracking-wide mb-1">
+            Pull Request
+          </div>
+          <a href={@pr_url} target="_blank" rel="noopener" class="link link-primary text-sm">
+            <.icon name="hero-arrow-top-right-on-square" class="size-4 inline" />
+            {@pr_url}
+          </a>
         </div>
       </div>
     </div>

--- a/lib/lattice_web/live/intents_live.ex
+++ b/lib/lattice_web/live/intents_live.ex
@@ -164,6 +164,7 @@ defmodule LatticeWeb.IntentsLive do
           </:col>
           <:col :let={intent} label="Summary">
             <span class="text-sm">{intent.summary}</span>
+            <.task_inline_details :if={Intent.task?(intent)} payload={intent.payload} />
           </:col>
           <:col :let={intent} label="State">
             <.intent_state_badge state={intent.state} />
@@ -191,6 +192,24 @@ defmodule LatticeWeb.IntentsLive do
   end
 
   # ── Functional Components ──────────────────────────────────────────
+
+  attr :payload, :map, required: true
+
+  defp task_inline_details(assigns) do
+    ~H"""
+    <div class="flex flex-wrap gap-1 mt-1">
+      <span :if={@payload["sprite_name"]} class="badge badge-xs badge-outline">
+        {@payload["sprite_name"]}
+      </span>
+      <span :if={@payload["repo"]} class="badge badge-xs badge-outline">
+        {@payload["repo"]}
+      </span>
+      <span :if={@payload["task_kind"]} class="badge badge-xs badge-ghost">
+        {@payload["task_kind"]}
+      </span>
+    </div>
+    """
+  end
 
   attr :total, :integer, required: true
   attr :by_state, :map, required: true

--- a/test/lattice/safety/classifier_test.exs
+++ b/test/lattice/safety/classifier_test.exs
@@ -56,6 +56,11 @@ defmodule Lattice.Safety.ClassifierTest do
       assert {:ok, %Action{classification: :controlled}} = Classifier.classify(:sprites, :exec)
     end
 
+    test "classifies sprites:run_task as controlled" do
+      assert {:ok, %Action{classification: :controlled}} =
+               Classifier.classify(:sprites, :run_task)
+    end
+
     test "classifies github:create_issue as controlled" do
       assert {:ok, %Action{classification: :controlled}} =
                Classifier.classify(:github, :create_issue)
@@ -140,6 +145,7 @@ defmodule Lattice.Safety.ClassifierTest do
       assert {:sprites, :wake} in controlled_actions
       assert {:sprites, :sleep} in controlled_actions
       assert {:sprites, :exec} in controlled_actions
+      assert {:sprites, :run_task} in controlled_actions
       assert {:github, :create_issue} in controlled_actions
     end
 
@@ -169,9 +175,9 @@ defmodule Lattice.Safety.ClassifierTest do
     test "covers all capability operations" do
       all = Classifier.all_classifications()
 
-      # Sprites: 6 operations
+      # Sprites: 7 operations (including run_task)
       sprites_ops = Enum.filter(all, fn {{cap, _op}, _class} -> cap == :sprites end)
-      assert length(sprites_ops) == 6
+      assert length(sprites_ops) == 7
 
       # GitHub: 7 operations
       github_ops = Enum.filter(all, fn {{cap, _op}, _class} -> cap == :github end)

--- a/test/lattice_web/live/intents_live_test.exs
+++ b/test/lattice_web/live/intents_live_test.exs
@@ -242,6 +242,28 @@ defmodule LatticeWeb.IntentsLiveTest do
     end
   end
 
+  # ── Task Display ─────────────────────────────────────────────────────
+
+  describe "task intent display" do
+    test "shows task-specific inline details", %{conn: conn} do
+      source = %{type: :sprite, id: "sprite-001"}
+
+      {:ok, intent} =
+        Intent.new_task(source, "my-sprite", "owner/repo",
+          task_kind: "open_pr_trivial_change",
+          instructions: "Add timestamp"
+        )
+
+      {:ok, _stored} = Store.create(intent)
+
+      {:ok, _view, html} = live(conn, ~p"/intents")
+
+      assert html =~ "my-sprite"
+      assert html =~ "owner/repo"
+      assert html =~ "open_pr_trivial_change"
+    end
+  end
+
   # ── Navigation ─────────────────────────────────────────────────────
 
   describe "navigation" do


### PR DESCRIPTION
## Summary
- Add Intent.new_task/4 convenience constructor that builds the task payload schema and delegates to new_action/2, with Intent.task?/1 predicate for identifying task intents
- Register {:sprites, :run_task} as :controlled in Safety.Classifier and add repo allowlist config (config :lattice, :task_allowlist) so tasks targeting allowlisted repos auto-approve through Pipeline.gate/1
- Display task-specific fields (sprite_name, repo, task_kind, PR URL artifact) in the Intents LiveView list and detail views via inline badges and a dedicated Task Details panel

## Test plan
- [x] Intent.new_task/4 creates valid task intents with correct payload fields, defaults, and validation errors
- [x] Intent.task?/1 correctly identifies task vs non-task intents
- [x] Classifier.classify(:sprites, :run_task) returns :controlled
- [x] Classifier registry counts updated (sprites operations: 6 -> 7)
- [x] Task intents classified as :controlled stop at :awaiting_approval by default
- [x] Task intents targeting allowlisted repos auto-approve with reason auto-approved (allowlisted repo)
- [x] Task intents targeting non-allowlisted repos still require approval
- [x] Non-task controlled intents are unaffected by task allowlist
- [x] Task inline details (sprite_name, repo, task_kind) render in intents list view
- [x] Task Details panel renders in intent detail view with all fields
- [x] PR URL artifact renders as a link in Task Details panel
- [x] Non-task intents do not show Task Details panel
- [x] All 899 tests pass, mix format, mix compile --warnings-as-errors, and mix credo --strict pass clean

Closes #65

Generated with [Claude Code](https://claude.com/claude-code)