### PR TITLE
Add PR lifecycle tracking (#160)

### DIFF
--- a/lib/lattice/application.ex
+++ b/lib/lattice/application.ex
@@ -38,6 +38,8 @@ defmodule Lattice.Application do
       Lattice.Webhooks.Dedup,
       # GitHub artifact association registry (ETS-backed)
       Lattice.Capabilities.GitHub.ArtifactRegistry,
+      # PR lifecycle tracker (ETS-backed, subscribes to artifact events)
+      Lattice.PRs.Tracker,
       # Sprite process infrastructure
       {Registry, keys: :unique, name: Lattice.Sprites.Registry},
       {DynamicSupervisor, name: Lattice.Sprites.DynamicSupervisor, strategy: :one_for_one},

--- a/lib/lattice/events.ex
+++ b/lib/lattice/events.ex
@@ -106,6 +106,10 @@ defmodule Lattice.Events do
   @spec artifacts_topic() :: String.t()
   def artifacts_topic, do: "artifacts"
 
+  @doc "Returns the PubSub topic for PR lifecycle events."
+  @spec prs_topic() :: String.t()
+  def prs_topic, do: "prs"
+
   @doc "Returns the PubSub topic for exec session protocol events."
   @spec exec_events_topic(String.t()) :: String.t()
   def exec_events_topic(session_id) when is_binary(session_id) do
@@ -190,6 +194,12 @@ defmodule Lattice.Events do
   @spec subscribe_artifacts() :: :ok | {:error, term()}
   def subscribe_artifacts do
     Phoenix.PubSub.subscribe(pubsub(), artifacts_topic())
+  end
+
+  @doc "Subscribe the calling process to PR lifecycle events."
+  @spec subscribe_prs() :: :ok | {:error, term()}
+  def subscribe_prs do
+    Phoenix.PubSub.subscribe(pubsub(), prs_topic())
   end
 
   # ── Broadcast ──────────────────────────────────────────────────────

--- a/lib/lattice/prs/pr.ex
+++ b/lib/lattice/prs/pr.ex
@@ -1,0 +1,127 @@
+defmodule Lattice.PRs.PR do
+  @moduledoc """
+  Represents a pull request tracked by Lattice.
+
+  Captures the full lifecycle state of a PR that Lattice created or is
+  monitoring, including review status, CI state, and links back to the
+  originating intent.
+
+  ## Review States
+
+  - `:pending` — no reviews yet
+  - `:approved` — at least one approving review, no outstanding changes requested
+  - `:changes_requested` — at least one reviewer requested changes
+  - `:commented` — only comment reviews (no approval/changes-requested)
+
+  ## PR States
+
+  - `:open` — PR is open
+  - `:closed` — PR was closed without merging
+  - `:merged` — PR was merged
+  """
+
+  @type review_state :: :pending | :approved | :changes_requested | :commented
+  @type pr_state :: :open | :closed | :merged
+
+  @type t :: %__MODULE__{
+          number: pos_integer(),
+          repo: String.t(),
+          title: String.t() | nil,
+          head_branch: String.t() | nil,
+          base_branch: String.t() | nil,
+          state: pr_state(),
+          review_state: review_state(),
+          mergeable: boolean() | nil,
+          ci_status: atom() | nil,
+          draft: boolean(),
+          intent_id: String.t() | nil,
+          run_id: String.t() | nil,
+          url: String.t() | nil,
+          created_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  @enforce_keys [:number, :repo]
+  defstruct [
+    :number,
+    :repo,
+    :title,
+    :head_branch,
+    :base_branch,
+    :intent_id,
+    :run_id,
+    :url,
+    :mergeable,
+    :ci_status,
+    state: :open,
+    review_state: :pending,
+    draft: false,
+    created_at: nil,
+    updated_at: nil
+  ]
+
+  @doc """
+  Create a new PR struct with defaults.
+
+  ## Examples
+
+      PR.new(42, "org/repo", intent_id: "int_abc", title: "Add feature")
+
+  """
+  @spec new(pos_integer(), String.t(), keyword()) :: t()
+  def new(number, repo, opts \\ []) when is_integer(number) and is_binary(repo) do
+    now = DateTime.utc_now()
+
+    %__MODULE__{
+      number: number,
+      repo: repo,
+      title: Keyword.get(opts, :title),
+      head_branch: Keyword.get(opts, :head_branch),
+      base_branch: Keyword.get(opts, :base_branch),
+      state: Keyword.get(opts, :state, :open),
+      review_state: Keyword.get(opts, :review_state, :pending),
+      mergeable: Keyword.get(opts, :mergeable),
+      ci_status: Keyword.get(opts, :ci_status),
+      draft: Keyword.get(opts, :draft, false),
+      intent_id: Keyword.get(opts, :intent_id),
+      run_id: Keyword.get(opts, :run_id),
+      url: Keyword.get(opts, :url),
+      created_at: Keyword.get(opts, :created_at, now),
+      updated_at: Keyword.get(opts, :updated_at, now)
+    }
+  end
+
+  @doc """
+  Update a PR with new fields, automatically bumping `updated_at`.
+  """
+  @spec update(t(), keyword()) :: t()
+  def update(%__MODULE__{} = pr, fields) do
+    pr
+    |> struct!(fields)
+    |> struct!(updated_at: DateTime.utc_now())
+  end
+
+  @doc """
+  Returns true if the PR needs attention (changes requested or failing CI).
+  """
+  @spec needs_attention?(t()) :: boolean()
+  def needs_attention?(%__MODULE__{state: :open, review_state: :changes_requested}), do: true
+  def needs_attention?(%__MODULE__{state: :open, ci_status: :failure}), do: true
+  def needs_attention?(%__MODULE__{state: :open, mergeable: false}), do: true
+  def needs_attention?(_pr), do: false
+
+  @doc """
+  Returns true if the PR is ready to merge (approved, CI passing, mergeable).
+  """
+  @spec merge_ready?(t()) :: boolean()
+  def merge_ready?(%__MODULE__{
+        state: :open,
+        review_state: :approved,
+        mergeable: true,
+        ci_status: ci
+      })
+      when ci in [:success, nil],
+      do: true
+
+  def merge_ready?(_pr), do: false
+end

--- a/lib/lattice/prs/tracker.ex
+++ b/lib/lattice/prs/tracker.ex
@@ -1,0 +1,256 @@
+defmodule Lattice.PRs.Tracker do
+  @moduledoc """
+  ETS-backed GenServer that tracks pull requests created by Lattice.
+
+  Maintains a table of `PR` structs indexed by `{repo, number}` and provides
+  lookup functions by PR number, intent, and state. Subscribes to the
+  `"artifacts"` PubSub topic to auto-register PRs when artifact links are
+  created.
+
+  ## PubSub Events
+
+  State changes broadcast on the `"prs"` topic:
+
+  - `{:pr_registered, pr}` — new PR tracked
+  - `{:pr_updated, pr, changes}` — PR state changed (changes is a keyword of old→new)
+  """
+
+  use GenServer
+
+  alias Lattice.PRs.PR
+
+  @table :lattice_prs
+  @by_intent_table :lattice_prs_by_intent
+
+  # ── Public API ────────────────────────────────────────────────────
+
+  @doc "Start the PR Tracker as a named GenServer."
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Register a new PR for tracking.
+
+  If the PR is already tracked, returns the existing record.
+  Broadcasts `{:pr_registered, pr}` on the `"prs"` PubSub topic.
+  """
+  @spec register(PR.t()) :: {:ok, PR.t()}
+  def register(%PR{} = pr) do
+    GenServer.call(__MODULE__, {:register, pr})
+  end
+
+  @doc """
+  Update a tracked PR's fields.
+
+  Returns the updated PR and broadcasts `{:pr_updated, pr, changes}`.
+  Returns `{:error, :not_found}` if the PR is not tracked.
+  """
+  @spec update_pr(String.t(), pos_integer(), keyword()) ::
+          {:ok, PR.t()} | {:error, :not_found}
+  def update_pr(repo, number, fields) do
+    GenServer.call(__MODULE__, {:update, repo, number, fields})
+  end
+
+  @doc """
+  Get a tracked PR by repo and number.
+  """
+  @spec get(String.t(), pos_integer()) :: PR.t() | nil
+  def get(repo, number) do
+    case :ets.lookup(@table, {repo, number}) do
+      [{_key, pr}] -> pr
+      [] -> nil
+    end
+  end
+
+  @doc """
+  Get all tracked PRs for an intent.
+  """
+  @spec for_intent(String.t()) :: [PR.t()]
+  def for_intent(intent_id) when is_binary(intent_id) do
+    case :ets.lookup(@by_intent_table, intent_id) do
+      [] -> []
+      entries -> Enum.map(entries, fn {_key, {repo, number}} -> get(repo, number) end)
+    end
+    |> Enum.reject(&is_nil/1)
+  end
+
+  @doc """
+  Get all tracked PRs with a given state.
+  """
+  @spec by_state(PR.pr_state()) :: [PR.t()]
+  def by_state(state) when state in [:open, :closed, :merged] do
+    @table
+    |> :ets.tab2list()
+    |> Enum.map(fn {_key, pr} -> pr end)
+    |> Enum.filter(&(&1.state == state))
+  end
+
+  @doc """
+  Get all tracked PRs that need attention.
+  """
+  @spec needs_attention() :: [PR.t()]
+  def needs_attention do
+    @table
+    |> :ets.tab2list()
+    |> Enum.map(fn {_key, pr} -> pr end)
+    |> Enum.filter(&PR.needs_attention?/1)
+  end
+
+  @doc """
+  Return all tracked PRs.
+  """
+  @spec all() :: [PR.t()]
+  def all do
+    @table
+    |> :ets.tab2list()
+    |> Enum.map(fn {_key, pr} -> pr end)
+  end
+
+  # ── GenServer Callbacks ──────────────────────────────────────────
+
+  @impl true
+  def init(_opts) do
+    :ets.new(@table, [:named_table, :set, :public, read_concurrency: true])
+    :ets.new(@by_intent_table, [:named_table, :bag, :public, read_concurrency: true])
+
+    # Subscribe to artifact events to auto-register PRs
+    Lattice.Events.subscribe_artifacts()
+
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_call({:register, %PR{} = pr}, _from, state) do
+    key = {pr.repo, pr.number}
+
+    case :ets.lookup(@table, key) do
+      [{_key, existing}] ->
+        {:reply, {:ok, existing}, state}
+
+      [] ->
+        :ets.insert(@table, {key, pr})
+
+        if pr.intent_id do
+          :ets.insert(@by_intent_table, {pr.intent_id, {pr.repo, pr.number}})
+        end
+
+        emit_telemetry(:registered, pr)
+        broadcast(:pr_registered, pr)
+
+        {:reply, {:ok, pr}, state}
+    end
+  end
+
+  @impl true
+  def handle_call({:update, repo, number, fields}, _from, state) do
+    key = {repo, number}
+
+    case :ets.lookup(@table, key) do
+      [{_key, existing}] ->
+        changes = detect_changes(existing, fields)
+        updated = PR.update(existing, fields)
+        :ets.insert(@table, {key, updated})
+
+        if changes != [] do
+          emit_telemetry(:updated, updated)
+          broadcast(:pr_updated, updated, changes)
+        end
+
+        {:reply, {:ok, updated}, state}
+
+      [] ->
+        {:reply, {:error, :not_found}, state}
+    end
+  end
+
+  @impl true
+  def handle_info({:artifact_registered, link}, state) do
+    maybe_register_from_artifact(link, state)
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # ── Private ──────────────────────────────────────────────────────
+
+  defp maybe_register_from_artifact(%{kind: :pull_request, ref: ref} = link, state)
+       when is_integer(ref) do
+    repo = extract_repo(link)
+
+    if repo do
+      pr =
+        PR.new(ref, repo,
+          intent_id: link.intent_id,
+          run_id: link.run_id,
+          url: link.url,
+          created_at: link.created_at
+        )
+
+      key = {pr.repo, pr.number}
+
+      case :ets.lookup(@table, key) do
+        [{_key, _existing}] ->
+          :ok
+
+        [] ->
+          :ets.insert(@table, {key, pr})
+
+          if pr.intent_id do
+            :ets.insert(@by_intent_table, {pr.intent_id, {pr.repo, pr.number}})
+          end
+
+          emit_telemetry(:registered, pr)
+          broadcast(:pr_registered, pr)
+      end
+    end
+
+    {:noreply, state}
+  end
+
+  defp maybe_register_from_artifact(_link, state), do: {:noreply, state}
+
+  defp extract_repo(%{url: url}) when is_binary(url) do
+    case Regex.run(~r{github\.com/([^/]+/[^/]+)/pull/}, url) do
+      [_, repo] -> repo
+      _ -> default_repo()
+    end
+  end
+
+  defp extract_repo(_link), do: default_repo()
+
+  defp default_repo do
+    Application.get_env(:lattice, :resources, [])
+    |> Keyword.get(:github_repo)
+  end
+
+  defp detect_changes(existing, fields) do
+    Enum.reduce(fields, [], fn {field, new_value}, acc ->
+      old_value = Map.get(existing, field)
+
+      if old_value != new_value do
+        [{field, old_value, new_value} | acc]
+      else
+        acc
+      end
+    end)
+  end
+
+  defp emit_telemetry(event, pr) do
+    :telemetry.execute(
+      [:lattice, :pr, event],
+      %{count: 1},
+      %{repo: pr.repo, number: pr.number, state: pr.state, review_state: pr.review_state}
+    )
+  end
+
+  defp broadcast(event, pr, changes \\ []) do
+    message =
+      case changes do
+        [] -> {event, pr}
+        changes -> {event, pr, changes}
+      end
+
+    Phoenix.PubSub.broadcast(Lattice.PubSub, Lattice.Events.prs_topic(), message)
+  end
+end

--- a/test/lattice/prs/pr_test.exs
+++ b/test/lattice/prs/pr_test.exs
@@ -1,0 +1,144 @@
+defmodule Lattice.PRs.PRTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.PRs.PR
+
+  describe "new/3" do
+    test "creates a PR with required fields and defaults" do
+      pr = PR.new(42, "org/repo")
+
+      assert pr.number == 42
+      assert pr.repo == "org/repo"
+      assert pr.state == :open
+      assert pr.review_state == :pending
+      assert pr.draft == false
+      assert pr.mergeable == nil
+      assert pr.ci_status == nil
+      assert %DateTime{} = pr.created_at
+      assert %DateTime{} = pr.updated_at
+    end
+
+    test "creates a PR with optional fields" do
+      pr =
+        PR.new(10, "org/repo",
+          title: "Add feature",
+          head_branch: "feat/add-feature",
+          base_branch: "main",
+          state: :open,
+          review_state: :approved,
+          draft: true,
+          intent_id: "int_abc",
+          run_id: "run_123",
+          url: "https://github.com/org/repo/pull/10"
+        )
+
+      assert pr.title == "Add feature"
+      assert pr.head_branch == "feat/add-feature"
+      assert pr.base_branch == "main"
+      assert pr.review_state == :approved
+      assert pr.draft == true
+      assert pr.intent_id == "int_abc"
+      assert pr.run_id == "run_123"
+      assert pr.url == "https://github.com/org/repo/pull/10"
+    end
+  end
+
+  describe "update/2" do
+    test "updates fields and bumps updated_at" do
+      pr = PR.new(1, "org/repo")
+      original_updated_at = pr.updated_at
+
+      # Small delay to ensure timestamp differs
+      Process.sleep(1)
+      updated = PR.update(pr, review_state: :approved, mergeable: true)
+
+      assert updated.review_state == :approved
+      assert updated.mergeable == true
+      assert DateTime.compare(updated.updated_at, original_updated_at) in [:gt, :eq]
+    end
+  end
+
+  describe "needs_attention?/1" do
+    test "returns true for changes_requested" do
+      pr = PR.new(1, "org/repo") |> struct!(review_state: :changes_requested)
+      assert PR.needs_attention?(pr)
+    end
+
+    test "returns true for failing CI" do
+      pr = PR.new(1, "org/repo") |> struct!(ci_status: :failure)
+      assert PR.needs_attention?(pr)
+    end
+
+    test "returns true for non-mergeable" do
+      pr = PR.new(1, "org/repo") |> struct!(mergeable: false)
+      assert PR.needs_attention?(pr)
+    end
+
+    test "returns false for approved PR" do
+      pr = PR.new(1, "org/repo") |> struct!(review_state: :approved)
+      refute PR.needs_attention?(pr)
+    end
+
+    test "returns false for merged PR" do
+      pr = PR.new(1, "org/repo") |> struct!(state: :merged, review_state: :changes_requested)
+      refute PR.needs_attention?(pr)
+    end
+  end
+
+  describe "merge_ready?/1" do
+    test "returns true when approved, mergeable, CI passing" do
+      pr =
+        PR.new(1, "org/repo")
+        |> struct!(review_state: :approved, mergeable: true, ci_status: :success)
+
+      assert PR.merge_ready?(pr)
+    end
+
+    test "returns true when approved, mergeable, no CI info" do
+      pr =
+        PR.new(1, "org/repo")
+        |> struct!(review_state: :approved, mergeable: true, ci_status: nil)
+
+      assert PR.merge_ready?(pr)
+    end
+
+    test "returns false when not approved" do
+      pr =
+        PR.new(1, "org/repo")
+        |> struct!(review_state: :pending, mergeable: true, ci_status: :success)
+
+      refute PR.merge_ready?(pr)
+    end
+
+    test "returns false when not mergeable" do
+      pr =
+        PR.new(1, "org/repo")
+        |> struct!(review_state: :approved, mergeable: false, ci_status: :success)
+
+      refute PR.merge_ready?(pr)
+    end
+
+    test "returns false when CI failing" do
+      pr =
+        PR.new(1, "org/repo")
+        |> struct!(review_state: :approved, mergeable: true, ci_status: :failure)
+
+      refute PR.merge_ready?(pr)
+    end
+
+    test "returns false for closed PR" do
+      pr =
+        PR.new(1, "org/repo")
+        |> struct!(
+          state: :closed,
+          review_state: :approved,
+          mergeable: true,
+          ci_status: :success
+        )
+
+      refute PR.merge_ready?(pr)
+    end
+  end
+end

--- a/test/lattice/prs/tracker_test.exs
+++ b/test/lattice/prs/tracker_test.exs
@@ -1,0 +1,165 @@
+defmodule Lattice.PRs.TrackerTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :unit
+
+  alias Lattice.PRs.PR
+  alias Lattice.PRs.Tracker
+
+  describe "register/1" do
+    test "registers a new PR" do
+      pr = PR.new(1001, "org/tracker-test-1", intent_id: "int_reg_1")
+      assert {:ok, registered} = Tracker.register(pr)
+      assert registered.number == 1001
+    end
+
+    test "returns existing PR if already registered" do
+      pr = PR.new(1002, "org/tracker-test-2")
+      {:ok, first} = Tracker.register(pr)
+
+      updated = %{pr | title: "Updated"}
+      {:ok, second} = Tracker.register(updated)
+
+      # Returns the original, not the updated version
+      assert second.title == first.title
+    end
+
+    test "broadcasts :pr_registered event" do
+      Lattice.Events.subscribe_prs()
+
+      pr = PR.new(1003, "org/tracker-test-3")
+      {:ok, _} = Tracker.register(pr)
+
+      assert_receive {:pr_registered, %PR{number: 1003}}
+    end
+  end
+
+  describe "get/2" do
+    test "returns a tracked PR" do
+      pr = PR.new(1010, "org/tracker-get-1")
+      {:ok, _} = Tracker.register(pr)
+
+      assert %PR{number: 1010} = Tracker.get("org/tracker-get-1", 1010)
+    end
+
+    test "returns nil for untracked PR" do
+      assert Tracker.get("org/nonexistent", 9999) == nil
+    end
+  end
+
+  describe "update_pr/3" do
+    test "updates tracked PR fields" do
+      pr = PR.new(1020, "org/tracker-update-1")
+      {:ok, _} = Tracker.register(pr)
+
+      assert {:ok, updated} =
+               Tracker.update_pr("org/tracker-update-1", 1020,
+                 review_state: :approved,
+                 mergeable: true
+               )
+
+      assert updated.review_state == :approved
+      assert updated.mergeable == true
+    end
+
+    test "returns error for untracked PR" do
+      assert {:error, :not_found} = Tracker.update_pr("org/nonexistent", 8888, state: :merged)
+    end
+
+    test "broadcasts :pr_updated with changes" do
+      pr = PR.new(1021, "org/tracker-update-2")
+      {:ok, _} = Tracker.register(pr)
+
+      Lattice.Events.subscribe_prs()
+
+      {:ok, _} = Tracker.update_pr("org/tracker-update-2", 1021, review_state: :changes_requested)
+
+      assert_receive {:pr_updated, %PR{number: 1021, review_state: :changes_requested}, changes}
+      assert {:review_state, :pending, :changes_requested} in changes
+    end
+
+    test "does not broadcast when no fields changed" do
+      pr = PR.new(1022, "org/tracker-update-3", review_state: :pending)
+      {:ok, _} = Tracker.register(pr)
+
+      Lattice.Events.subscribe_prs()
+
+      {:ok, _} = Tracker.update_pr("org/tracker-update-3", 1022, review_state: :pending)
+
+      refute_receive {:pr_updated, _, _}, 50
+    end
+  end
+
+  describe "for_intent/1" do
+    test "returns PRs linked to an intent" do
+      pr1 = PR.new(1030, "org/tracker-intent-1", intent_id: "int_linked_1")
+      pr2 = PR.new(1031, "org/tracker-intent-1", intent_id: "int_linked_1")
+      {:ok, _} = Tracker.register(pr1)
+      {:ok, _} = Tracker.register(pr2)
+
+      prs = Tracker.for_intent("int_linked_1")
+      numbers = Enum.map(prs, & &1.number)
+      assert 1030 in numbers
+      assert 1031 in numbers
+    end
+
+    test "returns empty list for unknown intent" do
+      assert Tracker.for_intent("int_unknown") == []
+    end
+  end
+
+  describe "by_state/1" do
+    test "filters PRs by state" do
+      pr1 = PR.new(1040, "org/tracker-state-1", state: :open)
+      pr2 = PR.new(1041, "org/tracker-state-1", state: :open)
+      {:ok, _} = Tracker.register(pr1)
+      {:ok, _} = Tracker.register(pr2)
+      {:ok, _} = Tracker.update_pr("org/tracker-state-1", 1041, state: :merged)
+
+      open = Tracker.by_state(:open)
+      assert Enum.any?(open, &(&1.number == 1040))
+
+      merged = Tracker.by_state(:merged)
+      assert Enum.any?(merged, &(&1.number == 1041))
+    end
+  end
+
+  describe "needs_attention/0" do
+    test "returns PRs that need attention" do
+      pr = PR.new(1050, "org/tracker-attention-1")
+      {:ok, _} = Tracker.register(pr)
+
+      {:ok, _} =
+        Tracker.update_pr("org/tracker-attention-1", 1050, review_state: :changes_requested)
+
+      attention = Tracker.needs_attention()
+      assert Enum.any?(attention, &(&1.number == 1050))
+    end
+  end
+
+  describe "auto-register from artifact events" do
+    test "registers PR when pull_request artifact is created" do
+      alias Lattice.Capabilities.GitHub.ArtifactLink
+      alias Lattice.Capabilities.GitHub.ArtifactRegistry
+
+      link =
+        ArtifactLink.new(%{
+          intent_id: "int_artifact_pr",
+          kind: :pull_request,
+          ref: 2001,
+          role: :output,
+          url: "https://github.com/org/artifact-repo/pull/2001"
+        })
+
+      {:ok, _} = ArtifactRegistry.register(link)
+
+      # Give the Tracker time to process the PubSub message
+      Process.sleep(50)
+
+      pr = Tracker.get("org/artifact-repo", 2001)
+      assert pr != nil
+      assert pr.number == 2001
+      assert pr.intent_id == "int_artifact_pr"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Create `Lattice.PRs.PR` struct with full lifecycle fields: state, review_state, mergeable, ci_status, draft, intent_id, run_id
- Add `needs_attention?/1` and `merge_ready?/1` predicates for PR triage
- Create `Lattice.PRs.Tracker` ETS-backed GenServer that auto-registers PRs from ArtifactRegistry events
- Provide lookups: `get/2`, `for_intent/1`, `by_state/1`, `needs_attention/0`
- Broadcast `{:pr_registered, pr}` and `{:pr_updated, pr, changes}` on `"prs"` PubSub topic
- Add `prs_topic/0` and `subscribe_prs/0` to Events module

## Test plan
- [x] PR struct tests: new, update, needs_attention?, merge_ready? (13 tests)
- [x] Tracker tests: register, get, update, for_intent, by_state, needs_attention, auto-register from artifacts (15 tests)
- [x] Full suite: 1479 tests, 0 failures

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)