### PR TITLE
Add post-fixup PR comment summaries (#163)

### DIFF
--- a/lib/lattice/application.ex
+++ b/lib/lattice/application.ex
@@ -40,7 +40,9 @@ defmodule Lattice.Application do
         # GitHub artifact association registry (ETS-backed)
         Lattice.Capabilities.GitHub.ArtifactRegistry,
         # PR lifecycle tracker (ETS-backed, subscribes to artifact events)
-        Lattice.PRs.Tracker
+        Lattice.PRs.Tracker,
+        # Post summary comments on PRs after fixup runs complete
+        Lattice.PRs.PostFixupCommenter
       ] ++
         maybe_pr_monitor() ++
         [

--- a/lib/lattice/prs/post_fixup_commenter.ex
+++ b/lib/lattice/prs/post_fixup_commenter.ex
@@ -1,0 +1,149 @@
+defmodule Lattice.PRs.PostFixupCommenter do
+  @moduledoc """
+  Subscribes to run completion events and posts summary comments on PRs
+  after fixup runs complete.
+
+  When a run for a `pr_fixup` intent completes, this module:
+  1. Looks up the originating intent and its PR info
+  2. Builds a structured GitHub comment with outcome, commit SHA, and details
+  3. Posts the comment via `GitHub.create_comment/2`
+
+  Runs as a GenServer in the supervision tree.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Lattice.Capabilities.GitHub
+  alias Lattice.Events
+  alias Lattice.Intents.Store
+  alias Lattice.PRs.Tracker
+
+  # ── Public API ────────────────────────────────────────────────────
+
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  # ── GenServer Callbacks ──────────────────────────────────────────
+
+  @impl true
+  def init(_opts) do
+    Events.subscribe_runs()
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_info({:run_completed, run}, state) do
+    handle_run_completed(run)
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # ── Private ──────────────────────────────────────────────────────
+
+  defp handle_run_completed(%{intent_id: nil}), do: :ok
+
+  defp handle_run_completed(%{intent_id: intent_id} = run) do
+    with {:ok, intent} <- Store.get(intent_id),
+         true <- intent.kind == :pr_fixup,
+         {:ok, pr_number} <- extract_pr_number(intent) do
+      comment_body = build_comment(run, intent)
+
+      case GitHub.create_comment(pr_number, comment_body) do
+        {:ok, _} ->
+          Logger.info("Posted fixup summary on PR ##{pr_number} for intent #{intent_id}")
+
+          # Update tracker review state back to pending after fixup
+          repo = extract_repo(intent)
+          if repo, do: Tracker.update_pr(repo, pr_number, review_state: :pending)
+
+        {:error, reason} ->
+          Logger.warning("Failed to post fixup comment on PR ##{pr_number}: #{inspect(reason)}")
+      end
+    else
+      {:ok, _intent} -> :ok
+      false -> :ok
+      {:error, _} -> :ok
+    end
+  end
+
+  defp extract_pr_number(%{payload: %{"pr_url" => url}}) do
+    case Regex.run(~r{/pull/(\d+)}, url) do
+      [_, num_str] -> {:ok, String.to_integer(num_str)}
+      _ -> {:error, :no_pr_number}
+    end
+  end
+
+  defp extract_pr_number(_), do: {:error, :no_pr_url}
+
+  defp extract_repo(%{payload: %{"pr_url" => url}}) do
+    case Regex.run(~r{github\.com/([^/]+/[^/]+)/pull/}, url) do
+      [_, repo] -> repo
+      _ -> nil
+    end
+  end
+
+  defp extract_repo(_), do: nil
+
+  @doc false
+  def build_comment(run, intent) do
+    status_emoji = if run.status == :completed, do: "white_check_mark", else: "x"
+    status_text = if run.status == :completed, do: "Success", else: "Failed"
+
+    commit_sha = extract_commit_sha(run)
+    feedback = intent.payload["feedback"] || "No feedback provided"
+
+    parts = [
+      "## :#{status_emoji}: Fixup #{status_text}",
+      "",
+      "**Intent:** `#{intent.id}`",
+      "**Feedback addressed:**",
+      "> #{feedback}"
+    ]
+
+    parts =
+      if commit_sha do
+        parts ++ ["", "**Commit:** `#{commit_sha}`"]
+      else
+        parts
+      end
+
+    parts =
+      if run.status != :completed and run.error do
+        parts ++ ["", "**Error:** `#{inspect(run.error)}`"]
+      else
+        parts
+      end
+
+    parts =
+      parts ++
+        [
+          "",
+          "<details>",
+          "<summary>Run details</summary>",
+          "",
+          "- **Sprite:** #{run.sprite_name || "unknown"}",
+          "- **Started:** #{run.started_at}",
+          "- **Finished:** #{run.finished_at || "in progress"}",
+          "",
+          "</details>",
+          "",
+          "_Posted by Lattice_"
+        ]
+
+    Enum.join(parts, "\n")
+  end
+
+  defp extract_commit_sha(%{artifacts: artifacts}) when is_list(artifacts) do
+    case Enum.find(artifacts, &match?(%{type: "commit"}, &1)) do
+      %{data: sha} -> sha
+      _ -> nil
+    end
+  end
+
+  defp extract_commit_sha(_), do: nil
+end

--- a/test/lattice/prs/post_fixup_commenter_test.exs
+++ b/test/lattice/prs/post_fixup_commenter_test.exs
@@ -1,0 +1,149 @@
+defmodule Lattice.PRs.PostFixupCommenterTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  @moduletag :unit
+
+  alias Lattice.Intents.Intent
+  alias Lattice.Intents.Store
+  alias Lattice.PRs.PostFixupCommenter
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  defp create_fixup_intent(opts \\ []) do
+    pr_number = Keyword.get(opts, :pr_number, 42)
+
+    {:ok, intent} =
+      Intent.new(:pr_fixup, %{type: :system, id: "test_1"},
+        summary: "Fix review feedback on PR ##{pr_number}",
+        payload: %{
+          "pr_url" => "https://github.com/org/repo/pull/#{pr_number}",
+          "feedback" => Keyword.get(opts, :feedback, "Fix the typo in README.md"),
+          "pr_title" => "Add feature",
+          "reviewer" => "reviewer1"
+        }
+      )
+
+    {:ok, stored} = Store.create(intent)
+    stored
+  end
+
+  defp make_run(intent, opts \\ []) do
+    %{
+      id: "run_test_#{:erlang.unique_integer([:positive])}",
+      intent_id: intent.id,
+      sprite_name: Keyword.get(opts, :sprite_name, "atlas"),
+      status: Keyword.get(opts, :status, :completed),
+      started_at: DateTime.utc_now(),
+      finished_at: DateTime.utc_now(),
+      error: Keyword.get(opts, :error),
+      artifacts: Keyword.get(opts, :artifacts, [])
+    }
+  end
+
+  describe "run completion handling" do
+    test "posts comment on PR after successful fixup run" do
+      intent = create_fixup_intent()
+      run = make_run(intent, artifacts: [%{type: "commit", data: "abc123def456"}])
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_comment, fn 42, body ->
+        assert body =~ "Fixup Success"
+        assert body =~ intent.id
+        assert body =~ "abc123def456"
+        assert body =~ "Fix the typo"
+        {:ok, %{"id" => 1}}
+      end)
+
+      # Broadcast directly to the commenter
+      Phoenix.PubSub.broadcast(Lattice.PubSub, "runs", {:run_completed, run})
+      Process.sleep(50)
+    end
+
+    test "posts comment on PR after failed fixup run" do
+      intent = create_fixup_intent(pr_number: 99)
+      run = make_run(intent, status: :failed, error: {:sprite_exec_failed, :timeout})
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_comment, fn 99, body ->
+        assert body =~ "Fixup Failed"
+        assert body =~ "sprite_exec_failed"
+        {:ok, %{"id" => 2}}
+      end)
+
+      Phoenix.PubSub.broadcast(Lattice.PubSub, "runs", {:run_completed, run})
+      Process.sleep(50)
+    end
+
+    test "ignores runs without intent_id" do
+      run = %{id: "run_orphan", intent_id: nil, status: :completed}
+
+      # No mock expectations — should not call GitHub
+      Phoenix.PubSub.broadcast(Lattice.PubSub, "runs", {:run_completed, run})
+      Process.sleep(50)
+    end
+
+    test "ignores runs for non-pr_fixup intents" do
+      {:ok, intent} =
+        Intent.new(:action, %{type: :system, id: "test_2"},
+          summary: "Some action",
+          payload: %{"capability" => "github", "operation" => "create_issue"}
+        )
+
+      {:ok, stored} = Store.create(intent)
+      run = make_run(stored)
+
+      # No mock expectations — should not call GitHub
+      Phoenix.PubSub.broadcast(Lattice.PubSub, "runs", {:run_completed, run})
+      Process.sleep(50)
+    end
+
+    test "handles GitHub comment failure gracefully" do
+      intent = create_fixup_intent(pr_number: 55)
+      run = make_run(intent)
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:create_comment, fn 55, _body -> {:error, :rate_limited} end)
+
+      Phoenix.PubSub.broadcast(Lattice.PubSub, "runs", {:run_completed, run})
+      Process.sleep(50)
+    end
+  end
+
+  describe "build_comment/2" do
+    test "includes commit SHA when present" do
+      intent = create_fixup_intent()
+      run = make_run(intent, artifacts: [%{type: "commit", data: "abc123"}])
+
+      comment = PostFixupCommenter.build_comment(run, intent)
+      assert comment =~ "`abc123`"
+    end
+
+    test "omits commit SHA when not present" do
+      intent = create_fixup_intent()
+      run = make_run(intent, artifacts: [])
+
+      comment = PostFixupCommenter.build_comment(run, intent)
+      refute comment =~ "Commit:"
+    end
+
+    test "includes feedback quote" do
+      intent = create_fixup_intent(feedback: "Fix the naming convention")
+      run = make_run(intent)
+
+      comment = PostFixupCommenter.build_comment(run, intent)
+      assert comment =~ "Fix the naming convention"
+    end
+
+    test "includes run details section" do
+      intent = create_fixup_intent()
+      run = make_run(intent, sprite_name: "sprite-01")
+
+      comment = PostFixupCommenter.build_comment(run, intent)
+      assert comment =~ "sprite-01"
+      assert comment =~ "Run details"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `Lattice.PRs.PostFixupCommenter` GenServer that subscribes to run completion events
- Posts structured GitHub comments on PRs after fixup runs (success or failure)
- Comments include outcome status, commit SHA, feedback quote, and collapsible run details
- Updates PR Tracker review state back to pending after fixup

## Test plan
- [x] 9 tests covering success/failure comments, non-fixup intent filtering, GitHub failure handling, and comment formatting
- [x] Full suite: 1507 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)