### PR TITLE
Add POST /api/sprites endpoint to create sprites at runtime

### DIFF
--- a/lib/lattice_web/router.ex
+++ b/lib/lattice_web/router.ex
@@ -72,6 +72,7 @@ defmodule LatticeWeb.Router do
     post "/fleet/audit", FleetController, :audit
 
     get "/sprites", SpriteController, :index
+    post "/sprites", SpriteController, :create
     get "/sprites/:id", SpriteController, :show
     put "/sprites/:id/desired", SpriteController, :update_desired
     post "/sprites/:id/reconcile", SpriteController, :reconcile

--- a/lib/lattice_web/schemas.ex
+++ b/lib/lattice_web/schemas.ex
@@ -32,7 +32,9 @@ defmodule LatticeWeb.Schemas do
             "INVALID_KIND",
             "INVALID_SOURCE_TYPE",
             "INVALID_STATE_TRANSITION",
-            "INVALID_TRANSITION"
+            "INVALID_TRANSITION",
+            "SPRITE_ALREADY_EXISTS",
+            "UPSTREAM_API_ERROR"
           ]
         }
       },
@@ -349,6 +351,28 @@ defmodule LatticeWeb.Schemas do
       required: [:state],
       example: %{
         "state" => "ready"
+      }
+    })
+  end
+
+  defmodule CreateSpriteRequest do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "CreateSpriteRequest",
+      description: "Request body for creating a new sprite.",
+      type: :object,
+      properties: %{
+        name: %Schema{
+          type: :string,
+          description: "Name for the new sprite"
+        }
+      },
+      required: [:name],
+      example: %{
+        "name" => "my-sprite"
       }
     })
   end


### PR DESCRIPTION
## Summary
- Add `POST /api/sprites` endpoint that creates a sprite via the Sprites API capability, starts a GenServer under the DynamicSupervisor, and returns sprite detail
- Add `FleetManager.add_sprite/2` to dynamically add sprites to the fleet at runtime with PubSub broadcast so the LiveView dashboard updates in real time
- Handle edge cases: missing name (422 `MISSING_FIELD`), duplicate name (422 `SPRITE_ALREADY_EXISTS`), upstream API failure (502 `UPSTREAM_API_ERROR`)

## Test plan
- [x] `POST /api/sprites` with valid name returns 200 with sprite detail data
- [x] Created sprite is queryable via `GET /api/sprites/:id` immediately after creation
- [x] Created sprite appears in `GET /api/sprites` list
- [x] Missing name returns 422 with `MISSING_FIELD`
- [x] Empty name returns 422 with `MISSING_FIELD`
- [x] Duplicate sprite name returns 422 with `SPRITE_ALREADY_EXISTS`
- [x] Upstream API failure returns 502 with `UPSTREAM_API_ERROR`
- [x] Unauthenticated request returns 401
- [x] `FleetManager.add_sprite/3` starts sprite and registers in Registry
- [x] `FleetManager.add_sprite/3` rejects duplicates with `{:error, :already_exists}`
- [x] `FleetManager.add_sprite/3` broadcasts fleet summary via PubSub
- [x] `FleetManager.add_sprite/3` respects `desired_state` option
- [x] New sprite appears in `fleet_summary/1` after addition
- [x] `mix format`, `mix compile --warnings-as-errors`, and `mix credo --strict` all pass

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)