### PR TITLE
Integrate runtime protocol states into intent lifecycle (#126)

### DIFF
--- a/lib/lattice/application.ex
+++ b/lib/lattice/application.ex
@@ -27,6 +27,8 @@ defmodule Lattice.Application do
       Lattice.Store.ETS,
       # Intent persistence
       Lattice.Intents.Store.ETS,
+      # Bridge Run lifecycle events to Intent state transitions
+      Lattice.Intents.RunBridge,
       # Sprite process infrastructure
       {Registry, keys: :unique, name: Lattice.Sprites.Registry},
       {DynamicSupervisor, name: Lattice.Sprites.DynamicSupervisor, strategy: :one_for_one},

--- a/lib/lattice/events.ex
+++ b/lib/lattice/events.ex
@@ -320,6 +320,42 @@ defmodule Lattice.Events do
     Phoenix.PubSub.broadcast(pubsub(), runs_topic(), {:run_failed, run})
   end
 
+  @doc """
+  Emit an intent blocked event.
+
+  Fires a `[:lattice, :intent, :blocked]` Telemetry event and broadcasts
+  `{:intent_blocked, intent}` on the intent-specific and all-intents topics.
+  """
+  @spec emit_intent_blocked(Lattice.Intents.Intent.t()) :: :ok
+  def emit_intent_blocked(%Lattice.Intents.Intent{} = intent) do
+    :telemetry.execute(
+      [:lattice, :intent, :blocked],
+      %{system_time: System.system_time()},
+      %{intent: intent, blocked_reason: intent.blocked_reason}
+    )
+
+    Phoenix.PubSub.broadcast(pubsub(), intent_topic(intent.id), {:intent_blocked, intent})
+    Phoenix.PubSub.broadcast(pubsub(), intents_all_topic(), {:intent_blocked, intent})
+  end
+
+  @doc """
+  Emit an intent resumed event.
+
+  Fires a `[:lattice, :intent, :resumed]` Telemetry event and broadcasts
+  `{:intent_resumed, intent}` on the intent-specific and all-intents topics.
+  """
+  @spec emit_intent_resumed(Lattice.Intents.Intent.t()) :: :ok
+  def emit_intent_resumed(%Lattice.Intents.Intent{} = intent) do
+    :telemetry.execute(
+      [:lattice, :intent, :resumed],
+      %{system_time: System.system_time()},
+      %{intent: intent}
+    )
+
+    Phoenix.PubSub.broadcast(pubsub(), intent_topic(intent.id), {:intent_resumed, intent})
+    Phoenix.PubSub.broadcast(pubsub(), intents_all_topic(), {:intent_resumed, intent})
+  end
+
   @doc "Broadcast a log line to a sprite's logs topic."
   @spec broadcast_sprite_log(String.t(), map()) :: :ok
   def broadcast_sprite_log(sprite_id, log_line) when is_binary(sprite_id) and is_map(log_line) do

--- a/lib/lattice/intents/intent.ex
+++ b/lib/lattice/intents/intent.ex
@@ -31,6 +31,8 @@ defmodule Lattice.Intents.Intent do
           | :awaiting_approval
           | :approved
           | :running
+          | :blocked
+          | :waiting_for_input
           | :completed
           | :failed
           | :rejected
@@ -64,7 +66,11 @@ defmodule Lattice.Intents.Intent do
           classified_at: DateTime.t() | nil,
           approved_at: DateTime.t() | nil,
           started_at: DateTime.t() | nil,
-          completed_at: DateTime.t() | nil
+          completed_at: DateTime.t() | nil,
+          blocked_at: DateTime.t() | nil,
+          resumed_at: DateTime.t() | nil,
+          blocked_reason: String.t() | nil,
+          pending_question: map() | nil
         }
 
   @enforce_keys [:id, :kind, :state, :source, :summary, :payload, :inserted_at, :updated_at]
@@ -80,6 +86,10 @@ defmodule Lattice.Intents.Intent do
     :approved_at,
     :started_at,
     :completed_at,
+    :blocked_at,
+    :resumed_at,
+    :blocked_reason,
+    :pending_question,
     :inserted_at,
     :updated_at,
     classification: nil,

--- a/lib/lattice/intents/run_bridge.ex
+++ b/lib/lattice/intents/run_bridge.ex
@@ -1,0 +1,142 @@
+defmodule Lattice.Intents.RunBridge do
+  @moduledoc """
+  Bridges Run lifecycle events to Intent state transitions.
+
+  Subscribes to the `"runs"` PubSub topic and, when a run enters a blocked
+  state or resumes, propagates that state change to the parent intent.
+  This keeps Run and Intent decoupled — the bridge is an observer process.
+
+  ## Event Mapping
+
+  - `{:run_blocked, %Run{status: :blocked}}` → Intent transitions to `:blocked`
+  - `{:run_blocked, %Run{status: :blocked_waiting_for_user}}` → Intent transitions to `:waiting_for_input`
+  - `{:run_resumed, %Run{}}` → Intent transitions back to `:running`
+  """
+
+  use GenServer
+  require Logger
+
+  alias Lattice.Events
+  alias Lattice.Intents.Store
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    Events.subscribe_runs()
+    {:ok, %{}}
+  end
+
+  # ── Run Blocked Events ──────────────────────────────────────────────
+
+  @impl GenServer
+  def handle_info({:run_blocked, %{intent_id: nil}}, state), do: {:noreply, state}
+
+  def handle_info({:run_blocked, %{intent_id: intent_id, status: :blocked} = run}, state) do
+    transition_intent_to_blocked(intent_id, run.blocked_reason)
+    {:noreply, state}
+  end
+
+  def handle_info(
+        {:run_blocked, %{intent_id: intent_id, status: :blocked_waiting_for_user} = run},
+        state
+      ) do
+    transition_intent_to_waiting(intent_id, run.question)
+    {:noreply, state}
+  end
+
+  # ── Run Resumed Events ─────────────────────────────────────────────
+
+  def handle_info({:run_resumed, %{intent_id: nil}}, state), do: {:noreply, state}
+
+  def handle_info({:run_resumed, %{intent_id: intent_id}}, state) do
+    transition_intent_to_running(intent_id)
+    {:noreply, state}
+  end
+
+  # Ignore all other messages
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # ── Private ─────────────────────────────────────────────────────────
+
+  defp transition_intent_to_blocked(intent_id, reason) do
+    with {:ok, intent} <- Store.get(intent_id),
+         true <- intent.state == :running do
+      case Store.update(intent_id, %{
+             state: :blocked,
+             blocked_reason: reason,
+             actor: :run_bridge,
+             reason: "run blocked: #{reason || "unknown"}"
+           }) do
+        {:ok, updated} ->
+          Events.emit_intent_blocked(updated)
+
+        {:error, err} ->
+          Logger.warning("RunBridge: failed to block intent #{intent_id}: #{inspect(err)}")
+      end
+    else
+      {:error, :not_found} ->
+        Logger.debug("RunBridge: intent #{intent_id} not found, ignoring block event")
+
+      false ->
+        Logger.debug("RunBridge: intent #{intent_id} not in :running state, ignoring block event")
+    end
+  end
+
+  defp transition_intent_to_waiting(intent_id, question) do
+    with {:ok, intent} <- Store.get(intent_id),
+         true <- intent.state == :running do
+      case Store.update(intent_id, %{
+             state: :waiting_for_input,
+             pending_question: question,
+             actor: :run_bridge,
+             reason: "run waiting for user input"
+           }) do
+        {:ok, updated} ->
+          Events.emit_intent_blocked(updated)
+
+        {:error, err} ->
+          Logger.warning(
+            "RunBridge: failed to set intent #{intent_id} to waiting_for_input: #{inspect(err)}"
+          )
+      end
+    else
+      {:error, :not_found} ->
+        Logger.debug("RunBridge: intent #{intent_id} not found, ignoring block_for_input event")
+
+      false ->
+        Logger.debug(
+          "RunBridge: intent #{intent_id} not in :running state, ignoring block_for_input event"
+        )
+    end
+  end
+
+  defp transition_intent_to_running(intent_id) do
+    with {:ok, intent} <- Store.get(intent_id),
+         true <- intent.state in [:blocked, :waiting_for_input] do
+      case Store.update(intent_id, %{
+             state: :running,
+             blocked_reason: nil,
+             pending_question: nil,
+             actor: :run_bridge,
+             reason: "run resumed"
+           }) do
+        {:ok, updated} ->
+          Events.emit_intent_resumed(updated)
+
+        {:error, err} ->
+          Logger.warning("RunBridge: failed to resume intent #{intent_id}: #{inspect(err)}")
+      end
+    else
+      {:error, :not_found} ->
+        Logger.debug("RunBridge: intent #{intent_id} not found, ignoring resume event")
+
+      false ->
+        Logger.debug(
+          "RunBridge: intent #{intent_id} not in blocked/waiting state, ignoring resume event"
+        )
+    end
+  end
+end

--- a/lib/lattice/intents/store/ets.ex
+++ b/lib/lattice/intents/store/ets.ex
@@ -30,7 +30,16 @@ defmodule Lattice.Intents.Store.ETS do
 
   @table_name :lattice_intents
   @frozen_fields [:payload, :affected_resources, :expected_side_effects, :rollback_strategy]
-  @post_approval_states [:approved, :running, :completed, :failed, :rejected, :canceled]
+  @post_approval_states [
+    :approved,
+    :running,
+    :blocked,
+    :waiting_for_input,
+    :completed,
+    :failed,
+    :rejected,
+    :canceled
+  ]
 
   # ── Client API ──────────────────────────────────────────────────────
 
@@ -255,6 +264,8 @@ defmodule Lattice.Intents.Store.ETS do
         {:affected_resources, value}, acc -> %{acc | affected_resources: value}
         {:expected_side_effects, value}, acc -> %{acc | expected_side_effects: value}
         {:rollback_strategy, value}, acc -> %{acc | rollback_strategy: value}
+        {:blocked_reason, value}, acc -> %{acc | blocked_reason: value}
+        {:pending_question, value}, acc -> %{acc | pending_question: value}
         _unknown, acc -> acc
       end)
       |> Map.put(:updated_at, now)

--- a/lib/lattice_web/controllers/api/intent_controller.ex
+++ b/lib/lattice_web/controllers/api/intent_controller.ex
@@ -18,7 +18,7 @@ defmodule LatticeWeb.Api.IntentController do
   security([%{"BearerAuth" => []}])
 
   @valid_kinds ~w(action inquiry maintenance)
-  @valid_filter_states ~w(proposed classified awaiting_approval approved running completed failed rejected canceled)
+  @valid_filter_states ~w(proposed classified awaiting_approval approved running blocked waiting_for_input completed failed rejected canceled)
   @valid_source_types ~w(sprite agent cron operator)
 
   # ── GET /api/intents ───────────────────────────────────────────────
@@ -46,6 +46,8 @@ defmodule LatticeWeb.Api.IntentController do
             "awaiting_approval",
             "approved",
             "running",
+            "blocked",
+            "waiting_for_input",
             "completed",
             "failed",
             "rejected",
@@ -521,7 +523,11 @@ defmodule LatticeWeb.Api.IntentController do
       classified_at: intent.classified_at,
       approved_at: intent.approved_at,
       started_at: intent.started_at,
-      completed_at: intent.completed_at
+      completed_at: intent.completed_at,
+      blocked_at: intent.blocked_at,
+      resumed_at: intent.resumed_at,
+      blocked_reason: intent.blocked_reason,
+      pending_question: intent.pending_question
     }
   end
 

--- a/lib/lattice_web/live/intent_live/show.ex
+++ b/lib/lattice_web/live/intent_live/show.ex
@@ -106,6 +106,14 @@ defmodule LatticeWeb.IntentLive.Show do
     {:noreply, refresh_intent(socket)}
   end
 
+  def handle_info({:intent_blocked, %Intent{id: id}}, %{assigns: %{intent_id: id}} = socket) do
+    {:noreply, refresh_intent(socket)}
+  end
+
+  def handle_info({:intent_resumed, %Intent{id: id}}, %{assigns: %{intent_id: id}} = socket) do
+    {:noreply, refresh_intent(socket)}
+  end
+
   def handle_info(
         {:intent_log_line, id, line, timestamp},
         %{assigns: %{intent_id: id}} = socket
@@ -206,6 +214,11 @@ defmodule LatticeWeb.IntentLive.Show do
 
         <.action_buttons intent={@intent} />
 
+        <.blocking_context_panel
+          :if={@intent.state in [:blocked, :waiting_for_input]}
+          intent={@intent}
+        />
+
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <.intent_details_panel intent={@intent} />
           <.classification_panel intent={@intent} />
@@ -292,6 +305,71 @@ defmodule LatticeWeb.IntentLive.Show do
       >
         <.icon name="hero-no-symbol" class="size-4" /> Cancel
       </button>
+    </div>
+    """
+  end
+
+  attr :intent, Intent, required: true
+
+  defp blocking_context_panel(assigns) do
+    ~H"""
+    <div class={[
+      "card shadow-sm",
+      if(@intent.state == :waiting_for_input,
+        do: "bg-error/10 border border-error/30",
+        else: "bg-warning/10 border border-warning/30"
+      )
+    ]}>
+      <div class="card-body">
+        <h2 class="card-title text-base">
+          <.icon
+            name={
+              if(@intent.state == :waiting_for_input,
+                do: "hero-question-mark-circle",
+                else: "hero-pause-circle"
+              )
+            }
+            class="size-5"
+          />
+          {if @intent.state == :waiting_for_input, do: "Waiting for Input", else: "Blocked"}
+        </h2>
+
+        <div :if={@intent.blocked_reason} class="mt-2">
+          <div class="text-xs font-medium text-base-content/60 uppercase tracking-wide mb-1">
+            Reason
+          </div>
+          <p class="text-sm">{@intent.blocked_reason}</p>
+        </div>
+
+        <div :if={@intent.pending_question} class="mt-2">
+          <div class="text-xs font-medium text-base-content/60 uppercase tracking-wide mb-1">
+            Question
+          </div>
+          <p class="text-sm font-medium">
+            {Map.get(
+              @intent.pending_question,
+              "prompt",
+              Map.get(@intent.pending_question, :prompt, "")
+            )}
+          </p>
+
+          <div
+            :if={question_choices(@intent.pending_question) != []}
+            class="mt-2 flex flex-wrap gap-2"
+          >
+            <span
+              :for={choice <- question_choices(@intent.pending_question)}
+              class="badge badge-sm badge-outline"
+            >
+              {choice}
+            </span>
+          </div>
+        </div>
+
+        <div :if={@intent.blocked_at} class="mt-3 text-xs text-base-content/50">
+          Blocked since <.relative_time datetime={@intent.blocked_at} />
+        </div>
+      </div>
     </div>
     """
   end
@@ -538,11 +616,13 @@ defmodule LatticeWeb.IntentLive.Show do
 
   defp live_log_panel(assigns) do
     is_running = assigns.intent.state == :running
+    is_blocked = assigns.intent.state in [:blocked, :waiting_for_input]
     is_terminal = assigns.intent.state in [:completed, :failed, :canceled, :rejected]
 
     assigns =
       assigns
       |> assign(:is_running, is_running)
+      |> assign(:is_blocked, is_blocked)
       |> assign(:is_terminal, is_terminal)
 
     ~H"""
@@ -551,6 +631,7 @@ defmodule LatticeWeb.IntentLive.Show do
         <h2 class="card-title text-base">
           <.icon name="hero-document-text" class="size-5" /> Live Logs
           <span :if={@is_running} class="loading loading-spinner loading-xs ml-2"></span>
+          <.intent_state_badge :if={@is_blocked} state={@intent.state} />
           <.intent_state_badge :if={@is_terminal} state={@intent.state} />
         </h2>
 
@@ -805,6 +886,12 @@ defmodule LatticeWeb.IntentLive.Show do
     :erlang.phash2({entry.from, entry.to, entry.timestamp})
   end
 
+  defp question_choices(nil), do: []
+
+  defp question_choices(question) when is_map(question) do
+    Map.get(question, "choices", Map.get(question, :choices, []))
+  end
+
   defp execution_duration(%Intent{started_at: nil}), do: nil
 
   defp execution_duration(%Intent{started_at: started_at, completed_at: nil}) do
@@ -834,6 +921,8 @@ defmodule LatticeWeb.IntentLive.Show do
   defp intent_state_color(:awaiting_approval), do: "badge-warning"
   defp intent_state_color(:approved), do: "badge-success"
   defp intent_state_color(:running), do: "badge-info"
+  defp intent_state_color(:blocked), do: "badge-warning"
+  defp intent_state_color(:waiting_for_input), do: "badge-error"
   defp intent_state_color(:completed), do: "badge-success"
   defp intent_state_color(:failed), do: "badge-error"
   defp intent_state_color(:rejected), do: "badge-error"

--- a/lib/lattice_web/live/intents_live.ex
+++ b/lib/lattice_web/live/intents_live.ex
@@ -79,6 +79,14 @@ defmodule LatticeWeb.IntentsLive do
     {:noreply, assign_intents(socket)}
   end
 
+  def handle_info({:intent_blocked, _intent}, socket) do
+    {:noreply, assign_intents(socket)}
+  end
+
+  def handle_info({:intent_resumed, _intent}, socket) do
+    {:noreply, assign_intents(socket)}
+  end
+
   def handle_info(:refresh, socket) do
     schedule_refresh()
     {:noreply, assign_intents(socket)}
@@ -521,6 +529,8 @@ defmodule LatticeWeb.IntentsLive do
   defp intent_state_color(:awaiting_approval), do: "badge-warning"
   defp intent_state_color(:approved), do: "badge-success"
   defp intent_state_color(:running), do: "badge-info"
+  defp intent_state_color(:blocked), do: "badge-warning"
+  defp intent_state_color(:waiting_for_input), do: "badge-error"
   defp intent_state_color(:completed), do: "badge-success"
   defp intent_state_color(:failed), do: "badge-error"
   defp intent_state_color(:rejected), do: "badge-error"
@@ -539,6 +549,8 @@ defmodule LatticeWeb.IntentsLive do
 
   defp sorted_state_counts(by_state) do
     order = [
+      :waiting_for_input,
+      :blocked,
       :awaiting_approval,
       :running,
       :approved,

--- a/test/lattice/intents/run_bridge_test.exs
+++ b/test/lattice/intents/run_bridge_test.exs
@@ -1,0 +1,226 @@
+defmodule Lattice.Intents.RunBridgeTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Events
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Store
+  alias Lattice.Intents.Store.ETS, as: StoreETS
+
+  @valid_source %{type: :sprite, id: "sprite-001"}
+
+  setup do
+    StoreETS.reset()
+    :ok
+  end
+
+  defp create_running_intent do
+    {:ok, intent} =
+      Intent.new_action(@valid_source,
+        summary: "Test action",
+        payload: %{"target" => "prod"},
+        affected_resources: ["fly-app-1"],
+        expected_side_effects: ["app restarted"]
+      )
+
+    {:ok, _} = Store.create(intent)
+    {:ok, _} = Store.update(intent.id, %{state: :classified})
+    {:ok, _} = Store.update(intent.id, %{state: :approved})
+    {:ok, _} = Store.update(intent.id, %{state: :running})
+    {:ok, running} = Store.get(intent.id)
+    running
+  end
+
+  describe "run_blocked → intent blocked" do
+    test "transitions intent to :blocked when run blocks" do
+      intent = create_running_intent()
+
+      run = %{
+        intent_id: intent.id,
+        status: :blocked,
+        blocked_reason: "missing credentials"
+      }
+
+      Phoenix.PubSub.broadcast(Lattice.PubSub, Events.runs_topic(), {:run_blocked, run})
+
+      # Give the RunBridge time to process
+      Process.sleep(50)
+
+      {:ok, updated} = Store.get(intent.id)
+      assert updated.state == :blocked
+      assert updated.blocked_reason == "missing credentials"
+      assert %DateTime{} = updated.blocked_at
+    end
+
+    test "transitions intent to :waiting_for_input when run blocks for user" do
+      intent = create_running_intent()
+
+      question = %{
+        "prompt" => "Which database adapter?",
+        "choices" => ["Ecto.Multi", "separate transactions"],
+        "default" => "Ecto.Multi"
+      }
+
+      run = %{
+        intent_id: intent.id,
+        status: :blocked_waiting_for_user,
+        question: question
+      }
+
+      Phoenix.PubSub.broadcast(Lattice.PubSub, Events.runs_topic(), {:run_blocked, run})
+
+      Process.sleep(50)
+
+      {:ok, updated} = Store.get(intent.id)
+      assert updated.state == :waiting_for_input
+      assert updated.pending_question == question
+    end
+
+    test "ignores run_blocked when intent_id is nil" do
+      run = %{intent_id: nil, status: :blocked, blocked_reason: "test"}
+
+      Phoenix.PubSub.broadcast(Lattice.PubSub, Events.runs_topic(), {:run_blocked, run})
+
+      Process.sleep(50)
+      # No crash, bridge continues
+    end
+
+    test "ignores run_blocked when intent is not in :running state" do
+      {:ok, intent} =
+        Intent.new_maintenance(@valid_source, summary: "Test", payload: %{})
+
+      {:ok, _} = Store.create(intent)
+
+      run = %{intent_id: intent.id, status: :blocked, blocked_reason: "test"}
+
+      Phoenix.PubSub.broadcast(Lattice.PubSub, Events.runs_topic(), {:run_blocked, run})
+
+      Process.sleep(50)
+
+      {:ok, still_proposed} = Store.get(intent.id)
+      assert still_proposed.state == :proposed
+    end
+  end
+
+  describe "run_resumed → intent resumed" do
+    test "transitions intent back to :running from :blocked" do
+      intent = create_running_intent()
+
+      # First block it
+      {:ok, _} =
+        Store.update(intent.id, %{
+          state: :blocked,
+          blocked_reason: "test block",
+          actor: :test
+        })
+
+      run = %{intent_id: intent.id}
+
+      Phoenix.PubSub.broadcast(Lattice.PubSub, Events.runs_topic(), {:run_resumed, run})
+
+      Process.sleep(50)
+
+      {:ok, updated} = Store.get(intent.id)
+      assert updated.state == :running
+      assert updated.blocked_reason == nil
+      assert updated.pending_question == nil
+      assert %DateTime{} = updated.resumed_at
+    end
+
+    test "transitions intent back to :running from :waiting_for_input" do
+      intent = create_running_intent()
+
+      # First set to waiting
+      {:ok, _} =
+        Store.update(intent.id, %{
+          state: :waiting_for_input,
+          pending_question: %{"prompt" => "test?"},
+          actor: :test
+        })
+
+      run = %{intent_id: intent.id}
+
+      Phoenix.PubSub.broadcast(Lattice.PubSub, Events.runs_topic(), {:run_resumed, run})
+
+      Process.sleep(50)
+
+      {:ok, updated} = Store.get(intent.id)
+      assert updated.state == :running
+      assert updated.blocked_reason == nil
+      assert updated.pending_question == nil
+    end
+
+    test "ignores run_resumed when intent_id is nil" do
+      run = %{intent_id: nil}
+
+      Phoenix.PubSub.broadcast(Lattice.PubSub, Events.runs_topic(), {:run_resumed, run})
+
+      Process.sleep(50)
+      # No crash, bridge continues
+    end
+
+    test "ignores run_resumed when intent is not blocked" do
+      intent = create_running_intent()
+
+      run = %{intent_id: intent.id}
+
+      Phoenix.PubSub.broadcast(Lattice.PubSub, Events.runs_topic(), {:run_resumed, run})
+
+      Process.sleep(50)
+
+      {:ok, still_running} = Store.get(intent.id)
+      assert still_running.state == :running
+    end
+  end
+
+  describe "telemetry events" do
+    setup do
+      test_pid = self()
+      ref = make_ref()
+      handler_id = "run-bridge-telemetry-#{inspect(ref)}"
+
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:lattice, :intent, :blocked],
+          [:lattice, :intent, :resumed]
+        ],
+        fn event_name, _measurements, metadata, _config ->
+          send(test_pid, {:telemetry, ref, event_name, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+      %{ref: ref}
+    end
+
+    test "emits [:lattice, :intent, :blocked] on block", %{ref: ref} do
+      intent = create_running_intent()
+
+      run = %{intent_id: intent.id, status: :blocked, blocked_reason: "test"}
+      Phoenix.PubSub.broadcast(Lattice.PubSub, Events.runs_topic(), {:run_blocked, run})
+
+      assert_receive {:telemetry, ^ref, [:lattice, :intent, :blocked], metadata}, 500
+      assert metadata.intent.id == intent.id
+    end
+
+    test "emits [:lattice, :intent, :resumed] on resume", %{ref: ref} do
+      intent = create_running_intent()
+
+      {:ok, _} =
+        Store.update(intent.id, %{
+          state: :blocked,
+          blocked_reason: "test",
+          actor: :test
+        })
+
+      run = %{intent_id: intent.id}
+      Phoenix.PubSub.broadcast(Lattice.PubSub, Events.runs_topic(), {:run_resumed, run})
+
+      assert_receive {:telemetry, ^ref, [:lattice, :intent, :resumed], metadata}, 500
+      assert metadata.intent.id == intent.id
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `:blocked` and `:waiting_for_input` states to the intent lifecycle state machine so operators see accurate execution state in the dashboard instead of a misleading "running" when a sprite is paused
- Creates a `RunBridge` GenServer that subscribes to `"runs"` PubSub and propagates blocked/resumed state changes from Run to parent Intent (decoupled via PubSub per PHILOSOPHY.md)
- Updates the intents dashboard and detail views with a blocking context panel showing the reason/question, badge colors for new states, and paused indicators in the live log panel

## Changes

| File | Change |
|------|--------|
| `lib/lattice/intents/intent.ex` | Add `blocked_at`, `resumed_at`, `blocked_reason`, `pending_question` fields and `:blocked`/`:waiting_for_input` state types |
| `lib/lattice/intents/lifecycle.ex` | Extend `@transitions` map with new states and 4-arity `put_lifecycle_timestamp` to track `from_state` |
| `lib/lattice/intents/store/ets.ex` | Add new fields to `apply_field_updates` and include new states in `@post_approval_states` |
| `lib/lattice/events.ex` | Add `emit_intent_blocked/1` and `emit_intent_resumed/1` |
| `lib/lattice/intents/run_bridge.ex` | **New** — GenServer bridging Run → Intent blocked state via PubSub |
| `lib/lattice/application.ex` | Add `RunBridge` to supervision tree |
| `lib/lattice_web/controllers/api/intent_controller.ex` | Add new states to filters, OpenAPI schema, and detail serialization |
| `lib/lattice_web/live/intents_live.ex` | Add event handlers and badge colors for blocked/waiting states |
| `lib/lattice_web/live/intent_live/show.ex` | Add blocking context panel, paused indicators, badge colors |
| `test/lattice/intents/lifecycle_test.exs` | 27 new tests for blocked state transitions and timestamps |
| `test/lattice/intents/run_bridge_test.exs` | **New** — integration tests for RunBridge PubSub propagation |

## Test plan

- [x] All 1230 tests pass (0 failures)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] Lifecycle tests cover all new transitions (running↔blocked, running↔waiting_for_input, blocked→canceled/failed)
- [x] RunBridge tests verify PubSub event propagation and edge cases (nil intent_id, wrong state)
- [x] Telemetry tests verify `[:lattice, :intent, :blocked]` and `[:lattice, :intent, :resumed]` events

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)