### PR TITLE
Add PR review reading and feedback signal parsing (#134)

### DIFF
--- a/lib/lattice/capabilities/github.ex
+++ b/lib/lattice/capabilities/github.ex
@@ -90,6 +90,16 @@ defmodule Lattice.Capabilities.GitHub do
   @doc "Delete a branch."
   @callback delete_branch(branch_name()) :: :ok | {:error, term()}
 
+  @doc "List reviews on a pull request."
+  @callback list_reviews(pr_number()) :: {:ok, [map()]} | {:error, term()}
+
+  @doc "List inline review comments on a pull request."
+  @callback list_review_comments(pr_number()) :: {:ok, [map()]} | {:error, term()}
+
+  @doc "Create an inline review comment on a pull request."
+  @callback create_review_comment(pr_number(), String.t(), String.t(), integer(), keyword()) ::
+              {:ok, map()} | {:error, term()}
+
   @doc "Create a new GitHub issue with the given attributes."
   def create_issue(title, attrs), do: impl().create_issue(title, attrs)
 
@@ -131,6 +141,16 @@ defmodule Lattice.Capabilities.GitHub do
 
   @doc "Delete a branch."
   def delete_branch(name), do: impl().delete_branch(name)
+
+  @doc "List reviews on a pull request."
+  def list_reviews(pr_number), do: impl().list_reviews(pr_number)
+
+  @doc "List inline review comments on a pull request."
+  def list_review_comments(pr_number), do: impl().list_review_comments(pr_number)
+
+  @doc "Create an inline review comment on a pull request."
+  def create_review_comment(pr_number, body, path, line, opts \\ []),
+    do: impl().create_review_comment(pr_number, body, path, line, opts)
 
   defp impl, do: Application.get_env(:lattice, :capabilities)[:github]
 end

--- a/lib/lattice/capabilities/github/feedback_parser.ex
+++ b/lib/lattice/capabilities/github/feedback_parser.ex
@@ -1,0 +1,80 @@
+defmodule Lattice.Capabilities.GitHub.FeedbackParser do
+  @moduledoc """
+  Pure function module that transforms GitHub PR review data into
+  structured feedback signals.
+
+  Takes lists of `%Review{}` and `%ReviewComment{}` structs from the
+  GitHub capability and produces actionable signals for intent creation.
+  """
+
+  alias Lattice.Capabilities.GitHub.Review
+  alias Lattice.Capabilities.GitHub.ReviewComment
+
+  @type feedback_signal ::
+          {:approved, String.t()}
+          | {:changes_requested, String.t(), [ReviewComment.t()]}
+          | {:commented, String.t(), [ReviewComment.t()]}
+
+  @action_keywords ~w(please should fix change add remove update rename move delete replace refactor)
+
+  @doc """
+  Parse reviews into structured feedback signals.
+
+  Groups inline comments by reviewer and returns one signal per review:
+  - `{:approved, reviewer}` — reviewer approved
+  - `{:changes_requested, reviewer, comments}` — reviewer wants changes
+  - `{:commented, reviewer, comments}` — general feedback
+  """
+  @spec parse_reviews([Review.t()], [ReviewComment.t()]) :: [feedback_signal()]
+  def parse_reviews(reviews, comments \\ []) do
+    comments_by_author = group_by_author(comments)
+
+    reviews
+    |> Enum.map(fn review ->
+      author_comments = Map.get(comments_by_author, review.author, [])
+
+      case review.state do
+        :approved ->
+          {:approved, review.author}
+
+        :changes_requested ->
+          {:changes_requested, review.author, author_comments}
+
+        :commented ->
+          {:commented, review.author, author_comments}
+      end
+    end)
+  end
+
+  @doc """
+  Group inline review comments by file path.
+
+  Returns a map of `%{path => [%ReviewComment{}]}`, useful for generating
+  per-file fixup tasks.
+  """
+  @spec group_by_file([ReviewComment.t()]) :: %{String.t() => [ReviewComment.t()]}
+  def group_by_file(comments) do
+    comments
+    |> Enum.filter(& &1.path)
+    |> Enum.group_by(& &1.path)
+  end
+
+  @doc """
+  Extract action items from review comments.
+
+  Uses simple keyword matching to identify comments that likely contain
+  actionable feedback. Returns only comments whose body contains one
+  or more action keywords.
+  """
+  @spec extract_action_items([ReviewComment.t()]) :: [ReviewComment.t()]
+  def extract_action_items(comments) do
+    Enum.filter(comments, fn comment ->
+      body_lower = String.downcase(comment.body)
+      Enum.any?(@action_keywords, &String.contains?(body_lower, &1))
+    end)
+  end
+
+  defp group_by_author(comments) do
+    Enum.group_by(comments, & &1.author)
+  end
+end

--- a/lib/lattice/capabilities/github/review.ex
+++ b/lib/lattice/capabilities/github/review.ex
@@ -1,0 +1,36 @@
+defmodule Lattice.Capabilities.GitHub.Review do
+  @moduledoc """
+  Struct representing a GitHub pull request review.
+
+  A review has a verdict (`state`) of `:approved`, `:changes_requested`,
+  or `:commented`, along with optional body text.
+  """
+
+  @type t :: %__MODULE__{
+          id: integer(),
+          author: String.t(),
+          state: :approved | :changes_requested | :commented,
+          body: String.t(),
+          submitted_at: String.t()
+        }
+
+  @enforce_keys [:id, :author, :state]
+  defstruct [:id, :author, :state, :submitted_at, body: ""]
+
+  @doc "Build a Review from a GitHub API JSON map."
+  @spec from_json(map()) :: t()
+  def from_json(data) when is_map(data) do
+    %__MODULE__{
+      id: data["id"],
+      author: get_in(data, ["user", "login"]) || data["author"] || "",
+      state: parse_state(data["state"]),
+      body: data["body"] || "",
+      submitted_at: data["submitted_at"] || data["submittedAt"]
+    }
+  end
+
+  defp parse_state("APPROVED"), do: :approved
+  defp parse_state("CHANGES_REQUESTED"), do: :changes_requested
+  defp parse_state("COMMENTED"), do: :commented
+  defp parse_state(_), do: :commented
+end

--- a/lib/lattice/capabilities/github/review_comment.ex
+++ b/lib/lattice/capabilities/github/review_comment.ex
@@ -1,0 +1,37 @@
+defmodule Lattice.Capabilities.GitHub.ReviewComment do
+  @moduledoc """
+  Struct representing an inline review comment on a pull request.
+
+  Inline comments are tied to a specific `path` and `line` in a commit.
+  Threads are linked via `in_reply_to_id`.
+  """
+
+  @type t :: %__MODULE__{
+          id: integer(),
+          path: String.t(),
+          line: integer() | nil,
+          body: String.t(),
+          author: String.t(),
+          created_at: String.t(),
+          in_reply_to_id: integer() | nil,
+          commit_id: String.t() | nil
+        }
+
+  @enforce_keys [:id, :body, :author]
+  defstruct [:id, :path, :line, :body, :author, :created_at, :in_reply_to_id, :commit_id]
+
+  @doc "Build a ReviewComment from a GitHub API JSON map."
+  @spec from_json(map()) :: t()
+  def from_json(data) when is_map(data) do
+    %__MODULE__{
+      id: data["id"],
+      path: data["path"],
+      line: data["line"] || data["original_line"],
+      body: data["body"] || "",
+      author: get_in(data, ["user", "login"]) || data["author"] || "",
+      created_at: data["created_at"] || data["createdAt"],
+      in_reply_to_id: data["in_reply_to_id"],
+      commit_id: data["commit_id"] || data["original_commit_id"]
+    }
+  end
+end

--- a/lib/lattice/safety/classifier.ex
+++ b/lib/lattice/safety/classifier.ex
@@ -64,6 +64,10 @@ defmodule Lattice.Safety.Classifier do
     {:github, :merge_pull_request} => :controlled,
     {:github, :create_branch} => :controlled,
     {:github, :delete_branch} => :controlled,
+    # GitHub — Reviews
+    {:github, :list_reviews} => :safe,
+    {:github, :list_review_comments} => :safe,
+    {:github, :create_review_comment} => :controlled,
     # Fly.io
     {:fly, :logs} => :safe,
     {:fly, :machine_status} => :safe,

--- a/test/lattice/capabilities/github/feedback_parser_test.exs
+++ b/test/lattice/capabilities/github/feedback_parser_test.exs
@@ -1,0 +1,161 @@
+defmodule Lattice.Capabilities.GitHub.FeedbackParserTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Capabilities.GitHub.FeedbackParser
+  alias Lattice.Capabilities.GitHub.Review
+  alias Lattice.Capabilities.GitHub.ReviewComment
+
+  describe "parse_reviews/2" do
+    test "returns :approved signal for approved review" do
+      reviews = [%Review{id: 1, author: "alice", state: :approved}]
+
+      assert [{:approved, "alice"}] = FeedbackParser.parse_reviews(reviews)
+    end
+
+    test "returns :changes_requested signal with inline comments" do
+      reviews = [%Review{id: 1, author: "bob", state: :changes_requested}]
+
+      comments = [
+        %ReviewComment{
+          id: 10,
+          body: "Please fix this",
+          author: "bob",
+          path: "lib/foo.ex",
+          line: 5
+        }
+      ]
+
+      assert [{:changes_requested, "bob", matched_comments}] =
+               FeedbackParser.parse_reviews(reviews, comments)
+
+      assert length(matched_comments) == 1
+      assert hd(matched_comments).body == "Please fix this"
+    end
+
+    test "returns :commented signal for general feedback" do
+      reviews = [%Review{id: 1, author: "carol", state: :commented}]
+
+      assert [{:commented, "carol", []}] = FeedbackParser.parse_reviews(reviews)
+    end
+
+    test "handles mixed review verdicts" do
+      reviews = [
+        %Review{id: 1, author: "alice", state: :approved},
+        %Review{id: 2, author: "bob", state: :changes_requested}
+      ]
+
+      comments = [
+        %ReviewComment{id: 10, body: "Fix the bug", author: "bob", path: "lib/bug.ex", line: 10}
+      ]
+
+      signals = FeedbackParser.parse_reviews(reviews, comments)
+
+      assert {:approved, "alice"} in signals
+
+      assert Enum.any?(signals, fn
+               {:changes_requested, "bob", [comment]} -> comment.body == "Fix the bug"
+               _ -> false
+             end)
+    end
+
+    test "comments without matching reviewer get empty list" do
+      reviews = [%Review{id: 1, author: "alice", state: :changes_requested}]
+
+      comments = [
+        %ReviewComment{id: 10, body: "My comment", author: "bob", path: "lib/foo.ex", line: 1}
+      ]
+
+      assert [{:changes_requested, "alice", []}] =
+               FeedbackParser.parse_reviews(reviews, comments)
+    end
+  end
+
+  describe "group_by_file/1" do
+    test "groups comments by file path" do
+      comments = [
+        %ReviewComment{id: 1, body: "Fix A", author: "alice", path: "lib/a.ex", line: 1},
+        %ReviewComment{id: 2, body: "Fix B", author: "alice", path: "lib/b.ex", line: 5},
+        %ReviewComment{id: 3, body: "Fix A2", author: "bob", path: "lib/a.ex", line: 10}
+      ]
+
+      grouped = FeedbackParser.group_by_file(comments)
+
+      assert length(grouped["lib/a.ex"]) == 2
+      assert length(grouped["lib/b.ex"]) == 1
+    end
+
+    test "skips comments without a path" do
+      comments = [
+        %ReviewComment{id: 1, body: "General", author: "alice", path: nil, line: nil},
+        %ReviewComment{id: 2, body: "Inline", author: "alice", path: "lib/foo.ex", line: 5}
+      ]
+
+      grouped = FeedbackParser.group_by_file(comments)
+
+      assert map_size(grouped) == 1
+      assert Map.has_key?(grouped, "lib/foo.ex")
+    end
+
+    test "returns empty map for empty list" do
+      assert %{} == FeedbackParser.group_by_file([])
+    end
+  end
+
+  describe "extract_action_items/1" do
+    test "matches comments with action keywords" do
+      comments = [
+        %ReviewComment{
+          id: 1,
+          body: "Please rename this variable",
+          author: "alice",
+          path: "lib/a.ex",
+          line: 1
+        },
+        %ReviewComment{id: 2, body: "Looks good!", author: "alice", path: "lib/b.ex", line: 1},
+        %ReviewComment{
+          id: 3,
+          body: "You should add a test",
+          author: "bob",
+          path: "lib/c.ex",
+          line: 1
+        }
+      ]
+
+      items = FeedbackParser.extract_action_items(comments)
+
+      assert length(items) == 2
+      bodies = Enum.map(items, & &1.body)
+      assert "Please rename this variable" in bodies
+      assert "You should add a test" in bodies
+    end
+
+    test "is case insensitive" do
+      comments = [
+        %ReviewComment{id: 1, body: "PLEASE FIX THIS", author: "alice", path: "lib/a.ex", line: 1}
+      ]
+
+      assert length(FeedbackParser.extract_action_items(comments)) == 1
+    end
+
+    test "returns empty list when no action keywords found" do
+      comments = [
+        %ReviewComment{
+          id: 1,
+          body: "Interesting approach",
+          author: "alice",
+          path: "lib/a.ex",
+          line: 1
+        },
+        %ReviewComment{id: 2, body: "Nice!", author: "bob", path: "lib/b.ex", line: 1}
+      ]
+
+      assert [] == FeedbackParser.extract_action_items(comments)
+    end
+
+    test "returns empty list for empty input" do
+      assert [] == FeedbackParser.extract_action_items([])
+    end
+  end
+end

--- a/test/lattice/capabilities/github/review_test.exs
+++ b/test/lattice/capabilities/github/review_test.exs
@@ -1,0 +1,103 @@
+defmodule Lattice.Capabilities.GitHub.ReviewTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Capabilities.GitHub.Review
+  alias Lattice.Capabilities.GitHub.ReviewComment
+
+  describe "Review.from_json/1" do
+    test "parses approved review" do
+      json = %{
+        "id" => 123,
+        "user" => %{"login" => "alice"},
+        "state" => "APPROVED",
+        "body" => "LGTM",
+        "submitted_at" => "2026-01-15T10:00:00Z"
+      }
+
+      review = Review.from_json(json)
+
+      assert review.id == 123
+      assert review.author == "alice"
+      assert review.state == :approved
+      assert review.body == "LGTM"
+      assert review.submitted_at == "2026-01-15T10:00:00Z"
+    end
+
+    test "parses changes_requested review" do
+      json = %{
+        "id" => 456,
+        "user" => %{"login" => "bob"},
+        "state" => "CHANGES_REQUESTED",
+        "body" => "Need fixes",
+        "submitted_at" => "2026-01-15T11:00:00Z"
+      }
+
+      review = Review.from_json(json)
+      assert review.state == :changes_requested
+    end
+
+    test "defaults unknown state to :commented" do
+      json = %{"id" => 1, "user" => %{"login" => "x"}, "state" => "PENDING"}
+      assert Review.from_json(json).state == :commented
+    end
+
+    test "handles missing body" do
+      json = %{"id" => 1, "user" => %{"login" => "x"}, "state" => "COMMENTED"}
+      assert Review.from_json(json).body == ""
+    end
+  end
+
+  describe "ReviewComment.from_json/1" do
+    test "parses inline comment" do
+      json = %{
+        "id" => 789,
+        "path" => "lib/foo.ex",
+        "line" => 42,
+        "body" => "Please fix this",
+        "user" => %{"login" => "alice"},
+        "created_at" => "2026-01-15T12:00:00Z",
+        "in_reply_to_id" => nil,
+        "commit_id" => "abc123"
+      }
+
+      comment = ReviewComment.from_json(json)
+
+      assert comment.id == 789
+      assert comment.path == "lib/foo.ex"
+      assert comment.line == 42
+      assert comment.body == "Please fix this"
+      assert comment.author == "alice"
+      assert comment.commit_id == "abc123"
+      assert comment.in_reply_to_id == nil
+    end
+
+    test "falls back to original_line when line is nil" do
+      json = %{
+        "id" => 1,
+        "path" => "lib/foo.ex",
+        "line" => nil,
+        "original_line" => 10,
+        "body" => "test",
+        "user" => %{"login" => "bob"}
+      }
+
+      assert ReviewComment.from_json(json).line == 10
+    end
+
+    test "parses reply comment" do
+      json = %{
+        "id" => 2,
+        "path" => "lib/foo.ex",
+        "line" => 5,
+        "body" => "Done!",
+        "user" => %{"login" => "carol"},
+        "in_reply_to_id" => 1
+      }
+
+      comment = ReviewComment.from_json(json)
+      assert comment.in_reply_to_id == 1
+    end
+  end
+end

--- a/test/lattice/capabilities/github_review_test.exs
+++ b/test/lattice/capabilities/github_review_test.exs
@@ -1,0 +1,70 @@
+defmodule Lattice.Capabilities.GitHubReviewTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  @moduletag :unit
+
+  alias Lattice.Capabilities.GitHub
+
+  setup :verify_on_exit!
+
+  describe "list_reviews/1" do
+    test "delegates to the configured implementation" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:list_reviews, fn pr_number ->
+        assert pr_number == 42
+        {:ok, [%{id: 1, author: "alice", state: :approved, body: "LGTM"}]}
+      end)
+
+      assert {:ok, [review]} = GitHub.list_reviews(42)
+      assert review.author == "alice"
+    end
+  end
+
+  describe "list_review_comments/1" do
+    test "delegates to the configured implementation" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:list_review_comments, fn pr_number ->
+        assert pr_number == 42
+
+        {:ok,
+         [
+           %{id: 10, path: "lib/foo.ex", line: 5, body: "Fix this", author: "bob"}
+         ]}
+      end)
+
+      assert {:ok, [comment]} = GitHub.list_review_comments(42)
+      assert comment.path == "lib/foo.ex"
+    end
+  end
+
+  describe "create_review_comment/5" do
+    test "delegates to the configured implementation" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_review_comment, fn pr_number, body, path, line, opts ->
+        assert pr_number == 42
+        assert body == "Please fix"
+        assert path == "lib/foo.ex"
+        assert line == 10
+        assert opts == []
+
+        {:ok, %{id: 20, body: body, path: path, line: line, author: "lattice-bot"}}
+      end)
+
+      assert {:ok, comment} = GitHub.create_review_comment(42, "Please fix", "lib/foo.ex", 10)
+      assert comment.body == "Please fix"
+    end
+
+    test "passes options through" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_review_comment, fn _pr, _body, _path, _line, opts ->
+        assert opts[:commit_id] == "abc123"
+        {:ok, %{id: 21}}
+      end)
+
+      assert {:ok, _} =
+               GitHub.create_review_comment(42, "Note", "lib/bar.ex", 5, commit_id: "abc123")
+    end
+  end
+end

--- a/test/lattice/safety/classifier_test.exs
+++ b/test/lattice/safety/classifier_test.exs
@@ -121,6 +121,21 @@ defmodule Lattice.Safety.ClassifierTest do
                Classifier.classify(:github, :delete_branch)
     end
 
+    test "classifies github:list_reviews as safe" do
+      assert {:ok, %Action{classification: :safe}} =
+               Classifier.classify(:github, :list_reviews)
+    end
+
+    test "classifies github:list_review_comments as safe" do
+      assert {:ok, %Action{classification: :safe}} =
+               Classifier.classify(:github, :list_review_comments)
+    end
+
+    test "classifies github:create_review_comment as controlled" do
+      assert {:ok, %Action{classification: :controlled}} =
+               Classifier.classify(:github, :create_review_comment)
+    end
+
     # ── Dangerous Actions ──────────────────────────────────────────────
 
     test "classifies sprites:delete_sprite as dangerous" do
@@ -176,6 +191,8 @@ defmodule Lattice.Safety.ClassifierTest do
       assert {:github, :get_issue} in safe_actions
       assert {:github, :list_pull_requests} in safe_actions
       assert {:github, :get_pull_request} in safe_actions
+      assert {:github, :list_reviews} in safe_actions
+      assert {:github, :list_review_comments} in safe_actions
       assert {:fly, :logs} in safe_actions
       assert {:fly, :machine_status} in safe_actions
       assert {:secret_store, :get_secret} in safe_actions
@@ -222,9 +239,9 @@ defmodule Lattice.Safety.ClassifierTest do
       sprites_ops = Enum.filter(all, fn {{cap, _op}, _class} -> cap == :sprites end)
       assert length(sprites_ops) == 8
 
-      # GitHub: 14 operations (7 issue + 7 PR/branch)
+      # GitHub: 17 operations (7 issue + 7 PR/branch + 3 reviews)
       github_ops = Enum.filter(all, fn {{cap, _op}, _class} -> cap == :github end)
-      assert length(github_ops) == 14
+      assert length(github_ops) == 17
 
       # Fly: 3 operations
       fly_ops = Enum.filter(all, fn {{cap, _op}, _class} -> cap == :fly end)


### PR DESCRIPTION
## Summary
- Adds 3 new callbacks to GitHub behaviour: `list_reviews`, `list_review_comments`, `create_review_comment`
- Defines `%Review{}` and `%ReviewComment{}` structs for structured API response data
- Implements `FeedbackParser` module: `parse_reviews/2` (extracts approved/changes_requested/commented signals), `group_by_file/1` (groups inline comments by file path), `extract_action_items/1` (heuristic keyword-based action item extraction)
- Registers 3 new operations in Safety Classifier (2 safe, 1 controlled)
- Full test coverage: struct parsing, feedback parsing, delegation, classifier

## Test plan
- [x] All 1354 tests pass, 0 failures
- [x] 26 new tests (7 struct, 12 feedback parser, 4 delegation, 3 classifier)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format` clean

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)