### PR TITLE
Add reactive sprite list with Presence tracking and adaptive polling

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -20,6 +20,10 @@ config :lattice, :capabilities,
 # Fleet configuration — sprites to discover and manage at boot
 config :lattice, :fleet, sprites: []
 
+# Fleet reconciliation intervals (adaptive: fast when viewers present, slow otherwise)
+config :lattice, :fleet_reconcile_fast_ms, 10_000
+config :lattice, :fleet_reconcile_slow_ms, 60_000
+
 # Auth provider — stub for dev, Clerk for production
 config :lattice, :auth, provider: Lattice.Auth.Stub
 

--- a/lib/lattice/application.ex
+++ b/lib/lattice/application.ex
@@ -34,6 +34,8 @@ defmodule Lattice.Application do
       # Exec session registry and supervisor for WebSocket exec connections
       {Registry, keys: :unique, name: Lattice.Sprites.ExecRegistry},
       Lattice.Sprites.ExecSupervisor,
+      # Presence tracking for adaptive fleet polling
+      LatticeWeb.Presence,
       # Start to serve requests, typically the last entry
       LatticeWeb.Endpoint
     ]

--- a/lib/lattice_web/live/sprite_live/show.ex
+++ b/lib/lattice_web/live/sprite_live/show.ex
@@ -33,6 +33,7 @@ defmodule LatticeWeb.SpriteLive.Show do
   alias Lattice.Sprites.Logs
   alias Lattice.Sprites.Sprite
   alias Lattice.Sprites.State
+  alias LatticeWeb.Presence
 
   @max_events 50
   @refresh_interval_ms 30_000
@@ -50,6 +51,13 @@ defmodule LatticeWeb.SpriteLive.Show do
             Events.subscribe_intents()
             Events.subscribe_sprite_logs(sprite_id)
             schedule_refresh()
+
+            Presence.track(self(), Presence.viewers_topic(), socket.id, %{
+              page: :sprite_detail,
+              sprite_id: sprite_id,
+              joined_at: DateTime.utc_now()
+            })
+
             Logs.fetch_historical(sprite_id)
           else
             []
@@ -519,6 +527,30 @@ defmodule LatticeWeb.SpriteLive.Show do
           <p :if={@last_reconciliation.details} class="text-xs text-base-content/50 mt-1">
             {@last_reconciliation.details}
           </p>
+        </div>
+
+        <div :if={@sprite_state.last_started_at || @sprite_state.last_active_at} class="divider my-2">
+        </div>
+        <div
+          :if={@sprite_state.last_started_at || @sprite_state.last_active_at}
+          class="grid grid-cols-2 gap-4"
+        >
+          <div :if={@sprite_state.last_started_at}>
+            <div class="text-xs font-medium text-base-content/60 uppercase tracking-wide">
+              Last Started
+            </div>
+            <div class="mt-1 text-sm">
+              <.relative_time datetime={@sprite_state.last_started_at} />
+            </div>
+          </div>
+          <div :if={@sprite_state.last_active_at}>
+            <div class="text-xs font-medium text-base-content/60 uppercase tracking-wide">
+              Last Active
+            </div>
+            <div class="mt-1 text-sm">
+              <.relative_time datetime={@sprite_state.last_active_at} />
+            </div>
+          </div>
         </div>
 
         <div class="text-xs text-base-content/50 mt-2">

--- a/lib/lattice_web/presence.ex
+++ b/lib/lattice_web/presence.ex
@@ -1,0 +1,53 @@
+defmodule LatticeWeb.Presence do
+  @moduledoc """
+  Tracks which operators are viewing fleet-related pages.
+
+  Used by `FleetManager` to adapt its reconciliation interval:
+  fast polling when viewers are present, slow when nobody is watching.
+
+  ## Usage
+
+  Track a viewer in a LiveView mount:
+
+      if connected?(socket) do
+        LatticeWeb.Presence.track(self(), "fleet:viewers", socket.id, %{
+          page: :fleet,
+          joined_at: DateTime.utc_now()
+        })
+      end
+
+  Check for active viewers:
+
+      LatticeWeb.Presence.has_viewers?()
+
+  Phoenix.Presence handles crash/disconnect cleanup automatically via
+  process monitoring. Works across distributed nodes via CRDT sync.
+  """
+
+  use Phoenix.Presence,
+    otp_app: :lattice,
+    pubsub_server: Lattice.PubSub
+
+  @viewers_topic "fleet:viewers"
+
+  @doc "Returns the PubSub topic used for fleet viewer tracking."
+  @spec viewers_topic() :: String.t()
+  def viewers_topic, do: @viewers_topic
+
+  @doc "Returns `true` if at least one operator has a fleet-related page open."
+  @spec has_viewers?() :: boolean()
+  def has_viewers? do
+    @viewers_topic
+    |> list()
+    |> map_size()
+    |> Kernel.>(0)
+  end
+
+  @doc "Returns the count of distinct viewer presences."
+  @spec viewer_count() :: non_neg_integer()
+  def viewer_count do
+    @viewers_topic
+    |> list()
+    |> map_size()
+  end
+end


### PR DESCRIPTION
## Summary

- **Phoenix.Presence integration** — tracks which operators have fleet-related pages open via CRDT-based presence tracking
- **Adaptive fleet reconciliation** — FleetManager polls API every 10s when viewers are present, 60s when nobody is watching, automatically syncing new/removed sprites
- **API timestamp storage** — stores `created_at`, `updated_at`, `last_started_at`, `last_active_at` from Sprites API responses in the State struct, displayed in fleet table and sprite detail panels
- **Telemetry** — new `[:lattice, :fleet, :reconcile]` event with duration/added/removed measurements

Closes #139

## Changes

| File | Change |
|------|--------|
| `lib/lattice_web/presence.ex` | New — Phoenix.Presence module with `has_viewers?/0` |
| `lib/lattice/sprites/state.ex` | Add 4 API timestamp fields + `update_api_timestamps/2` |
| `lib/lattice/sprites/sprite.ex` | Extract full API data in `fetch_sprite_data/1`, pass to `update_api_timestamps` |
| `lib/lattice/sprites/fleet_manager.ex` | Add adaptive fleet reconciliation loop with MapSet diff |
| `lib/lattice_web/live/fleet_live.ex` | Presence tracking + API timestamp in "Last Update" column |
| `lib/lattice_web/live/sprite_live/show.ex` | Presence tracking + "Last Started" / "Last Active" panels |
| `config/config.exs` | Fleet reconciliation interval config |
| `lib/lattice/application.ex` | Add Presence to supervision tree |
| `test/lattice/sprites/state_test.exs` | 5 new tests for `update_api_timestamps/2` |

## Test plan

- [x] 1096 tests, 0 failures (full suite)
- [x] `mix compile --warnings-as-errors` passes with 0 warnings
- [x] `mix format --check-formatted` passes
- [ ] Verify fleet dashboard shows real API timestamps in production
- [ ] Verify adaptive polling: fast refresh when page open, slow when closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)