### PR TITLE
UI polish: task views with live logs and PR links

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,11 +25,29 @@ import {LiveSocket} from "phoenix_live_view"
 import {hooks as colocatedHooks} from "phoenix-colocated/lattice"
 import topbar from "../vendor/topbar"
 
+// Custom hooks
+const AutoScroll = {
+  mounted() {
+    this._scrollToBottom()
+    this._observer = new MutationObserver(() => this._scrollToBottom())
+    this._observer.observe(this.el, { childList: true, subtree: true })
+  },
+  updated() {
+    this._scrollToBottom()
+  },
+  destroyed() {
+    if (this._observer) this._observer.disconnect()
+  },
+  _scrollToBottom() {
+    this.el.scrollTop = this.el.scrollHeight
+  }
+}
+
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: {...colocatedHooks},
+  hooks: {...colocatedHooks, AutoScroll},
 })
 
 // Show progress bar on live navigation and form submits

--- a/lib/lattice/events.ex
+++ b/lib/lattice/events.ex
@@ -225,6 +225,28 @@ defmodule Lattice.Events do
     Phoenix.PubSub.broadcast(pubsub(), observations_topic(), observation)
   end
 
+  @doc """
+  Broadcast a log line for a specific intent.
+
+  Used during task execution to stream log output to the intent detail
+  LiveView in real time.
+
+  ## Parameters
+
+  - `intent_id` — the intent ID to broadcast the log line for
+  - `line` — the log line content (string)
+  - `opts` — optional metadata:
+    - `:timestamp` — defaults to `DateTime.utc_now()`
+  """
+  @spec broadcast_intent_log(String.t(), String.t(), keyword()) :: :ok
+  def broadcast_intent_log(intent_id, line, opts \\ []) when is_binary(intent_id) do
+    timestamp = Keyword.get(opts, :timestamp, DateTime.utc_now())
+    message = {:intent_log_line, intent_id, line, timestamp}
+
+    Phoenix.PubSub.broadcast(pubsub(), intent_topic(intent_id), message)
+    Phoenix.PubSub.broadcast(pubsub(), intents_all_topic(), message)
+  end
+
   # ── Telemetry ──────────────────────────────────────────────────────
 
   @doc """

--- a/lib/lattice/intents/store.ex
+++ b/lib/lattice/intents/store.ex
@@ -47,6 +47,7 @@ defmodule Lattice.Intents.Store do
   @callback create(Intent.t()) :: {:ok, Intent.t()} | {:error, term()}
   @callback get(String.t()) :: {:ok, Intent.t()} | {:error, :not_found}
   @callback list(filters()) :: {:ok, [Intent.t()]}
+  @callback list_by_sprite(String.t()) :: {:ok, [Intent.t()]}
   @callback update(String.t(), map()) :: {:ok, Intent.t()} | {:error, term()}
   @callback add_artifact(String.t(), map()) :: {:ok, Intent.t()} | {:error, term()}
   @callback get_history(String.t()) :: {:ok, [Intent.transition_entry()]} | {:error, :not_found}
@@ -95,6 +96,18 @@ defmodule Lattice.Intents.Store do
   @spec list(filters()) :: {:ok, [Intent.t()]}
   def list(filters \\ %{}) when is_map(filters) do
     impl().list(filters)
+  end
+
+  @doc """
+  List intents associated with a specific sprite.
+
+  Returns intents where the source is a sprite with the given ID, or where
+  the payload targets the given sprite name. Results are sorted newest-first
+  by `updated_at`.
+  """
+  @spec list_by_sprite(String.t()) :: {:ok, [Intent.t()]}
+  def list_by_sprite(sprite_name) when is_binary(sprite_name) do
+    impl().list_by_sprite(sprite_name)
   end
 
   @doc """

--- a/test/lattice_web/live/sprite_live_show_test.exs
+++ b/test/lattice_web/live/sprite_live_show_test.exs
@@ -8,12 +8,19 @@ defmodule LatticeWeb.SpriteLive.ShowTest do
   alias Lattice.Events.HealthUpdate
   alias Lattice.Events.ReconciliationResult
   alias Lattice.Events.StateChange
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Store, as: IntentStore
   alias Lattice.Sprites.Sprite
 
   @moduletag :unit
 
   setup :set_mox_global
   setup :verify_on_exit!
+
+  setup do
+    IntentStore.ETS.reset()
+    :ok
+  end
 
   # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -109,6 +116,145 @@ defmodule LatticeWeb.SpriteLive.ShowTest do
       assert html =~ "Fleet"
       assert html =~ sprite_id
       assert has_element?(view, "a[href=\"/sprites\"]")
+    end
+
+    test "renders tasks section", %{conn: conn, sprite_id: sprite_id} do
+      {:ok, _view, html} = live(conn, ~p"/sprites/#{sprite_id}")
+
+      assert html =~ "Tasks"
+      assert html =~ "Assign Task"
+      assert html =~ "No tasks for this sprite yet"
+    end
+  end
+
+  # ── Tasks Section ──────────────────────────────────────────────────
+
+  describe "tasks section" do
+    setup do
+      sprite_id = "task-sprite-#{System.unique_integer([:positive])}"
+      start_test_sprite(sprite_id)
+      %{sprite_id: sprite_id}
+    end
+
+    test "shows tasks for this sprite", %{conn: conn, sprite_id: sprite_id} do
+      source = %{type: :sprite, id: sprite_id}
+
+      {:ok, task} =
+        Intent.new_task(source, sprite_id, "owner/repo",
+          task_kind: "open_pr",
+          instructions: "Do work"
+        )
+
+      {:ok, _stored} = IntentStore.create(task)
+
+      {:ok, _view, html} = live(conn, ~p"/sprites/#{sprite_id}")
+
+      assert html =~ "open_pr"
+      assert html =~ "owner/repo"
+    end
+
+    test "links tasks to intent detail view", %{conn: conn, sprite_id: sprite_id} do
+      source = %{type: :sprite, id: sprite_id}
+
+      {:ok, task} =
+        Intent.new_task(source, sprite_id, "owner/repo",
+          task_kind: "open_pr",
+          instructions: "Do work"
+        )
+
+      {:ok, stored} = IntentStore.create(task)
+
+      {:ok, view, _html} = live(conn, ~p"/sprites/#{sprite_id}")
+
+      assert has_element?(view, "a[href='/intents/#{stored.id}']", "View")
+    end
+  end
+
+  # ── Assign Task Form ──────────────────────────────────────────────
+
+  describe "assign task form" do
+    setup do
+      sprite_id = "form-sprite-#{System.unique_integer([:positive])}"
+      start_test_sprite(sprite_id)
+      %{sprite_id: sprite_id}
+    end
+
+    test "shows task form when Assign Task is clicked", %{conn: conn, sprite_id: sprite_id} do
+      {:ok, view, _html} = live(conn, ~p"/sprites/#{sprite_id}")
+
+      html = render_click(view, "show_task_form")
+
+      assert html =~ "Repository"
+      assert html =~ "Task Kind"
+      assert html =~ "Instructions"
+    end
+
+    test "hides task form when Cancel is clicked", %{conn: conn, sprite_id: sprite_id} do
+      {:ok, view, _html} = live(conn, ~p"/sprites/#{sprite_id}")
+
+      render_click(view, "show_task_form")
+      html = render_click(view, "hide_task_form")
+
+      assert html =~ "Assign Task"
+      refute html =~ "Repository *"
+    end
+
+    test "submits task and hides form", %{conn: conn, sprite_id: sprite_id} do
+      {:ok, view, _html} = live(conn, ~p"/sprites/#{sprite_id}")
+
+      render_click(view, "show_task_form")
+
+      render_submit(view, "submit_task", %{
+        "task" => %{
+          "repo" => "owner/test-repo",
+          "task_kind" => "open_pr",
+          "instructions" => "Add a README"
+        }
+      })
+
+      html = render(view)
+
+      # Form should be hidden after successful submission
+      assert html =~ "Assign Task"
+      refute html =~ "Instructions *"
+
+      # Task should appear in the tasks list
+      assert html =~ "owner/test-repo"
+      assert html =~ "open_pr"
+    end
+
+    test "keeps form visible when required fields are missing", %{
+      conn: conn,
+      sprite_id: sprite_id
+    } do
+      {:ok, view, _html} = live(conn, ~p"/sprites/#{sprite_id}")
+
+      render_click(view, "show_task_form")
+
+      render_submit(view, "submit_task", %{
+        "task" => %{
+          "repo" => "",
+          "task_kind" => "open_pr",
+          "instructions" => "Do work"
+        }
+      })
+
+      html = render(view)
+
+      # Form should still be visible (submission failed validation)
+      assert html =~ "Repository *"
+      assert html =~ "Instructions *"
+
+      # The "Assign Task" submit button should still be in the form
+      assert has_element?(view, "button[type='submit']", "Assign Task")
+    end
+
+    test "sprite name is pre-filled in the form", %{conn: conn, sprite_id: sprite_id} do
+      {:ok, view, _html} = live(conn, ~p"/sprites/#{sprite_id}")
+
+      html = render_click(view, "show_task_form")
+
+      assert html =~ sprite_id
     end
   end
 
@@ -229,6 +375,30 @@ defmodule LatticeWeb.SpriteLive.ShowTest do
 
       html = render(view)
       assert html =~ sprite_id
+    end
+
+    test "refreshes tasks on intent_created broadcast",
+         %{conn: conn, sprite_id: sprite_id} do
+      source = %{type: :sprite, id: sprite_id}
+
+      {:ok, task} =
+        Intent.new_task(source, sprite_id, "owner/repo",
+          task_kind: "open_pr",
+          instructions: "Do work"
+        )
+
+      {:ok, stored} = IntentStore.create(task)
+
+      {:ok, view, _html} = live(conn, ~p"/sprites/#{sprite_id}")
+
+      Phoenix.PubSub.broadcast(
+        Lattice.PubSub,
+        Events.intents_topic(),
+        {:intent_created, stored}
+      )
+
+      html = render(view)
+      assert html =~ "open_pr"
     end
   end
 


### PR DESCRIPTION
## Summary
- Extends **IntentLive.Show** with task details panel, live log streaming (PubSub-driven with auto-scroll), PR URL artifact display, and execution duration
- Adds **Tasks section** to SpriteLive.Show showing active/recent tasks for the sprite, with an "Assign Task" quick-action form (pre-fills sprite name, accepts repo, task kind, instructions)
- Adds **task_kind filter** to IntentsLive list view (only shown when task intents exist)
- Adds `Store.list_by_sprite/1` callback and ETS implementation for querying intents by sprite
- Adds `Events.broadcast_intent_log/3` for streaming log lines to intent detail LiveView
- Adds `AutoScroll` JS hook for terminal-style auto-scrolling log container

## Test plan
- [x] 26 sprite detail tests pass (including 7 new: tasks display, task linking, form show/hide/submit/validation, sprite name pre-fill, PubSub task refresh)
- [x] 24 intents list tests pass (including 2 new: task_kind filter, conditional filter visibility)
- [x] 25 intent detail tests pass (including 5 new: live log panel visibility, log line reception, log accumulation, execution duration, PR URL artifact)
- [x] Full suite: 990 tests, 0 failures
- [x] `mix format` clean
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo --strict` — no issues

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)