### PR TITLE
Add extensible intent kind registry (#130)

### DIFF
--- a/lib/lattice/application.ex
+++ b/lib/lattice/application.ex
@@ -14,6 +14,9 @@ defmodule Lattice.Application do
     # This ensures events emitted during startup are captured.
     TelemetryHandler.attach()
 
+    # Initialize the intent kind registry (ETS table for kind metadata)
+    Lattice.Intents.Kind.init()
+
     # Validate resource bindings and log instance identity at boot.
     # In prod, missing bindings cause a crash (fail fast).
     Instance.validate!()

--- a/lib/lattice/intents/kind.ex
+++ b/lib/lattice/intents/kind.ex
@@ -1,0 +1,213 @@
+defmodule Lattice.Intents.Kind do
+  @moduledoc """
+  Behaviour and registry for intent kinds.
+
+  Each kind defines its name, description, required payload fields, and
+  default safety classification. The registry allows compile-time registration
+  and runtime lookup of kinds.
+
+  ## Built-in kinds
+
+  - `:action` — produces side effects (deploy, modify infrastructure)
+  - `:inquiry` — requests human input or secrets
+  - `:maintenance` — proposes system improvements
+
+  ## Extended kinds
+
+  - `:issue_triage` — parse an issue, propose a plan
+  - `:pr_fixup` — respond to PR review feedback
+  - `:pr_create` — create a PR from an approved plan
+
+  ## Implementing a kind
+
+      defmodule MyApp.Intents.Kind.Custom do
+        @behaviour Lattice.Intents.Kind
+
+        @impl true
+        def name, do: :custom
+
+        @impl true
+        def description, do: "Custom intent kind"
+
+        @impl true
+        def required_payload_fields, do: [:some_field]
+
+        @impl true
+        def default_classification, do: :controlled
+      end
+
+  Then register it:
+
+      Lattice.Intents.Kind.register(MyApp.Intents.Kind.Custom)
+  """
+
+  require Logger
+
+  @type kind_name :: atom()
+
+  @doc "The atom name identifying this kind."
+  @callback name() :: kind_name()
+
+  @doc "Human-readable description for dashboard display."
+  @callback description() :: String.t()
+
+  @doc "Payload fields required for this kind (advisory, not blocking)."
+  @callback required_payload_fields() :: [atom() | String.t()]
+
+  @doc "Default safety classification when the classifier has no specific mapping."
+  @callback default_classification() :: :safe | :controlled | :dangerous
+
+  # ── Registry (ETS-backed) ─────────────────────────────────────────
+
+  @table_name :lattice_intent_kinds
+
+  @doc """
+  Initialize the kind registry. Called during application startup.
+  """
+  @spec init() :: :ok
+  def init do
+    if :ets.whereis(@table_name) == :undefined do
+      :ets.new(@table_name, [:set, :public, :named_table])
+    end
+
+    register_builtins()
+    :ok
+  end
+
+  @doc """
+  Register a kind module in the registry.
+  """
+  @spec register(module()) :: :ok
+  def register(module) when is_atom(module) do
+    ensure_table()
+    name = module.name()
+    :ets.insert(@table_name, {name, module})
+    :ok
+  end
+
+  @doc """
+  Look up a kind module by name.
+  """
+  @spec lookup(kind_name()) :: {:ok, module()} | {:error, :unknown_kind}
+  def lookup(name) when is_atom(name) do
+    ensure_table()
+
+    case :ets.lookup(@table_name, name) do
+      [{^name, module}] -> {:ok, module}
+      [] -> {:error, :unknown_kind}
+    end
+  end
+
+  @doc """
+  List all registered kind names.
+  """
+  @spec registered() :: [kind_name()]
+  def registered do
+    ensure_table()
+
+    :ets.foldl(fn {name, _module}, acc -> [name | acc] end, [], @table_name)
+    |> Enum.sort()
+  end
+
+  @doc """
+  List all registered kind modules with metadata.
+  """
+  @spec all() :: [%{name: kind_name(), description: String.t(), module: module()}]
+  def all do
+    ensure_table()
+
+    :ets.foldl(
+      fn {name, module}, acc ->
+        [%{name: name, description: module.description(), module: module} | acc]
+      end,
+      [],
+      @table_name
+    )
+    |> Enum.sort_by(& &1.name)
+  end
+
+  @doc """
+  Validate a payload against a kind's required fields.
+
+  Returns `:ok` or `{:warn, missing_fields}`. Advisory only — does not reject.
+  """
+  @spec validate_payload(kind_name(), map()) :: :ok | {:warn, [atom() | String.t()]}
+  def validate_payload(kind_name, payload) when is_atom(kind_name) and is_map(payload) do
+    case lookup(kind_name) do
+      {:ok, module} ->
+        required = module.required_payload_fields()
+
+        missing =
+          Enum.reject(required, fn field ->
+            key = to_string(field)
+            Map.has_key?(payload, key) or Map.has_key?(payload, field)
+          end)
+
+        case missing do
+          [] -> :ok
+          fields -> {:warn, fields}
+        end
+
+      {:error, :unknown_kind} ->
+        :ok
+    end
+  end
+
+  @doc """
+  Get the default classification for a kind.
+  """
+  @spec default_classification(kind_name()) ::
+          {:ok, :safe | :controlled | :dangerous} | {:error, :unknown_kind}
+  def default_classification(kind_name) when is_atom(kind_name) do
+    case lookup(kind_name) do
+      {:ok, module} -> {:ok, module.default_classification()}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Get the human-readable description for a kind.
+  """
+  @spec description(kind_name()) :: {:ok, String.t()} | {:error, :unknown_kind}
+  def description(kind_name) when is_atom(kind_name) do
+    case lookup(kind_name) do
+      {:ok, module} -> {:ok, module.description()}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Returns true if the kind name is registered.
+  """
+  @spec valid?(kind_name()) :: boolean()
+  def valid?(kind_name) when is_atom(kind_name) do
+    case lookup(kind_name) do
+      {:ok, _} -> true
+      {:error, _} -> false
+    end
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp ensure_table do
+    if :ets.whereis(@table_name) == :undefined do
+      :ets.new(@table_name, [:set, :public, :named_table])
+      register_builtins()
+    end
+  end
+
+  defp register_builtins do
+    builtins = [
+      Lattice.Intents.Kind.Action,
+      Lattice.Intents.Kind.Inquiry,
+      Lattice.Intents.Kind.Maintenance,
+      Lattice.Intents.Kind.IssueTriage,
+      Lattice.Intents.Kind.PrFixup,
+      Lattice.Intents.Kind.PrCreate
+    ]
+
+    Enum.each(builtins, fn module ->
+      :ets.insert(@table_name, {module.name(), module})
+    end)
+  end
+end

--- a/lib/lattice/intents/kind/action.ex
+++ b/lib/lattice/intents/kind/action.ex
@@ -1,0 +1,17 @@
+defmodule Lattice.Intents.Kind.Action do
+  @moduledoc "Built-in kind: produces side effects (deploy, modify infrastructure, scale fleet)."
+
+  @behaviour Lattice.Intents.Kind
+
+  @impl true
+  def name, do: :action
+
+  @impl true
+  def description, do: "Action"
+
+  @impl true
+  def required_payload_fields, do: ["capability", "operation"]
+
+  @impl true
+  def default_classification, do: :controlled
+end

--- a/lib/lattice/intents/kind/inquiry.ex
+++ b/lib/lattice/intents/kind/inquiry.ex
@@ -1,0 +1,18 @@
+defmodule Lattice.Intents.Kind.Inquiry do
+  @moduledoc "Built-in kind: requests human input or secrets."
+
+  @behaviour Lattice.Intents.Kind
+
+  @impl true
+  def name, do: :inquiry
+
+  @impl true
+  def description, do: "Inquiry"
+
+  @impl true
+  def required_payload_fields,
+    do: ["what_requested", "why_needed", "scope_of_impact", "expiration"]
+
+  @impl true
+  def default_classification, do: :controlled
+end

--- a/lib/lattice/intents/kind/issue_triage.ex
+++ b/lib/lattice/intents/kind/issue_triage.ex
@@ -1,0 +1,17 @@
+defmodule Lattice.Intents.Kind.IssueTriage do
+  @moduledoc "Parse an issue, ask clarifying questions, or propose a plan."
+
+  @behaviour Lattice.Intents.Kind
+
+  @impl true
+  def name, do: :issue_triage
+
+  @impl true
+  def description, do: "Issue Triage"
+
+  @impl true
+  def required_payload_fields, do: ["issue_url"]
+
+  @impl true
+  def default_classification, do: :controlled
+end

--- a/lib/lattice/intents/kind/maintenance.ex
+++ b/lib/lattice/intents/kind/maintenance.ex
@@ -1,0 +1,17 @@
+defmodule Lattice.Intents.Kind.Maintenance do
+  @moduledoc "Built-in kind: proposes system improvements (update base image, pin dependency)."
+
+  @behaviour Lattice.Intents.Kind
+
+  @impl true
+  def name, do: :maintenance
+
+  @impl true
+  def description, do: "Maintenance"
+
+  @impl true
+  def required_payload_fields, do: []
+
+  @impl true
+  def default_classification, do: :safe
+end

--- a/lib/lattice/intents/kind/pr_create.ex
+++ b/lib/lattice/intents/kind/pr_create.ex
@@ -1,0 +1,17 @@
+defmodule Lattice.Intents.Kind.PrCreate do
+  @moduledoc "Create a PR from an approved plan."
+
+  @behaviour Lattice.Intents.Kind
+
+  @impl true
+  def name, do: :pr_create
+
+  @impl true
+  def description, do: "PR Create"
+
+  @impl true
+  def required_payload_fields, do: ["repo", "branch"]
+
+  @impl true
+  def default_classification, do: :controlled
+end

--- a/lib/lattice/intents/kind/pr_fixup.ex
+++ b/lib/lattice/intents/kind/pr_fixup.ex
@@ -1,0 +1,17 @@
+defmodule Lattice.Intents.Kind.PrFixup do
+  @moduledoc "Respond to PR review feedback with follow-up commits."
+
+  @behaviour Lattice.Intents.Kind
+
+  @impl true
+  def name, do: :pr_fixup
+
+  @impl true
+  def description, do: "PR Fixup"
+
+  @impl true
+  def required_payload_fields, do: ["pr_url", "feedback"]
+
+  @impl true
+  def default_classification, do: :controlled
+end

--- a/lib/lattice/intents/pipeline.ex
+++ b/lib/lattice/intents/pipeline.ex
@@ -250,6 +250,14 @@ defmodule Lattice.Intents.Pipeline do
     end
   end
 
+  def classify_intent(%Intent{kind: kind}) do
+    # Extended kinds use their registered default classification
+    case Lattice.Intents.Kind.default_classification(kind) do
+      {:ok, classification} -> {:ok, classification}
+      {:error, :unknown_kind} -> {:ok, :controlled}
+    end
+  end
+
   # ── Private ────────────────────────────────────────────────────────
 
   defp gate_approval_required(intent_id, intent) do

--- a/lib/lattice_web/live/intent_live/show.ex
+++ b/lib/lattice_web/live/intent_live/show.ex
@@ -983,10 +983,12 @@ defmodule LatticeWeb.IntentLive.Show do
   defp format_source(%{type: type, id: id}), do: "#{type}:#{id}"
   defp format_source(_), do: "unknown"
 
-  defp format_kind(:action), do: "Action"
-  defp format_kind(:inquiry), do: "Inquiry"
-  defp format_kind(:maintenance), do: "Maintenance"
-  defp format_kind(kind), do: to_string(kind) |> String.capitalize()
+  defp format_kind(kind) do
+    case Lattice.Intents.Kind.description(kind) do
+      {:ok, desc} -> desc
+      {:error, _} -> kind |> to_string() |> String.replace("_", " ") |> String.capitalize()
+    end
+  end
 
   defp format_actor(nil), do: "-"
   defp format_actor(:pipeline), do: "pipeline"

--- a/lib/lattice_web/live/intents_live.ex
+++ b/lib/lattice_web/live/intents_live.ex
@@ -495,7 +495,7 @@ defmodule LatticeWeb.IntentsLive do
     Process.send_after(self(), :refresh, @refresh_interval_ms)
   end
 
-  defp intent_kinds, do: Intent.valid_kinds()
+  defp intent_kinds, do: Intent.registered_kinds()
 
   defp intent_states, do: Lifecycle.valid_states()
 
@@ -507,10 +507,12 @@ defmodule LatticeWeb.IntentsLive do
   defp format_source(%{type: type, id: id}), do: "#{type}:#{id}"
   defp format_source(_), do: "unknown"
 
-  defp format_kind(:action), do: "Action"
-  defp format_kind(:inquiry), do: "Inquiry"
-  defp format_kind(:maintenance), do: "Maintenance"
-  defp format_kind(kind), do: to_string(kind) |> String.capitalize()
+  defp format_kind(kind) do
+    case Lattice.Intents.Kind.description(kind) do
+      {:ok, desc} -> desc
+      {:error, _} -> kind |> to_string() |> String.replace("_", " ") |> String.capitalize()
+    end
+  end
 
   defp format_state(state) do
     state

--- a/test/lattice/intents/kind_test.exs
+++ b/test/lattice/intents/kind_test.exs
@@ -1,0 +1,241 @@
+defmodule Lattice.Intents.KindTest do
+  use ExUnit.Case
+
+  @moduletag :unit
+
+  alias Lattice.Intents.Kind
+  alias Lattice.Intents.Intent
+
+  setup do
+    Kind.init()
+    :ok
+  end
+
+  # ── Registry ──────────────────────────────────────────────────────────
+
+  describe "registry" do
+    test "registered/0 includes all built-in kinds" do
+      kinds = Kind.registered()
+      assert :action in kinds
+      assert :inquiry in kinds
+      assert :maintenance in kinds
+    end
+
+    test "registered/0 includes extended kinds" do
+      kinds = Kind.registered()
+      assert :issue_triage in kinds
+      assert :pr_fixup in kinds
+      assert :pr_create in kinds
+    end
+
+    test "lookup/1 returns module for registered kind" do
+      assert {:ok, Kind.Action} = Kind.lookup(:action)
+      assert {:ok, Kind.IssueTriage} = Kind.lookup(:issue_triage)
+    end
+
+    test "lookup/1 returns error for unknown kind" do
+      assert {:error, :unknown_kind} = Kind.lookup(:nonexistent)
+    end
+
+    test "all/0 returns metadata for each kind" do
+      all = Kind.all()
+      action = Enum.find(all, &(&1.name == :action))
+      assert action.description == "Action"
+      assert action.module == Kind.Action
+    end
+
+    test "valid?/1 returns true for registered kinds" do
+      assert Kind.valid?(:action)
+      assert Kind.valid?(:issue_triage)
+      refute Kind.valid?(:nonexistent)
+    end
+  end
+
+  # ── Custom kind registration ────────────────────────────────────────
+
+  describe "register/1" do
+    defmodule TestKind do
+      @behaviour Kind
+
+      @impl true
+      def name, do: :test_custom
+
+      @impl true
+      def description, do: "Test Custom"
+
+      @impl true
+      def required_payload_fields, do: ["custom_field"]
+
+      @impl true
+      def default_classification, do: :dangerous
+    end
+
+    test "registers a custom kind" do
+      Kind.register(TestKind)
+      assert {:ok, TestKind} = Kind.lookup(:test_custom)
+      assert :test_custom in Kind.registered()
+    end
+  end
+
+  # ── Payload validation ──────────────────────────────────────────────
+
+  describe "validate_payload/2" do
+    test "returns :ok when all required fields present" do
+      assert :ok =
+               Kind.validate_payload(:action, %{"capability" => "fly", "operation" => "deploy"})
+    end
+
+    test "returns warning when required fields missing" do
+      assert {:warn, missing} = Kind.validate_payload(:action, %{"capability" => "fly"})
+      assert "operation" in missing
+    end
+
+    test "returns :ok for maintenance (no required fields)" do
+      assert :ok = Kind.validate_payload(:maintenance, %{})
+    end
+
+    test "returns :ok for unknown kind" do
+      assert :ok = Kind.validate_payload(:completely_unknown, %{"anything" => true})
+    end
+
+    test "validates issue_triage requires issue_url" do
+      assert {:warn, ["issue_url"]} = Kind.validate_payload(:issue_triage, %{})
+
+      assert :ok =
+               Kind.validate_payload(:issue_triage, %{"issue_url" => "https://github.com/..."})
+    end
+
+    test "validates pr_fixup requires pr_url and feedback" do
+      assert {:warn, missing} = Kind.validate_payload(:pr_fixup, %{})
+      assert "pr_url" in missing
+      assert "feedback" in missing
+    end
+
+    test "validates pr_create requires repo and branch" do
+      assert {:warn, missing} = Kind.validate_payload(:pr_create, %{})
+      assert "repo" in missing
+      assert "branch" in missing
+    end
+  end
+
+  # ── Default classification ──────────────────────────────────────────
+
+  describe "default_classification/1" do
+    test "returns correct defaults for built-in kinds" do
+      assert {:ok, :controlled} = Kind.default_classification(:action)
+      assert {:ok, :controlled} = Kind.default_classification(:inquiry)
+      assert {:ok, :safe} = Kind.default_classification(:maintenance)
+    end
+
+    test "returns correct defaults for extended kinds" do
+      assert {:ok, :controlled} = Kind.default_classification(:issue_triage)
+      assert {:ok, :controlled} = Kind.default_classification(:pr_fixup)
+      assert {:ok, :controlled} = Kind.default_classification(:pr_create)
+    end
+
+    test "returns error for unknown kind" do
+      assert {:error, :unknown_kind} = Kind.default_classification(:nonexistent)
+    end
+  end
+
+  # ── Kind behaviour in Intent constructors ──────────────────────────
+
+  describe "Intent.new/3 with extended kinds" do
+    test "creates intent with issue_triage kind" do
+      {:ok, intent} =
+        Intent.new(:issue_triage, %{type: :webhook, id: "gh-123"},
+          summary: "Triage issue #42",
+          payload: %{"issue_url" => "https://github.com/org/repo/issues/42"}
+        )
+
+      assert intent.kind == :issue_triage
+      assert intent.state == :proposed
+    end
+
+    test "creates intent with pr_fixup kind" do
+      {:ok, intent} =
+        Intent.new(:pr_fixup, %{type: :webhook, id: "gh-456"},
+          summary: "Fix PR #10 review comments",
+          payload: %{"pr_url" => "https://github.com/org/repo/pull/10", "feedback" => "fix typo"}
+        )
+
+      assert intent.kind == :pr_fixup
+    end
+
+    test "creates intent with pr_create kind" do
+      {:ok, intent} =
+        Intent.new(:pr_create, %{type: :agent, id: "agent-1"},
+          summary: "Create PR from plan",
+          payload: %{"repo" => "org/repo", "branch" => "feat/new-feature"}
+        )
+
+      assert intent.kind == :pr_create
+    end
+
+    test "logs warning for missing recommended fields" do
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          {:ok, _intent} =
+            Intent.new(:issue_triage, %{type: :webhook, id: "gh-789"},
+              summary: "Triage without URL",
+              payload: %{"other" => "data"}
+            )
+        end)
+
+      assert log =~ "missing recommended payload fields"
+      assert log =~ "issue_url"
+    end
+
+    test "Intent.registered_kinds/0 returns all kinds" do
+      kinds = Intent.registered_kinds()
+      assert :action in kinds
+      assert :issue_triage in kinds
+      assert :pr_fixup in kinds
+      assert :pr_create in kinds
+    end
+  end
+
+  # ── Kind modules ───────────────────────────────────────────────────
+
+  describe "built-in kind modules" do
+    test "Action kind" do
+      assert Kind.Action.name() == :action
+      assert Kind.Action.description() == "Action"
+      assert Kind.Action.default_classification() == :controlled
+      assert Kind.Action.required_payload_fields() == ["capability", "operation"]
+    end
+
+    test "Inquiry kind" do
+      assert Kind.Inquiry.name() == :inquiry
+      assert Kind.Inquiry.description() == "Inquiry"
+      assert Kind.Inquiry.default_classification() == :controlled
+    end
+
+    test "Maintenance kind" do
+      assert Kind.Maintenance.name() == :maintenance
+      assert Kind.Maintenance.default_classification() == :safe
+      assert Kind.Maintenance.required_payload_fields() == []
+    end
+
+    test "IssueTriage kind" do
+      assert Kind.IssueTriage.name() == :issue_triage
+      assert Kind.IssueTriage.description() == "Issue Triage"
+      assert Kind.IssueTriage.default_classification() == :controlled
+      assert Kind.IssueTriage.required_payload_fields() == ["issue_url"]
+    end
+
+    test "PrFixup kind" do
+      assert Kind.PrFixup.name() == :pr_fixup
+      assert Kind.PrFixup.description() == "PR Fixup"
+      assert Kind.PrFixup.required_payload_fields() == ["pr_url", "feedback"]
+    end
+
+    test "PrCreate kind" do
+      assert Kind.PrCreate.name() == :pr_create
+      assert Kind.PrCreate.description() == "PR Create"
+      assert Kind.PrCreate.required_payload_fields() == ["repo", "branch"]
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Kind` behaviour and ETS-backed registry for intent kinds
- Implements 6 kind modules: Action, Inquiry, Maintenance (built-in), IssueTriage, PrFixup, PrCreate (extended)
- Adds `Intent.new/3` generic constructor that works with any registered kind, with advisory payload validation
- Updates `Pipeline.classify_intent/1` to use kind-specific default classification as fallback
- Updates dashboard and detail view to use registry for kind labels and filters
- Initializes registry at application startup

## Test plan

- [x] 28 unit tests in `kind_test.exs`
- [x] Full test suite: 1310 tests, 0 failures
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)