### PR TITLE
Add webhook-driven intent creation (#127)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,6 +32,11 @@ config :lattice, :guardrails,
 # Task allowlist — repos that auto-approve task intents
 config :lattice, :task_allowlist, auto_approve_repos: []
 
+# Webhook configuration
+config :lattice, :webhooks,
+  github_secret: nil,
+  dedup_ttl_ms: :timer.minutes(5)
+
 # Configure the endpoint
 config :lattice, LatticeWeb.Endpoint,
   url: [host: "localhost"],
@@ -103,7 +108,9 @@ config :logger, :default_formatter,
     :source,
     :from,
     :to,
-    :artifact_type
+    :artifact_type,
+    :event_type,
+    :delivery_id
   ]
 
 # Use Jason for JSON parsing in Phoenix

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -53,6 +53,13 @@ capabilities =
 
 config :lattice, :capabilities, capabilities
 
+# Webhook secret for GitHub HMAC-SHA256 signature verification
+if github_webhook_secret = System.get_env("GITHUB_WEBHOOK_SECRET") do
+  config :lattice, :webhooks,
+    github_secret: github_webhook_secret,
+    dedup_ttl_ms: :timer.minutes(5)
+end
+
 # Auth provider: use Clerk when secret key is configured, otherwise stub
 if System.get_env("CLERK_SECRET_KEY") do
   config :lattice, :auth, provider: Lattice.Auth.Clerk

--- a/config/test.exs
+++ b/config/test.exs
@@ -35,3 +35,8 @@ config :lattice, :auth, provider: Lattice.Auth.Stub
 
 # Empty fleet in tests — individual tests configure their own sprites
 config :lattice, :fleet, sprites: []
+
+# Test webhook secret for HMAC signature verification
+config :lattice, :webhooks,
+  github_secret: "test-webhook-secret",
+  dedup_ttl_ms: :timer.minutes(5)

--- a/lib/lattice/application.ex
+++ b/lib/lattice/application.ex
@@ -29,6 +29,8 @@ defmodule Lattice.Application do
       Lattice.Intents.Store.ETS,
       # Bridge Run lifecycle events to Intent state transitions
       Lattice.Intents.RunBridge,
+      # Webhook deduplication (ETS-backed with TTL sweep)
+      Lattice.Webhooks.Dedup,
       # Sprite process infrastructure
       {Registry, keys: :unique, name: Lattice.Sprites.Registry},
       {DynamicSupervisor, name: Lattice.Sprites.DynamicSupervisor, strategy: :one_for_one},

--- a/lib/lattice/events/telemetry_handler.ex
+++ b/lib/lattice/events/telemetry_handler.ex
@@ -42,7 +42,9 @@ defmodule Lattice.Events.TelemetryHandler do
     [:lattice, :observation, :emitted],
     [:lattice, :intent, :created],
     [:lattice, :intent, :transitioned],
-    [:lattice, :intent, :artifact_added]
+    [:lattice, :intent, :artifact_added],
+    [:lattice, :webhook, :received],
+    [:lattice, :webhook, :intent_proposed]
   ]
 
   @doc """
@@ -252,6 +254,33 @@ defmodule Lattice.Events.TelemetryHandler do
       "Artifact added to intent: #{intent.id}",
       intent_id: intent.id,
       artifact_type: Map.get(artifact, :type, :unknown)
+    )
+  end
+
+  def handle_event(
+        [:lattice, :webhook, :received],
+        _measurements,
+        %{event_type: event_type, delivery_id: delivery_id},
+        _config
+      ) do
+    Logger.info(
+      "Webhook received: #{event_type}",
+      event_type: event_type,
+      delivery_id: delivery_id
+    )
+  end
+
+  def handle_event(
+        [:lattice, :webhook, :intent_proposed],
+        _measurements,
+        %{event_type: event_type, intent: intent},
+        _config
+      ) do
+    Logger.info(
+      "Webhook proposed intent: #{intent.id} (#{event_type})",
+      intent_id: intent.id,
+      event_type: event_type,
+      kind: intent.kind
     )
   end
 end

--- a/lib/lattice/intents/intent.ex
+++ b/lib/lattice/intents/intent.ex
@@ -22,7 +22,7 @@ defmodule Lattice.Intents.Intent do
   """
 
   @valid_kinds [:action, :inquiry, :maintenance]
-  @valid_source_types [:sprite, :agent, :cron, :operator]
+  @valid_source_types [:sprite, :agent, :cron, :operator, :webhook]
 
   @type kind :: :action | :inquiry | :maintenance
   @type state ::
@@ -38,7 +38,7 @@ defmodule Lattice.Intents.Intent do
           | :rejected
           | :canceled
   @type classification :: :safe | :controlled | :dangerous | nil
-  @type source :: %{type: :sprite | :agent | :cron | :operator, id: String.t()}
+  @type source :: %{type: :sprite | :agent | :cron | :operator | :webhook, id: String.t()}
   @type transition_entry :: %{
           from: state(),
           to: state(),

--- a/lib/lattice/webhooks/dedup.ex
+++ b/lib/lattice/webhooks/dedup.ex
@@ -1,0 +1,97 @@
+defmodule Lattice.Webhooks.Dedup do
+  @moduledoc """
+  ETS-backed webhook event deduplication.
+
+  Tracks delivery IDs from the `X-GitHub-Delivery` header to prevent
+  double-processing when GitHub retries webhook deliveries. Each entry
+  has a configurable TTL (default: 5 minutes).
+
+  ## Design
+
+  - ETS table: `:set`, `:public`, `:named_table`
+  - Uses `:erlang.monotonic_time(:millisecond)` for expiry to avoid wall-clock drift
+  - Periodic sweep every TTL interval removes expired entries
+  - Public table allows direct reads without GenServer bottleneck
+  """
+
+  use GenServer
+
+  @table_name :lattice_webhook_dedup
+
+  # ── Client API ──────────────────────────────────────────────────────
+
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Check if a delivery ID has already been seen.
+
+  Returns `true` if the delivery has been processed before (duplicate),
+  `false` if it's new. Automatically records the delivery ID.
+  """
+  @spec seen?(String.t()) :: boolean()
+  def seen?(delivery_id) when is_binary(delivery_id) do
+    now = :erlang.monotonic_time(:millisecond)
+
+    case :ets.lookup(@table_name, delivery_id) do
+      [{^delivery_id, _expires_at}] ->
+        true
+
+      [] ->
+        ttl = ttl_ms()
+        :ets.insert(@table_name, {delivery_id, now + ttl})
+        false
+    end
+  end
+
+  @doc """
+  Reset the dedup table. Intended for test cleanup only.
+  """
+  def reset do
+    :ets.delete_all_objects(@table_name)
+    :ok
+  end
+
+  # ── GenServer Callbacks ─────────────────────────────────────────────
+
+  @impl GenServer
+  def init(_opts) do
+    table = :ets.new(@table_name, [:set, :public, :named_table])
+    schedule_sweep()
+    {:ok, %{table: table}}
+  end
+
+  @impl GenServer
+  def handle_info(:sweep, state) do
+    sweep_expired(state.table)
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────
+
+  defp sweep_expired(table) do
+    now = :erlang.monotonic_time(:millisecond)
+
+    :ets.foldl(
+      fn {id, expires_at}, acc ->
+        if expires_at < now, do: :ets.delete(table, id)
+        acc
+      end,
+      :ok,
+      table
+    )
+  end
+
+  defp schedule_sweep do
+    Process.send_after(self(), :sweep, ttl_ms())
+  end
+
+  defp ttl_ms do
+    :lattice
+    |> Application.get_env(:webhooks, [])
+    |> Keyword.get(:dedup_ttl_ms, :timer.minutes(5))
+  end
+end

--- a/lib/lattice/webhooks/github.ex
+++ b/lib/lattice/webhooks/github.ex
@@ -1,0 +1,226 @@
+defmodule Lattice.Webhooks.GitHub do
+  @moduledoc """
+  Handles GitHub webhook events and converts them into intent proposals.
+
+  This module is the "Signal → Intent" bridge for GitHub events. It receives
+  parsed webhook payloads, determines whether they should produce an intent,
+  and proposes them through the pipeline.
+
+  ## Supported Events
+
+  - `issues.opened` with `lattice-work` label → `:action` intent
+  - `issues.labeled` with `lattice-work` label → `:action` intent
+  - `issue_comment.created` on governance issues → delegates to `Governance.sync_from_github/1`
+  - `pull_request.review_submitted` with `changes_requested` → `:action` intent
+
+  ## Design
+
+  - Thin handler: parse, validate, propose
+  - All governance logic stays in `Lattice.Intents.Governance`
+  - Returns `{:ok, intent}` for proposed intents or `:ignored` for unhandled events
+  """
+
+  require Logger
+
+  alias Lattice.Intents.Governance
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Pipeline
+  alias Lattice.Intents.Store
+
+  @trigger_label "lattice-work"
+
+  # ── Public API ──────────────────────────────────────────────────────
+
+  @doc """
+  Handle a GitHub webhook event.
+
+  Dispatches to the appropriate handler based on event type and action.
+  Returns `{:ok, intent}` when an intent was proposed, `:ignored` when
+  the event was not actionable, or `{:error, reason}` on failure.
+  """
+  @spec handle_event(String.t(), map()) :: {:ok, Intent.t()} | :ignored | {:error, term()}
+  def handle_event(event_type, payload) do
+    action = Map.get(payload, "action")
+    do_handle(event_type, action, payload)
+  end
+
+  # ── Issues ──────────────────────────────────────────────────────────
+
+  defp do_handle("issues", "opened", payload) do
+    if has_trigger_label?(payload) do
+      propose_issue_triage(payload)
+    else
+      :ignored
+    end
+  end
+
+  defp do_handle("issues", "labeled", payload) do
+    label = get_in(payload, ["label", "name"])
+
+    if label == @trigger_label do
+      propose_issue_triage(payload)
+    else
+      :ignored
+    end
+  end
+
+  # ── Issue Comments (governance sync) ────────────────────────────────
+
+  defp do_handle("issue_comment", "created", payload) do
+    issue = Map.get(payload, "issue", %{})
+    labels = get_label_names(issue)
+
+    cond do
+      "intent-awaiting-approval" in labels ->
+        sync_governance_from_comment(issue)
+
+      has_intent_id_in_body?(issue) ->
+        sync_governance_from_comment(issue)
+
+      true ->
+        :ignored
+    end
+  end
+
+  # ── Pull Request Reviews ────────────────────────────────────────────
+
+  defp do_handle("pull_request", "review_submitted", payload) do
+    review = Map.get(payload, "review", %{})
+    state = Map.get(review, "state")
+
+    if state == "changes_requested" do
+      propose_pr_fixup(payload)
+    else
+      :ignored
+    end
+  end
+
+  # ── Catch-all ───────────────────────────────────────────────────────
+
+  defp do_handle(_event_type, _action, _payload), do: :ignored
+
+  # ── Private: Intent Proposals ───────────────────────────────────────
+
+  defp propose_issue_triage(payload) do
+    issue = Map.get(payload, "issue", %{})
+    repo = get_in(payload, ["repository", "full_name"]) || "unknown"
+    issue_number = Map.get(issue, "number")
+    issue_title = Map.get(issue, "title", "Untitled")
+    issue_body = Map.get(issue, "body", "")
+    sender = get_in(payload, ["sender", "login"]) || "unknown"
+
+    source = %{type: :webhook, id: "github:issues:#{issue_number}"}
+
+    case Intent.new_action(source,
+           summary: "Triage issue ##{issue_number}: #{issue_title}",
+           payload: %{
+             "capability" => "github",
+             "operation" => "issue_triage",
+             "repo" => repo,
+             "issue_number" => issue_number,
+             "issue_title" => issue_title,
+             "issue_body" => issue_body,
+             "sender" => sender
+           },
+           affected_resources: ["repo:#{repo}", "issue:#{issue_number}"],
+           expected_side_effects: ["triage issue ##{issue_number}"],
+           metadata: %{webhook_event: "issues", webhook_sender: sender}
+         ) do
+      {:ok, intent} ->
+        Pipeline.propose(intent)
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp propose_pr_fixup(payload) do
+    pr = Map.get(payload, "pull_request", %{})
+    review = Map.get(payload, "review", %{})
+    repo = get_in(payload, ["repository", "full_name"]) || "unknown"
+    pr_number = Map.get(pr, "number")
+    pr_title = Map.get(pr, "title", "Untitled")
+    review_body = Map.get(review, "body", "")
+    reviewer = Map.get(review, "user", %{}) |> Map.get("login", "unknown")
+
+    source = %{type: :webhook, id: "github:pull_request:#{pr_number}:review"}
+
+    case Intent.new_action(source,
+           summary: "Fix PR ##{pr_number}: #{pr_title} (changes requested by #{reviewer})",
+           payload: %{
+             "capability" => "github",
+             "operation" => "pr_fixup",
+             "repo" => repo,
+             "pr_number" => pr_number,
+             "pr_title" => pr_title,
+             "review_body" => review_body,
+             "reviewer" => reviewer
+           },
+           affected_resources: ["repo:#{repo}", "pr:#{pr_number}"],
+           expected_side_effects: ["address review on PR ##{pr_number}"],
+           metadata: %{webhook_event: "pull_request", webhook_sender: reviewer}
+         ) do
+      {:ok, intent} ->
+        Pipeline.propose(intent)
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  # ── Private: Governance Sync ────────────────────────────────────────
+
+  defp sync_governance_from_comment(issue) do
+    body = Map.get(issue, "body", "")
+
+    with {:ok, intent_id} <- extract_intent_id(body),
+         {:ok, intent} <- fetch_intent_for_sync(intent_id) do
+      case Governance.sync_from_github(intent) do
+        {:ok, %Intent{}} = result -> result
+        {:ok, :no_change} -> :ignored
+        {:error, _} = error -> error
+      end
+    else
+      _ -> :ignored
+    end
+  end
+
+  defp fetch_intent_for_sync(intent_id) do
+    case Store.get(intent_id) do
+      {:ok, _intent} = result ->
+        result
+
+      {:error, :not_found} ->
+        Logger.debug("Webhook: governance comment for unknown intent #{intent_id}")
+        :error
+    end
+  end
+
+  # ── Private: Helpers ────────────────────────────────────────────────
+
+  defp has_trigger_label?(payload) do
+    issue = Map.get(payload, "issue", %{})
+    labels = get_label_names(issue)
+    @trigger_label in labels
+  end
+
+  defp get_label_names(issue) do
+    issue
+    |> Map.get("labels", [])
+    |> Enum.map(&Map.get(&1, "name", ""))
+  end
+
+  defp has_intent_id_in_body?(issue) do
+    body = Map.get(issue, "body", "")
+    String.contains?(body, "lattice:intent_id=")
+  end
+
+  @intent_id_regex ~r/lattice:intent_id=([a-zA-Z0-9_-]+)/
+
+  defp extract_intent_id(body) when is_binary(body) do
+    case Regex.run(@intent_id_regex, body) do
+      [_, intent_id] -> {:ok, intent_id}
+      _ -> :error
+    end
+  end
+end

--- a/lib/lattice_web/controllers/api/intent_controller.ex
+++ b/lib/lattice_web/controllers/api/intent_controller.ex
@@ -19,7 +19,7 @@ defmodule LatticeWeb.Api.IntentController do
 
   @valid_kinds ~w(action inquiry maintenance)
   @valid_filter_states ~w(proposed classified awaiting_approval approved running blocked waiting_for_input completed failed rejected canceled)
-  @valid_source_types ~w(sprite agent cron operator)
+  @valid_source_types ~w(sprite agent cron operator webhook)
 
   # ── GET /api/intents ───────────────────────────────────────────────
 
@@ -61,7 +61,7 @@ defmodule LatticeWeb.Api.IntentController do
         in: :query,
         schema: %OpenApiSpex.Schema{
           type: :string,
-          enum: ["sprite", "agent", "cron", "operator"]
+          enum: ["sprite", "agent", "cron", "operator", "webhook"]
         },
         description: "Filter by source type",
         required: false

--- a/lib/lattice_web/controllers/api/webhook_controller.ex
+++ b/lib/lattice_web/controllers/api/webhook_controller.ex
@@ -1,0 +1,114 @@
+defmodule LatticeWeb.Api.WebhookController do
+  @moduledoc """
+  Controller for receiving GitHub webhook events.
+
+  Handles `POST /api/webhooks/github`. Webhook requests are authenticated
+  via HMAC-SHA256 signature (not bearer token). Event deduplication uses
+  the `X-GitHub-Delivery` header.
+
+  ## Flow
+
+  1. Signature verified by `LatticeWeb.Plugs.WebhookSignature` (in pipeline)
+  2. Delivery ID checked against `Lattice.Webhooks.Dedup`
+  3. Event type extracted from `X-GitHub-Event` header
+  4. Dispatched to `Lattice.Webhooks.GitHub.handle_event/2`
+  """
+
+  use LatticeWeb, :controller
+
+  alias Lattice.Webhooks.Dedup
+  alias Lattice.Webhooks.GitHub, as: WebhookHandler
+
+  require Logger
+
+  @doc """
+  POST /api/webhooks/github — receive and process a GitHub webhook event.
+  """
+  def github(conn, params) do
+    with {:ok, event_type} <- get_event_type(conn),
+         {:ok, delivery_id} <- get_delivery_id(conn),
+         :ok <- check_dedup(delivery_id) do
+      emit_received(event_type, delivery_id)
+
+      case WebhookHandler.handle_event(event_type, params) do
+        {:ok, intent} ->
+          emit_intent_proposed(event_type, intent)
+
+          conn
+          |> put_status(200)
+          |> json(%{status: "processed", intent_id: intent.id})
+
+        :ignored ->
+          conn
+          |> put_status(200)
+          |> json(%{status: "ignored"})
+
+        {:error, reason} ->
+          Logger.warning("Webhook handler error",
+            event_type: event_type,
+            delivery_id: delivery_id,
+            reason: inspect(reason)
+          )
+
+          conn
+          |> put_status(422)
+          |> json(%{error: "Failed to process webhook", detail: inspect(reason)})
+      end
+    else
+      {:error, :missing_event_type} ->
+        conn
+        |> put_status(400)
+        |> json(%{error: "Missing X-GitHub-Event header"})
+
+      {:error, :missing_delivery_id} ->
+        conn
+        |> put_status(400)
+        |> json(%{error: "Missing X-GitHub-Delivery header"})
+
+      {:error, :duplicate} ->
+        conn
+        |> put_status(200)
+        |> json(%{status: "duplicate"})
+    end
+  end
+
+  # ── Private ─────────────────────────────────────────────────────────
+
+  defp get_event_type(conn) do
+    case Plug.Conn.get_req_header(conn, "x-github-event") do
+      [event_type] when is_binary(event_type) -> {:ok, event_type}
+      _ -> {:error, :missing_event_type}
+    end
+  end
+
+  defp get_delivery_id(conn) do
+    case Plug.Conn.get_req_header(conn, "x-github-delivery") do
+      [delivery_id] when is_binary(delivery_id) -> {:ok, delivery_id}
+      _ -> {:error, :missing_delivery_id}
+    end
+  end
+
+  defp check_dedup(delivery_id) do
+    if Dedup.seen?(delivery_id) do
+      {:error, :duplicate}
+    else
+      :ok
+    end
+  end
+
+  defp emit_received(event_type, delivery_id) do
+    :telemetry.execute(
+      [:lattice, :webhook, :received],
+      %{system_time: System.system_time()},
+      %{event_type: event_type, delivery_id: delivery_id}
+    )
+  end
+
+  defp emit_intent_proposed(event_type, intent) do
+    :telemetry.execute(
+      [:lattice, :webhook, :intent_proposed],
+      %{system_time: System.system_time()},
+      %{event_type: event_type, intent: intent}
+    )
+  end
+end

--- a/lib/lattice_web/endpoint.ex
+++ b/lib/lattice_web/endpoint.ex
@@ -51,7 +51,8 @@ defmodule LatticeWeb.Endpoint do
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    json_decoder: Phoenix.json_library()
+    json_decoder: Phoenix.json_library(),
+    body_reader: {LatticeWeb.Plugs.CacheBodyReader, :read_body, []}
 
   plug Plug.MethodOverride
   plug Plug.Head

--- a/lib/lattice_web/plugs/cache_body_reader.ex
+++ b/lib/lattice_web/plugs/cache_body_reader.ex
@@ -1,0 +1,38 @@
+defmodule LatticeWeb.Plugs.CacheBodyReader do
+  @moduledoc """
+  A custom body reader that caches the raw request body in `conn.assigns`.
+
+  Used for webhook signature verification, where we need the exact raw bytes
+  that were signed by the sender to compute HMAC-SHA256.
+
+  ## Usage
+
+  Configure in the endpoint's `Plug.Parsers`:
+
+      plug Plug.Parsers,
+        body_reader: {LatticeWeb.Plugs.CacheBodyReader, :read_body, []},
+        ...
+
+  The raw body is stored in `conn.assigns[:raw_body]` as an iodata list.
+  """
+
+  @doc """
+  Read the request body and cache it in conn assigns.
+
+  Implements the `body_reader` callback signature expected by `Plug.Parsers`.
+  """
+  def read_body(conn, opts) do
+    case Plug.Conn.read_body(conn, opts) do
+      {:ok, body, conn} ->
+        conn = update_in(conn.assigns[:raw_body], &[body | &1 || []])
+        {:ok, body, conn}
+
+      {:more, body, conn} ->
+        conn = update_in(conn.assigns[:raw_body], &[body | &1 || []])
+        {:more, body, conn}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+end

--- a/lib/lattice_web/plugs/webhook_signature.ex
+++ b/lib/lattice_web/plugs/webhook_signature.ex
@@ -1,0 +1,84 @@
+defmodule LatticeWeb.Plugs.WebhookSignature do
+  @moduledoc """
+  Plug that verifies GitHub webhook HMAC-SHA256 signatures.
+
+  GitHub signs webhook payloads using a shared secret. This plug recomputes
+  the HMAC-SHA256 hash of the raw request body and compares it to the
+  signature in the `X-Hub-Signature-256` header.
+
+  ## Usage
+
+      plug LatticeWeb.Plugs.WebhookSignature
+
+  Requires the raw body to be cached via `LatticeWeb.Plugs.CacheBodyReader`.
+  The webhook secret is read from `Application.get_env(:lattice, :webhooks)[:github_secret]`.
+
+  Returns 401 if:
+  - No webhook secret is configured
+  - The `X-Hub-Signature-256` header is missing
+  - The signature does not match
+  """
+
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    secret = webhook_secret()
+
+    if is_nil(secret) or secret == "" do
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(401, Jason.encode!(%{error: "Webhook secret not configured"}))
+      |> halt()
+    else
+      verify_signature(conn, secret)
+    end
+  end
+
+  defp verify_signature(conn, secret) do
+    with {:ok, signature} <- get_signature(conn),
+         {:ok, raw_body} <- get_raw_body(conn),
+         :ok <- check_signature(raw_body, secret, signature) do
+      conn
+    else
+      {:error, reason} ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(401, Jason.encode!(%{error: reason}))
+        |> halt()
+    end
+  end
+
+  defp get_signature(conn) do
+    case get_req_header(conn, "x-hub-signature-256") do
+      ["sha256=" <> signature] -> {:ok, signature}
+      _ -> {:error, "Missing or invalid X-Hub-Signature-256 header"}
+    end
+  end
+
+  defp get_raw_body(conn) do
+    case conn.assigns[:raw_body] do
+      nil -> {:error, "No raw body available for signature verification"}
+      chunks -> {:ok, chunks |> Enum.reverse() |> IO.iodata_to_binary()}
+    end
+  end
+
+  defp check_signature(raw_body, secret, expected_signature) do
+    computed =
+      :crypto.mac(:hmac, :sha256, secret, raw_body)
+      |> Base.encode16(case: :lower)
+
+    if Plug.Crypto.secure_compare(computed, expected_signature) do
+      :ok
+    else
+      {:error, "Invalid webhook signature"}
+    end
+  end
+
+  defp webhook_secret do
+    :lattice
+    |> Application.get_env(:webhooks, [])
+    |> Keyword.get(:github_secret)
+  end
+end

--- a/lib/lattice_web/router.ex
+++ b/lib/lattice_web/router.ex
@@ -31,6 +31,11 @@ defmodule LatticeWeb.Router do
     plug LatticeWeb.Plugs.Auth
   end
 
+  pipeline :webhook do
+    plug :accepts, ["json"]
+    plug LatticeWeb.Plugs.WebhookSignature
+  end
+
   pipeline :api_docs do
     plug :accepts, ["json", "html"]
     plug OpenApiSpex.Plug.PutApiSpec, module: LatticeWeb.ApiSpec
@@ -62,6 +67,13 @@ defmodule LatticeWeb.Router do
     pipe_through :api
 
     get "/health", HealthController, :index
+  end
+
+  # Webhook routes -- authenticated via HMAC signature, not bearer token
+  scope "/api/webhooks", LatticeWeb.Api do
+    pipe_through :webhook
+
+    post "/github", WebhookController, :github
   end
 
   # Authenticated API routes -- protected by bearer token

--- a/test/lattice/events/telemetry_handler_test.exs
+++ b/test/lattice/events/telemetry_handler_test.exs
@@ -43,7 +43,9 @@ defmodule Lattice.Events.TelemetryHandlerTest do
       assert [:lattice, :intent, :created] in events
       assert [:lattice, :intent, :transitioned] in events
       assert [:lattice, :intent, :artifact_added] in events
-      assert length(events) == 10
+      assert [:lattice, :webhook, :received] in events
+      assert [:lattice, :webhook, :intent_proposed] in events
+      assert length(events) == 12
     end
   end
 

--- a/test/lattice/intents/intent_test.exs
+++ b/test/lattice/intents/intent_test.exs
@@ -436,7 +436,8 @@ defmodule Lattice.Intents.IntentTest do
       assert :agent in types
       assert :cron in types
       assert :operator in types
-      assert length(types) == 4
+      assert :webhook in types
+      assert length(types) == 5
     end
   end
 

--- a/test/lattice/webhooks/dedup_test.exs
+++ b/test/lattice/webhooks/dedup_test.exs
@@ -1,0 +1,41 @@
+defmodule Lattice.Webhooks.DedupTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Webhooks.Dedup
+
+  setup do
+    Dedup.reset()
+    :ok
+  end
+
+  describe "seen?/1" do
+    test "returns false for new delivery ID" do
+      refute Dedup.seen?("delivery-001")
+    end
+
+    test "returns true for previously seen delivery ID" do
+      refute Dedup.seen?("delivery-002")
+      assert Dedup.seen?("delivery-002")
+    end
+
+    test "different delivery IDs are tracked independently" do
+      refute Dedup.seen?("delivery-a")
+      refute Dedup.seen?("delivery-b")
+      assert Dedup.seen?("delivery-a")
+      assert Dedup.seen?("delivery-b")
+    end
+  end
+
+  describe "reset/0" do
+    test "clears all tracked delivery IDs" do
+      Dedup.seen?("delivery-x")
+      assert Dedup.seen?("delivery-x")
+
+      Dedup.reset()
+
+      refute Dedup.seen?("delivery-x")
+    end
+  end
+end

--- a/test/lattice/webhooks/github_test.exs
+++ b/test/lattice/webhooks/github_test.exs
@@ -1,0 +1,165 @@
+defmodule Lattice.Webhooks.GitHubTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Intents.Store.ETS, as: StoreETS
+  alias Lattice.Webhooks.GitHub, as: WebhookHandler
+
+  setup do
+    StoreETS.reset()
+    :ok
+  end
+
+  # ── issues.opened ──────────────────────────────────────────────────
+
+  describe "issues.opened" do
+    test "proposes action intent when issue has lattice-work label" do
+      payload = issue_payload("opened", labels: ["lattice-work"])
+
+      assert {:ok, intent} = WebhookHandler.handle_event("issues", payload)
+      assert intent.kind == :action
+      assert intent.source.type == :webhook
+      assert intent.source.id == "github:issues:42"
+      assert String.contains?(intent.summary, "Triage issue #42")
+      assert intent.payload["operation"] == "issue_triage"
+      assert intent.payload["repo"] == "org/repo"
+    end
+
+    test "ignores issue without lattice-work label" do
+      payload = issue_payload("opened", labels: ["bug", "help-wanted"])
+
+      assert :ignored = WebhookHandler.handle_event("issues", payload)
+    end
+
+    test "ignores issue with no labels" do
+      payload = issue_payload("opened", labels: [])
+
+      assert :ignored = WebhookHandler.handle_event("issues", payload)
+    end
+  end
+
+  # ── issues.labeled ─────────────────────────────────────────────────
+
+  describe "issues.labeled" do
+    test "proposes action intent when lattice-work label is added" do
+      payload =
+        issue_payload("labeled", labels: ["lattice-work"])
+        |> Map.put("label", %{"name" => "lattice-work"})
+
+      assert {:ok, intent} = WebhookHandler.handle_event("issues", payload)
+      assert intent.kind == :action
+      assert intent.payload["operation"] == "issue_triage"
+    end
+
+    test "ignores when non-trigger label is added" do
+      payload =
+        issue_payload("labeled", labels: ["bug", "lattice-work"])
+        |> Map.put("label", %{"name" => "bug"})
+
+      assert :ignored = WebhookHandler.handle_event("issues", payload)
+    end
+  end
+
+  # ── pull_request.review_submitted ──────────────────────────────────
+
+  describe "pull_request.review_submitted" do
+    test "proposes action intent when changes_requested" do
+      payload = pr_review_payload("changes_requested")
+
+      assert {:ok, intent} = WebhookHandler.handle_event("pull_request", payload)
+      assert intent.kind == :action
+      assert intent.source.type == :webhook
+      assert intent.payload["operation"] == "pr_fixup"
+      assert intent.payload["pr_number"] == 99
+      assert intent.payload["reviewer"] == "reviewer-user"
+    end
+
+    test "ignores approved review" do
+      payload = pr_review_payload("approved")
+
+      assert :ignored = WebhookHandler.handle_event("pull_request", payload)
+    end
+
+    test "ignores commented review" do
+      payload = pr_review_payload("commented")
+
+      assert :ignored = WebhookHandler.handle_event("pull_request", payload)
+    end
+  end
+
+  # ── issue_comment.created (governance sync) ────────────────────────
+
+  describe "issue_comment.created" do
+    test "ignores comments on non-governance issues" do
+      payload = %{
+        "action" => "created",
+        "issue" => %{
+          "number" => 10,
+          "title" => "Regular issue",
+          "body" => "Just a normal issue",
+          "labels" => []
+        },
+        "comment" => %{"body" => "Nice work!"}
+      }
+
+      assert :ignored = WebhookHandler.handle_event("issue_comment", payload)
+    end
+  end
+
+  # ── Unhandled events ───────────────────────────────────────────────
+
+  describe "unhandled events" do
+    test "ignores push events" do
+      assert :ignored = WebhookHandler.handle_event("push", %{})
+    end
+
+    test "ignores ping events" do
+      assert :ignored = WebhookHandler.handle_event("ping", %{"zen" => "test"})
+    end
+
+    test "ignores unknown events" do
+      assert :ignored = WebhookHandler.handle_event("deployment", %{})
+    end
+
+    test "ignores issues.closed" do
+      payload = issue_payload("closed", labels: ["lattice-work"])
+      assert :ignored = WebhookHandler.handle_event("issues", payload)
+    end
+  end
+
+  # ── Test Helpers ───────────────────────────────────────────────────
+
+  defp issue_payload(action, opts) do
+    labels = Keyword.get(opts, :labels, [])
+
+    %{
+      "action" => action,
+      "issue" => %{
+        "number" => 42,
+        "title" => "Test issue title",
+        "body" => "Test issue body",
+        "labels" => Enum.map(labels, &%{"name" => &1})
+      },
+      "repository" => %{"full_name" => "org/repo"},
+      "sender" => %{"login" => "test-user"}
+    }
+  end
+
+  defp pr_review_payload(review_state) do
+    %{
+      "action" => "review_submitted",
+      "pull_request" => %{
+        "number" => 99,
+        "title" => "Fix the thing"
+      },
+      "review" => %{
+        "state" => review_state,
+        "body" => "Please fix the tests",
+        "user" => %{"login" => "reviewer-user"}
+      },
+      "repository" => %{"full_name" => "org/repo"},
+      "sender" => %{"login" => "reviewer-user"}
+    }
+  end
+end

--- a/test/lattice_web/controllers/api/webhook_controller_test.exs
+++ b/test/lattice_web/controllers/api/webhook_controller_test.exs
@@ -1,0 +1,213 @@
+defmodule LatticeWeb.Api.WebhookControllerTest do
+  use LatticeWeb.ConnCase
+
+  @moduletag :unit
+
+  alias Lattice.Intents.Store.ETS, as: StoreETS
+  alias Lattice.Webhooks.Dedup
+
+  @secret "test-webhook-secret"
+
+  setup do
+    StoreETS.reset()
+    Dedup.reset()
+    :ok
+  end
+
+  # ── Helpers ──────────────────────────────────────────────────────────
+
+  defp sign(body) do
+    :crypto.mac(:hmac, :sha256, @secret, body)
+    |> Base.encode16(case: :lower)
+  end
+
+  defp webhook_conn(conn, event_type, payload, opts \\ []) do
+    delivery_id =
+      Keyword.get(opts, :delivery_id, "delivery-#{System.unique_integer([:positive])}")
+
+    body = Jason.encode!(payload)
+    signature = sign(body)
+
+    conn
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("x-github-event", event_type)
+    |> put_req_header("x-github-delivery", delivery_id)
+    |> put_req_header("x-hub-signature-256", "sha256=#{signature}")
+    |> post("/api/webhooks/github", body)
+  end
+
+  # ── issues.opened with lattice-work label ──────────────────────────
+
+  describe "POST /api/webhooks/github — issues.opened" do
+    test "creates intent from issue with lattice-work label", %{conn: conn} do
+      payload = %{
+        "action" => "opened",
+        "issue" => %{
+          "number" => 42,
+          "title" => "Fix login bug",
+          "body" => "Login is broken",
+          "labels" => [%{"name" => "lattice-work"}]
+        },
+        "repository" => %{"full_name" => "org/repo"},
+        "sender" => %{"login" => "alice"}
+      }
+
+      conn = webhook_conn(conn, "issues", payload)
+
+      assert %{"status" => "processed", "intent_id" => intent_id} = json_response(conn, 200)
+      assert is_binary(intent_id)
+    end
+
+    test "ignores issue without lattice-work label", %{conn: conn} do
+      payload = %{
+        "action" => "opened",
+        "issue" => %{
+          "number" => 43,
+          "title" => "Normal issue",
+          "body" => "Nothing special",
+          "labels" => [%{"name" => "bug"}]
+        },
+        "repository" => %{"full_name" => "org/repo"},
+        "sender" => %{"login" => "bob"}
+      }
+
+      conn = webhook_conn(conn, "issues", payload)
+
+      assert %{"status" => "ignored"} = json_response(conn, 200)
+    end
+  end
+
+  # ── pull_request.review_submitted ──────────────────────────────────
+
+  describe "POST /api/webhooks/github — pull_request review" do
+    test "creates intent when changes_requested", %{conn: conn} do
+      payload = %{
+        "action" => "review_submitted",
+        "pull_request" => %{
+          "number" => 99,
+          "title" => "Add feature"
+        },
+        "review" => %{
+          "state" => "changes_requested",
+          "body" => "Fix the tests",
+          "user" => %{"login" => "reviewer"}
+        },
+        "repository" => %{"full_name" => "org/repo"},
+        "sender" => %{"login" => "reviewer"}
+      }
+
+      conn = webhook_conn(conn, "pull_request", payload)
+
+      assert %{"status" => "processed", "intent_id" => _} = json_response(conn, 200)
+    end
+
+    test "ignores approved review", %{conn: conn} do
+      payload = %{
+        "action" => "review_submitted",
+        "pull_request" => %{
+          "number" => 99,
+          "title" => "Add feature"
+        },
+        "review" => %{
+          "state" => "approved",
+          "body" => "LGTM",
+          "user" => %{"login" => "reviewer"}
+        },
+        "repository" => %{"full_name" => "org/repo"},
+        "sender" => %{"login" => "reviewer"}
+      }
+
+      conn = webhook_conn(conn, "pull_request", payload)
+
+      assert %{"status" => "ignored"} = json_response(conn, 200)
+    end
+  end
+
+  # ── Deduplication ──────────────────────────────────────────────────
+
+  describe "deduplication" do
+    test "rejects duplicate delivery IDs", %{conn: conn} do
+      payload = %{
+        "action" => "opened",
+        "issue" => %{
+          "number" => 50,
+          "title" => "Dedup test",
+          "body" => "",
+          "labels" => [%{"name" => "lattice-work"}]
+        },
+        "repository" => %{"full_name" => "org/repo"},
+        "sender" => %{"login" => "test"}
+      }
+
+      delivery_id = "fixed-delivery-id"
+
+      conn1 = webhook_conn(conn, "issues", payload, delivery_id: delivery_id)
+      assert %{"status" => "processed"} = json_response(conn1, 200)
+
+      conn2 = webhook_conn(build_conn(), "issues", payload, delivery_id: delivery_id)
+      assert %{"status" => "duplicate"} = json_response(conn2, 200)
+    end
+  end
+
+  # ── Missing headers ────────────────────────────────────────────────
+
+  describe "missing headers" do
+    test "returns 400 when X-GitHub-Event is missing", %{conn: conn} do
+      body = Jason.encode!(%{"action" => "opened"})
+      signature = sign(body)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("x-github-delivery", "delivery-123")
+        |> put_req_header("x-hub-signature-256", "sha256=#{signature}")
+        |> post("/api/webhooks/github", body)
+
+      assert %{"error" => "Missing X-GitHub-Event header"} = json_response(conn, 400)
+    end
+
+    test "returns 400 when X-GitHub-Delivery is missing", %{conn: conn} do
+      body = Jason.encode!(%{"action" => "opened"})
+      signature = sign(body)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("x-github-event", "issues")
+        |> put_req_header("x-hub-signature-256", "sha256=#{signature}")
+        |> post("/api/webhooks/github", body)
+
+      assert %{"error" => "Missing X-GitHub-Delivery header"} = json_response(conn, 400)
+    end
+  end
+
+  # ── Signature rejection ────────────────────────────────────────────
+
+  describe "signature verification" do
+    test "rejects request with invalid signature", %{conn: conn} do
+      body = Jason.encode!(%{"action" => "opened"})
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("x-github-event", "issues")
+        |> put_req_header("x-github-delivery", "delivery-bad")
+        |> put_req_header("x-hub-signature-256", "sha256=badbadbadbad")
+        |> post("/api/webhooks/github", body)
+
+      assert conn.status == 401
+    end
+  end
+
+  # ── Unhandled events ───────────────────────────────────────────────
+
+  describe "unhandled events" do
+    test "returns ignored for ping events", %{conn: conn} do
+      payload = %{"zen" => "Keep it logically awesome"}
+
+      conn = webhook_conn(conn, "ping", payload)
+
+      assert %{"status" => "ignored"} = json_response(conn, 200)
+    end
+  end
+end

--- a/test/lattice_web/plugs/webhook_signature_test.exs
+++ b/test/lattice_web/plugs/webhook_signature_test.exs
@@ -1,0 +1,97 @@
+defmodule LatticeWeb.Plugs.WebhookSignatureTest do
+  use LatticeWeb.ConnCase, async: true
+
+  @moduletag :unit
+
+  alias LatticeWeb.Plugs.WebhookSignature
+
+  @secret "test-webhook-secret"
+
+  defp sign(body, secret \\ @secret) do
+    :crypto.mac(:hmac, :sha256, secret, body)
+    |> Base.encode16(case: :lower)
+  end
+
+  defp build_signed_conn(body) do
+    signature = sign(body)
+
+    :post
+    |> Plug.Test.conn("/api/webhooks/github", body)
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> Plug.Conn.put_req_header("x-hub-signature-256", "sha256=#{signature}")
+    |> Map.update!(:assigns, &Map.put(&1, :raw_body, [body]))
+  end
+
+  describe "call/2" do
+    test "passes through with valid signature" do
+      body = ~s({"action":"opened"})
+      conn = build_signed_conn(body)
+
+      result = WebhookSignature.call(conn, [])
+
+      refute result.halted
+    end
+
+    test "rejects invalid signature" do
+      body = ~s({"action":"opened"})
+
+      conn =
+        :post
+        |> Plug.Test.conn("/api/webhooks/github", body)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_req_header("x-hub-signature-256", "sha256=invalid")
+        |> Map.update!(:assigns, &Map.put(&1, :raw_body, [body]))
+
+      result = WebhookSignature.call(conn, [])
+
+      assert result.halted
+      assert result.status == 401
+    end
+
+    test "rejects when X-Hub-Signature-256 header is missing" do
+      body = ~s({"action":"opened"})
+
+      conn =
+        :post
+        |> Plug.Test.conn("/api/webhooks/github", body)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Map.update!(:assigns, &Map.put(&1, :raw_body, [body]))
+
+      result = WebhookSignature.call(conn, [])
+
+      assert result.halted
+      assert result.status == 401
+    end
+
+    test "rejects when raw body is not available" do
+      body = ~s({"action":"opened"})
+      signature = sign(body)
+
+      conn =
+        :post
+        |> Plug.Test.conn("/api/webhooks/github", body)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> Plug.Conn.put_req_header("x-hub-signature-256", "sha256=#{signature}")
+
+      result = WebhookSignature.call(conn, [])
+
+      assert result.halted
+      assert result.status == 401
+    end
+
+    test "rejects when webhook secret is not configured" do
+      original = Application.get_env(:lattice, :webhooks)
+      Application.put_env(:lattice, :webhooks, Keyword.put(original, :github_secret, nil))
+
+      on_exit(fn -> Application.put_env(:lattice, :webhooks, original) end)
+
+      body = ~s({"action":"opened"})
+      conn = build_signed_conn(body)
+
+      result = WebhookSignature.call(conn, [])
+
+      assert result.halted
+      assert result.status == 401
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `POST /api/webhooks/github` endpoint for receiving GitHub webhook events, authenticated via HMAC-SHA256 signature verification (not bearer token)
- Implements the "Signal → Intent" ingestion path from NORTHSTAR.md: `issues.opened`/`labeled` with `lattice-work` label proposes issue_triage intents, `pull_request.review_submitted` with `changes_requested` proposes pr_fixup intents
- Adds ETS-backed webhook event deduplication using `X-GitHub-Delivery` header with 5-minute TTL sweep
- Adds `:webhook` as a valid intent source type alongside `:sprite`, `:agent`, `:cron`, `:operator`
- Extends telemetry with `[:lattice, :webhook, :received]` and `[:lattice, :webhook, :intent_proposed]` events

## New files

| File | Purpose |
|------|---------|
| `lib/lattice/webhooks/github.ex` | GitHub event handler — dispatches events to intent proposals |
| `lib/lattice/webhooks/dedup.ex` | ETS GenServer for delivery ID deduplication with TTL |
| `lib/lattice_web/controllers/api/webhook_controller.ex` | Webhook endpoint controller |
| `lib/lattice_web/plugs/webhook_signature.ex` | HMAC-SHA256 signature verification plug |
| `lib/lattice_web/plugs/cache_body_reader.ex` | Raw body caching for Plug.Parsers |

## Test plan

- [x] Unit tests for webhook signature verification plug (5 tests)
- [x] Unit tests for ETS dedup GenServer (4 tests)
- [x] Unit tests for GitHub event handler — all event types and edge cases (13 tests)
- [x] Integration tests for webhook controller — full request pipeline (9 tests)
- [x] Existing test updates: source type count (5), telemetry event count (12)
- [x] Full suite: 1261 tests, 0 failures

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)