### PR TITLE
Add structured system comments with sentinel markers (#135)

### DIFF
--- a/lib/lattice/capabilities/github/comments.ex
+++ b/lib/lattice/capabilities/github/comments.ex
@@ -1,0 +1,216 @@
+defmodule Lattice.Capabilities.GitHub.Comments do
+  @moduledoc """
+  Structured comment templates for GitHub-based human-in-the-loop governance.
+
+  Renders machine-parseable Markdown comments with sentinel markers (HTML
+  comments invisible to GitHub users). These enable Lattice to both post
+  structured information and later read back responses.
+
+  ## Sentinel Markers
+
+  Each comment type includes a sentinel like:
+
+      <!-- lattice:question intent_id=int_xxx -->
+
+  These are parsed by `Lattice.Capabilities.GitHub.Comments.Parser`.
+  """
+
+  alias Lattice.Intents.Intent
+
+  @doc """
+  Render a question comment for an intent in `:waiting_for_input` state.
+
+  The `questions` parameter should be a list of maps with `:text` keys,
+  or a single map with a `:text` key for a single question.
+  """
+  @spec question_comment(Intent.t(), list() | map()) :: String.t()
+  def question_comment(%Intent{} = intent, questions) do
+    questions = List.wrap(questions)
+
+    question_list =
+      questions
+      |> Enum.with_index(1)
+      |> Enum.map_join("\n", fn {q, i} ->
+        text = extract_question_text(q)
+        "- [ ] **#{i}.** #{text}"
+      end)
+
+    """
+    ## Lattice needs your input
+
+    **Intent:** `#{intent.id}` — #{intent.summary || "No summary"}
+
+    #{question_list}
+
+    **How to respond:** Reply to this comment with your answers. Check the boxes above or write your response below.
+
+    #{sentinel(:question, intent)}
+    _Posted by Lattice._\
+    """
+    |> String.trim()
+  end
+
+  @doc """
+  Render a plan comment showing the proposed execution plan.
+  """
+  @spec plan_comment(Intent.t(), map() | nil) :: String.t()
+  def plan_comment(%Intent{} = intent, plan) when not is_nil(plan) do
+    plan_body =
+      if is_binary(plan.rendered_markdown) and plan.rendered_markdown != "" do
+        plan.rendered_markdown
+      else
+        render_plan_steps(plan)
+      end
+
+    version = Map.get(plan, :version, 1)
+
+    """
+    ## Proposed Execution Plan
+
+    **Intent:** `#{intent.id}` — #{intent.summary || "No summary"}
+
+    #{plan_body}
+
+    **To approve:** Add the `intent-approved` label to this issue.
+    **To reject:** Add the `intent-rejected` label.
+
+    #{sentinel(:plan, intent, version: version)}
+    _Posted by Lattice._\
+    """
+    |> String.trim()
+  end
+
+  @doc """
+  Render an execution summary comment with outcome, duration, and artifacts.
+  """
+  @spec summary_comment(Intent.t(), map()) :: String.t()
+  def summary_comment(%Intent{} = intent, result) do
+    status = Map.get(result, :status, :unknown)
+    status_label = status_emoji(status)
+    duration = format_duration(Map.get(result, :duration_ms))
+
+    output_section = format_output(result)
+    artifacts_section = format_artifacts(intent)
+
+    """
+    ## Execution #{status_label}
+
+    **Intent:** `#{intent.id}` — #{intent.summary || "No summary"}
+    **Duration:** #{duration}
+
+    #{output_section}#{artifacts_section}
+    #{sentinel(:summary, intent)}
+    _Posted by Lattice._\
+    """
+    |> String.trim()
+  end
+
+  @doc """
+  Render a progress update comment showing current plan step.
+  """
+  @spec progress_comment(Intent.t(), map()) :: String.t()
+  def progress_comment(%Intent{} = intent, update) do
+    current_step = Map.get(update, :current_step, "?")
+    total_steps = Map.get(update, :total_steps, "?")
+    message = Map.get(update, :message, "Execution in progress.")
+
+    """
+    ## Progress Update
+
+    **Intent:** `#{intent.id}`
+    **Step:** #{current_step} of #{total_steps}
+
+    #{message}
+
+    #{sentinel(:progress, intent)}
+    _Posted by Lattice._\
+    """
+    |> String.trim()
+  end
+
+  # ── Private: Question Helpers ──────────────────────────────────────
+
+  defp extract_question_text(%{text: text}), do: text
+  defp extract_question_text(%{"text" => text}), do: text
+  defp extract_question_text(text) when is_binary(text), do: text
+  defp extract_question_text(other), do: inspect(other)
+
+  # ── Private: Sentinel Markers ─────────────────────────────────────
+
+  defp sentinel(type, %Intent{id: id}, opts \\ []) do
+    extra =
+      opts
+      |> Enum.map_join(" ", fn {k, v} -> "#{k}=#{v}" end)
+
+    extra_str = if extra == "", do: "", else: " #{extra}"
+    "<!-- lattice:#{type} intent_id=#{id}#{extra_str} -->"
+  end
+
+  # ── Private: Plan Rendering ───────────────────────────────────────
+
+  defp render_plan_steps(%{steps: steps}) when is_list(steps) do
+    steps
+    |> Enum.with_index(1)
+    |> Enum.map_join("\n", fn {step, i} ->
+      skill = if step.skill, do: " `#{step.skill}`", else: ""
+      checkbox = step_checkbox(step.status)
+      "#{i}. #{checkbox} #{step.description}#{skill}"
+    end)
+  end
+
+  defp render_plan_steps(_), do: "_No steps defined._"
+
+  defp step_checkbox(:completed), do: "[x]"
+  defp step_checkbox(:running), do: "[~]"
+  defp step_checkbox(:failed), do: "[!]"
+  defp step_checkbox(:skipped), do: "[-]"
+  defp step_checkbox(_), do: "[ ]"
+
+  # ── Private: Summary Helpers ──────────────────────────────────────
+
+  defp status_emoji(:success), do: "Completed"
+  defp status_emoji(:failure), do: "Failed"
+  defp status_emoji(_), do: "Outcome"
+
+  defp format_duration(nil), do: "N/A"
+  defp format_duration(ms) when is_number(ms) and ms < 1000, do: "#{ms}ms"
+  defp format_duration(ms) when is_number(ms), do: "#{Float.round(ms / 1000, 1)}s"
+  defp format_duration(_), do: "N/A"
+
+  defp format_output(result) do
+    cond do
+      Map.has_key?(result, :error) and result.error != nil ->
+        "### Error\n\n```\n#{inspect(result.error, pretty: true, limit: 500)}\n```\n\n"
+
+      Map.has_key?(result, :output) and result.output != nil ->
+        "### Output\n\n```\n#{inspect(result.output, pretty: true, limit: 500)}\n```\n\n"
+
+      true ->
+        ""
+    end
+  end
+
+  defp format_artifacts(%Intent{metadata: metadata}) when is_map(metadata) do
+    case Map.get(metadata, :artifacts) do
+      artifacts when is_list(artifacts) and artifacts != [] ->
+        items =
+          Enum.map_join(artifacts, "\n", fn artifact ->
+            label = Map.get(artifact, :label, Map.get(artifact, :type, "artifact"))
+            url = Map.get(artifact, :url)
+
+            if url do
+              "- [#{label}](#{url})"
+            else
+              "- #{label}"
+            end
+          end)
+
+        "### Artifacts\n\n#{items}\n\n"
+
+      _ ->
+        ""
+    end
+  end
+
+  defp format_artifacts(_), do: ""
+end

--- a/lib/lattice/capabilities/github/comments/parser.ex
+++ b/lib/lattice/capabilities/github/comments/parser.ex
@@ -1,0 +1,125 @@
+defmodule Lattice.Capabilities.GitHub.Comments.Parser do
+  @moduledoc """
+  Parses user responses from GitHub comments that reply to structured
+  Lattice comments (questions, plans, etc.).
+
+  Uses sentinel markers (`<!-- lattice:... -->`) embedded in the original
+  comment to identify the comment type and extract metadata.
+  """
+
+  @sentinel_regex ~r/<!--\s*lattice:(\w+)\s+(.*?)\s*-->/
+
+  @doc """
+  Extract sentinel metadata from a comment body.
+
+  Returns `{:ok, %{type: atom, attrs: map}}` or `:error` if no sentinel found.
+
+  ## Examples
+
+      iex> extract_sentinel("some text <!-- lattice:question intent_id=int_abc --> footer")
+      {:ok, %{type: :question, attrs: %{"intent_id" => "int_abc"}}}
+
+  """
+  @spec extract_sentinel(String.t()) :: {:ok, %{type: atom(), attrs: map()}} | :error
+  def extract_sentinel(body) when is_binary(body) do
+    case Regex.run(@sentinel_regex, body) do
+      [_, type, attrs_str] ->
+        attrs = parse_attrs(attrs_str)
+        {:ok, %{type: String.to_existing_atom(type), attrs: attrs}}
+
+      nil ->
+        :error
+    end
+  rescue
+    ArgumentError -> :error
+  end
+
+  @doc """
+  Parse a user's response to a question comment.
+
+  Detects checked checkboxes (`- [x]`) and extracts freeform text that
+  isn't part of the original template structure. Returns structured response
+  data or `{:error, :not_a_response}` if the comment doesn't look like a reply.
+
+  ## Examples
+
+      iex> parse_response("- [x] **1.** Deploy to staging\\n- [ ] **2.** Skip\\n\\nAlso please run tests")
+      {:ok, %{checked: [1], freeform: "Also please run tests"}}
+
+  """
+  @spec parse_response(String.t()) ::
+          {:ok, %{checked: [integer()], freeform: String.t()}} | {:error, :not_a_response}
+  def parse_response(body) when is_binary(body) do
+    checked = extract_checked_items(body)
+    freeform = extract_freeform(body)
+
+    if checked == [] and freeform == "" do
+      {:error, :not_a_response}
+    else
+      {:ok, %{checked: checked, freeform: String.trim(freeform)}}
+    end
+  end
+
+  @doc """
+  Parse a full comment, extracting both sentinel info and response data.
+
+  Combines `extract_sentinel/1` and `parse_response/1` for convenience.
+  Returns a structured map with intent_id, comment type, and response payload.
+  """
+  @spec parse_comment(String.t()) ::
+          {:ok, map()} | {:error, :not_a_lattice_comment | :not_a_response}
+  def parse_comment(body) when is_binary(body) do
+    case extract_sentinel(body) do
+      {:ok, %{type: type, attrs: attrs}} ->
+        case parse_response(body) do
+          {:ok, response} ->
+            {:ok,
+             %{
+               intent_id: Map.get(attrs, "intent_id"),
+               type: type,
+               response: response
+             }}
+
+          {:error, _} ->
+            {:error, :not_a_response}
+        end
+
+      :error ->
+        {:error, :not_a_lattice_comment}
+    end
+  end
+
+  # ── Private ──────────────────────────────────────────────────────
+
+  @checked_regex ~r/-\s*\[x\]\s*\*\*(\d+)\.\*\*/i
+
+  defp extract_checked_items(body) do
+    @checked_regex
+    |> Regex.scan(body)
+    |> Enum.map(fn [_, num] -> String.to_integer(num) end)
+    |> Enum.sort()
+  end
+
+  defp extract_freeform(body) do
+    body
+    |> String.split("\n")
+    |> Enum.reject(fn line ->
+      trimmed = String.trim(line)
+
+      trimmed == "" or
+        String.starts_with?(trimmed, "- [") or
+        String.starts_with?(trimmed, "##") or
+        String.starts_with?(trimmed, "**") or
+        String.starts_with?(trimmed, "<!--") or
+        String.starts_with?(trimmed, "_Posted by")
+    end)
+    |> Enum.join("\n")
+    |> String.trim()
+  end
+
+  defp parse_attrs(attrs_str) do
+    ~r/(\w+)=(\S+)/
+    |> Regex.scan(attrs_str)
+    |> Map.new(fn [_, key, value] -> {key, value} end)
+  end
+end

--- a/test/lattice/capabilities/github/comments/parser_test.exs
+++ b/test/lattice/capabilities/github/comments/parser_test.exs
@@ -1,0 +1,165 @@
+defmodule Lattice.Capabilities.GitHub.Comments.ParserTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Capabilities.GitHub.Comments.Parser
+
+  describe "extract_sentinel/1" do
+    test "extracts question sentinel" do
+      body = "some text\n<!-- lattice:question intent_id=int_abc -->\nfooter"
+
+      assert {:ok, %{type: :question, attrs: %{"intent_id" => "int_abc"}}} =
+               Parser.extract_sentinel(body)
+    end
+
+    test "extracts plan sentinel with version" do
+      body = "<!-- lattice:plan intent_id=int_xyz version=3 -->"
+
+      assert {:ok, %{type: :plan, attrs: attrs}} = Parser.extract_sentinel(body)
+      assert attrs["intent_id"] == "int_xyz"
+      assert attrs["version"] == "3"
+    end
+
+    test "extracts summary sentinel" do
+      body = "## Summary\n<!-- lattice:summary intent_id=int_123 -->"
+
+      assert {:ok, %{type: :summary, attrs: %{"intent_id" => "int_123"}}} =
+               Parser.extract_sentinel(body)
+    end
+
+    test "returns :error when no sentinel present" do
+      assert :error = Parser.extract_sentinel("Just a regular comment")
+    end
+
+    test "returns :error for invalid atom type" do
+      assert :error = Parser.extract_sentinel("<!-- lattice:nonexistent_type_abc intent_id=x -->")
+    end
+  end
+
+  describe "parse_response/1" do
+    test "extracts checked checkbox items" do
+      body = """
+      - [x] **1.** Deploy to staging
+      - [ ] **2.** Skip tests
+      - [x] **3.** Notify team
+      """
+
+      assert {:ok, %{checked: [1, 3], freeform: ""}} = Parser.parse_response(body)
+    end
+
+    test "extracts freeform text" do
+      body = """
+      Yes, please deploy to staging and also run the smoke tests afterward.
+      """
+
+      assert {:ok, %{checked: [], freeform: freeform}} = Parser.parse_response(body)
+      assert freeform =~ "please deploy to staging"
+    end
+
+    test "extracts both checked items and freeform text" do
+      body = """
+      - [x] **1.** Deploy to staging
+      - [ ] **2.** Skip tests
+
+      Also please run smoke tests after deploying.
+      """
+
+      assert {:ok, %{checked: [1], freeform: freeform}} = Parser.parse_response(body)
+      assert freeform =~ "smoke tests"
+    end
+
+    test "returns error for empty/template-only content" do
+      body = """
+      ## Lattice needs your input
+
+      **Intent:** `int_abc`
+
+      <!-- lattice:question intent_id=int_abc -->
+      _Posted by Lattice._
+      """
+
+      assert {:error, :not_a_response} = Parser.parse_response(body)
+    end
+
+    test "handles case-insensitive checkbox matching" do
+      body = "- [X] **1.** Option one"
+
+      assert {:ok, %{checked: [1]}} = Parser.parse_response(body)
+    end
+  end
+
+  describe "parse_comment/1" do
+    test "combines sentinel and response extraction" do
+      body = """
+      - [x] **1.** Deploy to staging
+      - [ ] **2.** Skip tests
+
+      Sounds good, go ahead.
+
+      <!-- lattice:question intent_id=int_abc -->
+      _Posted by Lattice._
+      """
+
+      assert {:ok, result} = Parser.parse_comment(body)
+      assert result.intent_id == "int_abc"
+      assert result.type == :question
+      assert 1 in result.response.checked
+      assert result.response.freeform =~ "Sounds good"
+    end
+
+    test "returns error for non-lattice comment" do
+      assert {:error, :not_a_lattice_comment} = Parser.parse_comment("Just a regular comment")
+    end
+
+    test "returns error when sentinel present but no response content" do
+      body = """
+      ## Lattice needs your input
+      <!-- lattice:question intent_id=int_abc -->
+      _Posted by Lattice._
+      """
+
+      assert {:error, :not_a_response} = Parser.parse_comment(body)
+    end
+  end
+
+  describe "round-trip: question → response" do
+    test "posted question can be parsed after user edits checkboxes" do
+      alias Lattice.Capabilities.GitHub.Comments
+      alias Lattice.Intents.Intent
+
+      now = DateTime.utc_now()
+
+      intent = %Intent{
+        id: "int_round_trip",
+        kind: :action,
+        state: :waiting_for_input,
+        source: %{type: :sprite, id: "sprite-001"},
+        summary: "Deploy prod",
+        payload: %{},
+        classification: :controlled,
+        metadata: %{},
+        inserted_at: now,
+        updated_at: now
+      }
+
+      original =
+        Comments.question_comment(intent, [
+          %{text: "Deploy to production?"},
+          %{text: "Run smoke tests?"}
+        ])
+
+      # Simulate user checking item 1 and adding freeform
+      user_edited =
+        original
+        |> String.replace("- [ ] **1.**", "- [x] **1.**")
+        |> Kernel.<>("\n\nYes, deploy now please.")
+
+      assert {:ok, %{type: :question, attrs: %{"intent_id" => "int_round_trip"}}} =
+               Parser.extract_sentinel(user_edited)
+
+      assert {:ok, %{checked: [1], freeform: freeform}} = Parser.parse_response(user_edited)
+      assert freeform =~ "deploy now please"
+    end
+  end
+end

--- a/test/lattice/capabilities/github/comments_test.exs
+++ b/test/lattice/capabilities/github/comments_test.exs
@@ -1,0 +1,168 @@
+defmodule Lattice.Capabilities.GitHub.CommentsTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Capabilities.GitHub.Comments
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Plan
+  alias Lattice.Intents.Plan.Step
+
+  defp build_intent(overrides \\ %{}) do
+    now = DateTime.utc_now()
+
+    Map.merge(
+      %Intent{
+        id: "int_test123",
+        kind: :action,
+        state: :running,
+        source: %{type: :sprite, id: "sprite-001"},
+        summary: "Deploy staging",
+        payload: %{},
+        classification: :controlled,
+        metadata: %{governance_issue: 42},
+        inserted_at: now,
+        updated_at: now
+      },
+      overrides
+    )
+  end
+
+  describe "question_comment/2" do
+    test "renders questions with checkboxes and sentinel" do
+      intent = build_intent(%{pending_question: %{text: "Which environment?"}})
+
+      questions = [
+        %{text: "Deploy to staging?"},
+        %{text: "Run integration tests?"}
+      ]
+
+      result = Comments.question_comment(intent, questions)
+
+      assert result =~ "Lattice needs your input"
+      assert result =~ "`int_test123`"
+      assert result =~ "Deploy staging"
+      assert result =~ "- [ ] **1.** Deploy to staging?"
+      assert result =~ "- [ ] **2.** Run integration tests?"
+      assert result =~ "<!-- lattice:question intent_id=int_test123 -->"
+      assert result =~ "How to respond"
+    end
+
+    test "handles a single question map" do
+      intent = build_intent()
+      result = Comments.question_comment(intent, %{text: "Proceed?"})
+
+      assert result =~ "- [ ] **1.** Proceed?"
+    end
+  end
+
+  describe "plan_comment/2" do
+    test "renders plan with rendered_markdown" do
+      intent = build_intent()
+
+      plan = %Plan{
+        title: "Deploy Plan",
+        steps: [],
+        source: :agent,
+        version: 2,
+        rendered_markdown: "## Deploy Plan\n\n1. [ ] Build\n2. [ ] Deploy"
+      }
+
+      result = Comments.plan_comment(intent, plan)
+
+      assert result =~ "Proposed Execution Plan"
+      assert result =~ "`int_test123`"
+      assert result =~ "## Deploy Plan"
+      assert result =~ "1. [ ] Build"
+      assert result =~ "intent-approved"
+      assert result =~ "<!-- lattice:plan intent_id=int_test123 version=2 -->"
+    end
+
+    test "falls back to step rendering when no rendered_markdown" do
+      intent = build_intent()
+
+      plan = %Plan{
+        title: "Test Plan",
+        steps: [
+          %Step{id: "s1", description: "Run tests", skill: "test_runner", status: :pending},
+          %Step{id: "s2", description: "Deploy", skill: nil, status: :completed}
+        ],
+        source: :agent,
+        version: 1,
+        rendered_markdown: ""
+      }
+
+      result = Comments.plan_comment(intent, plan)
+
+      assert result =~ "1. [ ] Run tests `test_runner`"
+      assert result =~ "2. [x] Deploy"
+    end
+  end
+
+  describe "summary_comment/2" do
+    test "renders success summary" do
+      intent = build_intent()
+      result_data = %{status: :success, duration_ms: 1500, output: "Deployed successfully"}
+
+      result = Comments.summary_comment(intent, result_data)
+
+      assert result =~ "Execution Completed"
+      assert result =~ "`int_test123`"
+      assert result =~ "1.5s"
+      assert result =~ "Deployed successfully"
+      assert result =~ "<!-- lattice:summary intent_id=int_test123 -->"
+    end
+
+    test "renders failure summary with error" do
+      intent = build_intent()
+      result_data = %{status: :failure, duration_ms: 200, error: "Connection refused"}
+
+      result = Comments.summary_comment(intent, result_data)
+
+      assert result =~ "Execution Failed"
+      assert result =~ "200ms"
+      assert result =~ "Connection refused"
+    end
+
+    test "renders artifacts when present" do
+      intent =
+        build_intent(%{
+          metadata: %{
+            governance_issue: 42,
+            artifacts: [
+              %{label: "PR #10", url: "https://github.com/org/repo/pull/10"},
+              %{type: "branch", label: "feat/deploy"}
+            ]
+          }
+        })
+
+      result_data = %{status: :success}
+      result = Comments.summary_comment(intent, result_data)
+
+      assert result =~ "Artifacts"
+      assert result =~ "[PR #10](https://github.com/org/repo/pull/10)"
+      assert result =~ "- feat/deploy"
+    end
+
+    test "handles no duration" do
+      intent = build_intent()
+      result = Comments.summary_comment(intent, %{status: :success})
+
+      assert result =~ "N/A"
+    end
+  end
+
+  describe "progress_comment/2" do
+    test "renders progress update" do
+      intent = build_intent()
+      update = %{current_step: 2, total_steps: 5, message: "Running integration tests..."}
+
+      result = Comments.progress_comment(intent, update)
+
+      assert result =~ "Progress Update"
+      assert result =~ "2 of 5"
+      assert result =~ "Running integration tests..."
+      assert result =~ "<!-- lattice:progress intent_id=int_test123 -->"
+    end
+  end
+end

--- a/test/lattice/intents/governance_test.exs
+++ b/test/lattice/intents/governance_test.exs
@@ -320,9 +320,8 @@ defmodule Lattice.Intents.GovernanceTest do
 
       Lattice.Capabilities.MockGitHub
       |> expect(:create_comment, fn 42, body ->
-        assert body =~ "Execution Outcome"
-        assert body =~ "Completed"
-        assert body =~ "1500ms"
+        assert body =~ "Execution Completed"
+        assert body =~ "1.5s"
         assert body =~ "deployed"
 
         {:ok, %{id: 1, body: body, issue_number: 42}}


### PR DESCRIPTION
## Summary
- Implements `GitHub.Comments` module with 4 template functions: `question_comment`, `plan_comment`, `summary_comment`, `progress_comment`
- Each template includes HTML sentinel markers (`<!-- lattice:type intent_id=... -->`) for machine parsing
- Implements `GitHub.Comments.Parser` with `extract_sentinel/1`, `parse_response/1`, and `parse_comment/1` for round-trip parsing
- Wires into governance: replaces plain-text `format_outcome_comment` with `Comments.summary_comment`, adds `post_question/1` and `post_plan/1` delegation functions
- Full round-trip test: post question → user edits checkboxes → parse response

## Test plan
- [x] All 1377 tests pass, 0 failures
- [x] 23 new tests (9 template rendering, 14 parser/round-trip)
- [x] Updated governance test for new summary format
- [x] `mix compile --warnings-as-errors` clean

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)