### PR TITLE
Add POST /api/sprites/:name/tasks endpoint

### DIFF
--- a/lib/lattice_web/controllers/api/task_controller.ex
+++ b/lib/lattice_web/controllers/api/task_controller.ex
@@ -1,0 +1,140 @@
+defmodule LatticeWeb.Api.TaskController do
+  @moduledoc """
+  API controller for assigning tasks to sprites.
+
+  Provides the `POST /api/sprites/:name/tasks` endpoint which builds a Task
+  intent from the request body, validates that the target sprite exists, and
+  feeds it through the intent pipeline (classify -> gate -> approve/await).
+  """
+
+  use LatticeWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Pipeline
+  alias Lattice.Sprites.FleetManager
+
+  tags(["Tasks"])
+  security([%{"BearerAuth" => []}])
+
+  @source %{type: :operator, id: "api"}
+
+  operation(:create,
+    summary: "Assign a task to a sprite",
+    description:
+      "Creates a Task intent for the given sprite and feeds it through the classify-gate pipeline. " <>
+        "Safe or allowlisted tasks auto-approve; others await human approval.",
+    parameters: [
+      name: [
+        in: :path,
+        type: :string,
+        description: "Sprite name",
+        required: true
+      ]
+    ],
+    request_body:
+      {"Task assignment request", "application/json", LatticeWeb.Schemas.CreateTaskRequest},
+    responses: [
+      ok: {"Created task intent", "application/json", LatticeWeb.Schemas.TaskIntentResponse},
+      not_found: {"Sprite not found", "application/json", LatticeWeb.Schemas.ErrorResponse},
+      unprocessable_entity:
+        {"Validation error", "application/json", LatticeWeb.Schemas.ErrorResponse},
+      unauthorized: {"Unauthorized", "application/json", LatticeWeb.Schemas.UnauthorizedResponse}
+    ]
+  )
+
+  @doc """
+  POST /api/sprites/:name/tasks -- assign a task to a sprite.
+
+  Validates the sprite exists, builds a Task intent via `Intent.new_task/4`,
+  and proposes it through `Pipeline.propose/1`.
+  """
+  def create(conn, %{"name" => sprite_name} = params) do
+    with {:sprite, {:ok, _pid}} <- {:sprite, FleetManager.get_sprite_pid(sprite_name)},
+         {:validate, :ok} <- {:validate, validate_required_fields(params)},
+         {:intent, {:ok, intent}} <- {:intent, build_task_intent(sprite_name, params)},
+         {:pipeline, {:ok, result}} <- {:pipeline, Pipeline.propose(intent)} do
+      conn
+      |> put_status(200)
+      |> json(%{
+        data: serialize_task_intent(result, sprite_name),
+        timestamp: DateTime.utc_now()
+      })
+    else
+      {:sprite, {:error, :not_found}} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "Sprite not found", code: "SPRITE_NOT_FOUND"})
+
+      {:validate, {:error, {:missing_field, field}}} ->
+        conn
+        |> put_status(422)
+        |> json(%{
+          error: "Missing required field: #{field}",
+          code: "MISSING_FIELD"
+        })
+
+      {:intent, {:error, {:missing_field, field}}} ->
+        conn
+        |> put_status(422)
+        |> json(%{
+          error: "Missing required field: #{field}",
+          code: "MISSING_FIELD"
+        })
+
+      {:pipeline, {:error, reason}} ->
+        conn
+        |> put_status(422)
+        |> json(%{
+          error: "Failed to create task: #{inspect(reason)}",
+          code: "PIPELINE_ERROR"
+        })
+    end
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp validate_required_fields(params) do
+    cond do
+      not is_binary(Map.get(params, "repo")) or Map.get(params, "repo") == "" ->
+        {:error, {:missing_field, :repo}}
+
+      not is_binary(Map.get(params, "task_kind")) or Map.get(params, "task_kind") == "" ->
+        {:error, {:missing_field, :task_kind}}
+
+      not is_binary(Map.get(params, "instructions")) or Map.get(params, "instructions") == "" ->
+        {:error, {:missing_field, :instructions}}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp build_task_intent(sprite_name, params) do
+    opts =
+      [
+        task_kind: Map.fetch!(params, "task_kind"),
+        instructions: Map.fetch!(params, "instructions")
+      ]
+      |> maybe_add_opt(:base_branch, Map.get(params, "base_branch"))
+      |> maybe_add_opt(:pr_title, Map.get(params, "pr_title"))
+      |> maybe_add_opt(:pr_body, Map.get(params, "pr_body"))
+      |> maybe_add_opt(:summary, Map.get(params, "summary"))
+
+    Intent.new_task(@source, sprite_name, Map.fetch!(params, "repo"), opts)
+  end
+
+  defp maybe_add_opt(opts, _key, nil), do: opts
+  defp maybe_add_opt(opts, _key, ""), do: opts
+  defp maybe_add_opt(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp serialize_task_intent(%Intent{} = intent, sprite_name) do
+    %{
+      intent_id: intent.id,
+      state: intent.state,
+      classification: intent.classification,
+      sprite_name: sprite_name,
+      repo: Map.get(intent.payload, "repo")
+    }
+  end
+end

--- a/lib/lattice_web/router.ex
+++ b/lib/lattice_web/router.ex
@@ -76,6 +76,7 @@ defmodule LatticeWeb.Router do
     get "/sprites/:id", SpriteController, :show
     put "/sprites/:id/desired", SpriteController, :update_desired
     post "/sprites/:id/reconcile", SpriteController, :reconcile
+    post "/sprites/:name/tasks", TaskController, :create
 
     get "/intents", IntentController, :index
     get "/intents/:id", IntentController, :show

--- a/lib/lattice_web/schemas.ex
+++ b/lib/lattice_web/schemas.ex
@@ -778,4 +778,120 @@ defmodule LatticeWeb.Schemas do
       }
     })
   end
+
+  # ── Tasks ───────────────────────────────────────────────────────
+
+  defmodule CreateTaskRequest do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "CreateTaskRequest",
+      description: "Request body for assigning a task to a sprite.",
+      type: :object,
+      properties: %{
+        repo: %Schema{
+          type: :string,
+          description: "Target repository in owner/repo format"
+        },
+        task_kind: %Schema{
+          type: :string,
+          description: "Kind of task to run (e.g. open_pr_trivial_change)"
+        },
+        instructions: %Schema{
+          type: :string,
+          description: "Instructions for the sprite to execute"
+        },
+        base_branch: %Schema{
+          type: :string,
+          description: "Branch to base work on (default: main)"
+        },
+        pr_title: %Schema{
+          type: :string,
+          description: "Title for the PR to create"
+        },
+        pr_body: %Schema{
+          type: :string,
+          description: "Body for the PR to create"
+        },
+        summary: %Schema{
+          type: :string,
+          description: "Custom human-readable summary (defaults to auto-generated)"
+        }
+      },
+      required: [:repo, :task_kind, :instructions],
+      example: %{
+        "repo" => "plattegruber/lattice",
+        "task_kind" => "open_pr_trivial_change",
+        "instructions" => "Add a build timestamp to README.md",
+        "base_branch" => "main",
+        "pr_title" => "Add build timestamp",
+        "pr_body" => "Automated change via Lattice"
+      }
+    })
+  end
+
+  defmodule TaskIntentData do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "TaskIntentData",
+      description: "Task intent data returned after creation.",
+      type: :object,
+      properties: %{
+        intent_id: %Schema{type: :string, description: "Intent identifier"},
+        state: %Schema{
+          type: :string,
+          description: "Current lifecycle state",
+          enum: [
+            "proposed",
+            "classified",
+            "awaiting_approval",
+            "approved",
+            "running",
+            "completed",
+            "failed",
+            "rejected",
+            "canceled"
+          ]
+        },
+        classification: %Schema{
+          type: :string,
+          nullable: true,
+          description: "Safety classification",
+          enum: ["safe", "controlled", "dangerous"]
+        },
+        sprite_name: %Schema{type: :string, description: "Target sprite name"},
+        repo: %Schema{type: :string, description: "Target repository"}
+      },
+      required: [:intent_id, :state, :sprite_name, :repo],
+      example: %{
+        "intent_id" => "int_abc123",
+        "state" => "awaiting_approval",
+        "classification" => "controlled",
+        "sprite_name" => "my-sprite",
+        "repo" => "plattegruber/lattice"
+      }
+    })
+  end
+
+  defmodule TaskIntentResponse do
+    @moduledoc false
+    require OpenApiSpex
+    alias OpenApiSpex.Schema
+
+    OpenApiSpex.schema(%{
+      title: "TaskIntentResponse",
+      description: "Response envelope after creating a task intent.",
+      type: :object,
+      properties: %{
+        data: LatticeWeb.Schemas.TaskIntentData,
+        timestamp: %Schema{type: :string, format: :datetime, description: "ISO 8601 timestamp"}
+      },
+      required: [:data, :timestamp]
+    })
+  end
 end

--- a/test/lattice_web/controllers/api/task_controller_test.exs
+++ b/test/lattice_web/controllers/api/task_controller_test.exs
@@ -1,0 +1,288 @@
+defmodule LatticeWeb.Api.TaskControllerTest do
+  use LatticeWeb.ConnCase
+
+  alias Lattice.Intents.Store.ETS, as: StoreETS
+  alias Lattice.Sprites.FleetManager
+  alias Lattice.Sprites.Sprite
+
+  @moduletag :unit
+
+  setup do
+    StoreETS.reset()
+    :ok
+  end
+
+  # ── Helpers ──────────────────────────────────────────────────────────
+
+  defp authenticated(conn) do
+    put_req_header(conn, "authorization", "Bearer test-token")
+  end
+
+  defp start_sprite(sprite_id, opts \\ []) do
+    desired = Keyword.get(opts, :desired_state, :hibernating)
+
+    {:ok, _pid} =
+      DynamicSupervisor.start_child(
+        Lattice.Sprites.DynamicSupervisor,
+        {Sprite,
+         [
+           sprite_id: sprite_id,
+           desired_state: desired,
+           name: Sprite.via(sprite_id),
+           reconcile_interval_ms: 600_000
+         ]}
+      )
+
+    :sys.replace_state(FleetManager, fn state ->
+      %{state | sprite_ids: state.sprite_ids ++ [sprite_id]}
+    end)
+
+    on_exit(fn ->
+      :sys.replace_state(FleetManager, fn state ->
+        %{state | sprite_ids: state.sprite_ids -- [sprite_id]}
+      end)
+
+      case Registry.lookup(Lattice.Sprites.Registry, sprite_id) do
+        [{pid, _}] ->
+          DynamicSupervisor.terminate_child(Lattice.Sprites.DynamicSupervisor, pid)
+
+        _ ->
+          :ok
+      end
+    end)
+
+    :ok
+  end
+
+  defp valid_task_params do
+    %{
+      "repo" => "plattegruber/lattice",
+      "task_kind" => "open_pr_trivial_change",
+      "instructions" => "Add a build timestamp to README.md"
+    }
+  end
+
+  defp with_guardrails(config, fun) do
+    previous = Application.get_env(:lattice, :guardrails, [])
+    Application.put_env(:lattice, :guardrails, config)
+
+    try do
+      fun.()
+    after
+      Application.put_env(:lattice, :guardrails, previous)
+    end
+  end
+
+  # ── POST /api/sprites/:name/tasks ──────────────────────────────────
+
+  describe "POST /api/sprites/:name/tasks" do
+    test "creates a task intent for an existing sprite", %{conn: conn} do
+      start_sprite("task-sprite-001")
+
+      with_guardrails(
+        [allow_controlled: true, require_approval_for_controlled: true],
+        fn ->
+          conn =
+            conn
+            |> authenticated()
+            |> post("/api/sprites/task-sprite-001/tasks", valid_task_params())
+
+          body = json_response(conn, 200)
+
+          assert is_binary(body["data"]["intent_id"])
+          assert body["data"]["state"] in ["awaiting_approval", "approved"]
+          assert body["data"]["classification"] == "controlled"
+          assert body["data"]["sprite_name"] == "task-sprite-001"
+          assert body["data"]["repo"] == "plattegruber/lattice"
+          assert is_binary(body["timestamp"])
+        end
+      )
+    end
+
+    test "accepts optional fields", %{conn: conn} do
+      start_sprite("task-sprite-opts")
+
+      params =
+        valid_task_params()
+        |> Map.put("base_branch", "develop")
+        |> Map.put("pr_title", "My PR")
+        |> Map.put("pr_body", "Description of changes")
+        |> Map.put("summary", "Custom summary")
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/sprites/task-sprite-opts/tasks", params)
+
+      body = json_response(conn, 200)
+
+      assert is_binary(body["data"]["intent_id"])
+      assert body["data"]["sprite_name"] == "task-sprite-opts"
+    end
+
+    test "auto-approves tasks on allowlisted repos", %{conn: conn} do
+      start_sprite("task-sprite-allow")
+
+      previous_guardrails = Application.get_env(:lattice, :guardrails, [])
+      previous_allowlist = Application.get_env(:lattice, :task_allowlist, [])
+
+      Application.put_env(:lattice, :guardrails,
+        allow_controlled: true,
+        require_approval_for_controlled: true
+      )
+
+      Application.put_env(:lattice, :task_allowlist, auto_approve_repos: ["plattegruber/lattice"])
+
+      on_exit(fn ->
+        Application.put_env(:lattice, :guardrails, previous_guardrails)
+        Application.put_env(:lattice, :task_allowlist, previous_allowlist)
+      end)
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/sprites/task-sprite-allow/tasks", valid_task_params())
+
+      body = json_response(conn, 200)
+
+      assert body["data"]["state"] == "approved"
+      assert body["data"]["classification"] == "controlled"
+    end
+
+    test "returns 404 when sprite does not exist", %{conn: conn} do
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/sprites/nonexistent-sprite/tasks", valid_task_params())
+
+      body = json_response(conn, 404)
+
+      assert body["error"] == "Sprite not found"
+      assert body["code"] == "SPRITE_NOT_FOUND"
+    end
+
+    test "returns 422 when repo is missing", %{conn: conn} do
+      start_sprite("task-sprite-no-repo")
+
+      params = Map.delete(valid_task_params(), "repo")
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/sprites/task-sprite-no-repo/tasks", params)
+
+      body = json_response(conn, 422)
+
+      assert body["error"] =~ "repo"
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 422 when repo is empty string", %{conn: conn} do
+      start_sprite("task-sprite-empty-repo")
+
+      params = Map.put(valid_task_params(), "repo", "")
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/sprites/task-sprite-empty-repo/tasks", params)
+
+      body = json_response(conn, 422)
+
+      assert body["error"] =~ "repo"
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 422 when task_kind is missing", %{conn: conn} do
+      start_sprite("task-sprite-no-kind")
+
+      params = Map.delete(valid_task_params(), "task_kind")
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/sprites/task-sprite-no-kind/tasks", params)
+
+      body = json_response(conn, 422)
+
+      assert body["error"] =~ "task_kind"
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 422 when task_kind is empty string", %{conn: conn} do
+      start_sprite("task-sprite-empty-kind")
+
+      params = Map.put(valid_task_params(), "task_kind", "")
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/sprites/task-sprite-empty-kind/tasks", params)
+
+      body = json_response(conn, 422)
+
+      assert body["error"] =~ "task_kind"
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 422 when instructions is missing", %{conn: conn} do
+      start_sprite("task-sprite-no-instr")
+
+      params = Map.delete(valid_task_params(), "instructions")
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/sprites/task-sprite-no-instr/tasks", params)
+
+      body = json_response(conn, 422)
+
+      assert body["error"] =~ "instructions"
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 422 when instructions is empty string", %{conn: conn} do
+      start_sprite("task-sprite-empty-instr")
+
+      params = Map.put(valid_task_params(), "instructions", "")
+
+      conn =
+        conn
+        |> authenticated()
+        |> post("/api/sprites/task-sprite-empty-instr/tasks", params)
+
+      body = json_response(conn, 422)
+
+      assert body["error"] =~ "instructions"
+      assert body["code"] == "MISSING_FIELD"
+    end
+
+    test "returns 401 without authentication", %{conn: conn} do
+      conn = post(conn, "/api/sprites/any-sprite/tasks", valid_task_params())
+
+      assert json_response(conn, 401)
+    end
+
+    test "created task intent is visible via GET /api/intents", %{conn: conn} do
+      start_sprite("task-sprite-list")
+
+      conn
+      |> authenticated()
+      |> post("/api/sprites/task-sprite-list/tasks", valid_task_params())
+
+      conn =
+        build_conn()
+        |> authenticated()
+        |> get("/api/intents")
+
+      body = json_response(conn, 200)
+
+      assert [_ | _] = body["data"]
+
+      task_intent = Enum.find(body["data"], &(&1["kind"] == "action"))
+      assert task_intent != nil
+      assert task_intent["source"]["type"] == "operator"
+      assert task_intent["source"]["id"] == "api"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `POST /api/sprites/:name/tasks` endpoint in a new `TaskController` for assigning tasks to sprites
- Validate sprite exists (404), required fields repo/task_kind/instructions (422), and auth (401)
- Build Task intent via `Intent.new_task/4` with source `%{type: :operator, id: "api"}`, feed through `Pipeline.propose/1`
- Return response envelope: `{ data: { intent_id, state, classification, sprite_name, repo }, timestamp }`
- Add OpenAPI schemas: `CreateTaskRequest`, `TaskIntentData`, `TaskIntentResponse`
- 12 comprehensive tests covering happy path, validation errors, auth, allowlist auto-approval

Closes #66

## Test plan
- [x] `mix format --check-formatted` passes
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix credo --strict` passes (0 issues)
- [x] `mix test` passes (960 tests, 0 failures)
- [ ] Manual: `POST /api/sprites/:name/tasks` with valid body returns 200 with intent data
- [ ] Manual: Missing sprite returns 404
- [ ] Manual: Missing required fields return 422
- [ ] Manual: Allowlisted repo auto-approves

🤖 Generated with [Claude Code](https://claude.com/claude-code)