### PR TITLE
Fix ambient duplicate processing, timeouts, and progress indicators

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -96,10 +96,8 @@ if System.get_env("ANTHROPIC_API_KEY") do
   config :lattice, Lattice.Ambient.SpriteDelegate,
     enabled: System.get_env("AMBIENT_DELEGATION", "false") == "true",
     sprite_name: System.get_env("AMBIENT_SPRITE_NAME", "lattice-ambient"),
-    delegation_timeout_ms:
-      String.to_integer(System.get_env("AMBIENT_DELEGATION_TIMEOUT_MS", "120000")),
-    implementation_timeout_ms:
-      String.to_integer(System.get_env("AMBIENT_IMPLEMENTATION_TIMEOUT_MS", "300000"))
+    exec_idle_timeout_ms:
+      String.to_integer(System.get_env("AMBIENT_EXEC_IDLE_TIMEOUT_MS", "1800000"))
 end
 
 # Auth provider: Clerk is the default; the secret key is required for prod

--- a/lib/lattice/ambient/responder.ex
+++ b/lib/lattice/ambient/responder.ex
@@ -87,6 +87,15 @@ defmodule Lattice.Ambient.Responder do
     state = %{state | active_tasks: tasks}
 
     case task_entry do
+      {:implement, event, rocket_id} ->
+        remove_rocket_reaction(event, rocket_id)
+        handle_implementation_result(event, result, state)
+
+      {:delegate, event, rocket_id} ->
+        remove_rocket_reaction(event, rocket_id)
+        handle_delegation_result(event, result, state)
+
+      # Backwards compat for in-flight tasks without rocket_id
       {:implement, event} ->
         handle_implementation_result(event, result, state)
 
@@ -100,8 +109,9 @@ defmodule Lattice.Ambient.Responder do
       when is_map_key(tasks, ref) do
     {task_entry, tasks} = Map.pop(tasks, ref)
     state = %{state | active_tasks: tasks}
-    event = unwrap_task_event(task_entry)
+    {event, rocket_id} = unwrap_task_event(task_entry)
 
+    remove_rocket_reaction(event, rocket_id)
     Logger.error("Ambient: task crashed for #{thread_key(event)}: #{inspect(reason)}")
     add_confused_reaction(event)
     {:noreply, state}
@@ -135,17 +145,21 @@ defmodule Lattice.Ambient.Responder do
   defp handle_classification({:ok, :implement, _}, event, thread_context, state) do
     Logger.info("Ambient: classify=implement on #{thread_key(event)}")
 
+    rocket_id = add_rocket_reaction(event)
+
     task =
       Task.Supervisor.async_nolink(
         Lattice.Ambient.TaskSupervisor,
         fn -> SpriteDelegate.handle_implementation(event, thread_context) end
       )
 
-    put_in(state.active_tasks[task.ref], {:implement, event})
+    put_in(state.active_tasks[task.ref], {:implement, event, rocket_id})
   end
 
   defp handle_classification({:ok, :delegate, _}, event, thread_context, state) do
     Logger.info("Ambient: classify=delegate on #{thread_key(event)}")
+
+    rocket_id = add_rocket_reaction(event)
 
     task =
       Task.Supervisor.async_nolink(
@@ -153,7 +167,7 @@ defmodule Lattice.Ambient.Responder do
         fn -> SpriteDelegate.handle(event, thread_context) end
       )
 
-    put_in(state.active_tasks[task.ref], event)
+    put_in(state.active_tasks[task.ref], {:delegate, event, rocket_id})
   end
 
   defp handle_classification({:ok, :respond, response_text}, event, _thread_context, state) do
@@ -231,8 +245,10 @@ defmodule Lattice.Ambient.Responder do
     end
   end
 
-  defp unwrap_task_event({:implement, event}), do: event
-  defp unwrap_task_event(event) when is_map(event), do: event
+  defp unwrap_task_event({:implement, event, rocket_id}), do: {event, rocket_id}
+  defp unwrap_task_event({:delegate, event, rocket_id}), do: {event, rocket_id}
+  defp unwrap_task_event({:implement, event}), do: {event, nil}
+  defp unwrap_task_event(event) when is_map(event), do: {event, nil}
 
   # ── Private: PR Creation ─────────────────────────────────────────
 
@@ -339,6 +355,53 @@ defmodule Lattice.Ambient.Responder do
   rescue
     e ->
       Logger.warning("Ambient: failed to add confused reaction: #{inspect(e)}")
+  end
+
+  defp add_rocket_reaction(event) do
+    case reaction_target(event) do
+      {:comment, comment_id} ->
+        case GitHub.create_comment_reaction(comment_id, "rocket") do
+          {:ok, %{id: id}} -> id
+          _ -> nil
+        end
+
+      {:issue, number} ->
+        case GitHub.create_issue_reaction(number, "rocket") do
+          {:ok, %{id: id}} -> id
+          _ -> nil
+        end
+
+      {:review_comment, comment_id} ->
+        case GitHub.create_review_comment_reaction(comment_id, "rocket") do
+          {:ok, %{id: id}} -> id
+          _ -> nil
+        end
+
+      :none ->
+        nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  defp remove_rocket_reaction(_event, nil), do: :ok
+
+  defp remove_rocket_reaction(event, reaction_id) do
+    case reaction_target(event) do
+      {:comment, comment_id} ->
+        GitHub.delete_comment_reaction(comment_id, reaction_id)
+
+      {:issue, number} ->
+        GitHub.delete_issue_reaction(number, reaction_id)
+
+      {:review_comment, comment_id} ->
+        GitHub.delete_review_comment_reaction(comment_id, reaction_id)
+
+      :none ->
+        :ok
+    end
+  rescue
+    _ -> :ok
   end
 
   defp reaction_target(%{type: :issue_comment, comment_id: id}) when not is_nil(id),

--- a/lib/lattice/ambient/sprite_delegate.ex
+++ b/lib/lattice/ambient/sprite_delegate.ex
@@ -87,20 +87,29 @@ defmodule Lattice.Ambient.SpriteDelegate do
   defp run_implementation(sprite_name, event, thread_context) do
     prompt = build_implementation_prompt(event, thread_context)
     work_dir = work_dir()
-    timeout = implementation_timeout_ms()
 
     write_cmd =
       "cat > /tmp/implement_prompt.txt << 'LATTICE_PROMPT_EOF'\n#{prompt}\nLATTICE_PROMPT_EOF"
 
-    with {:ok, _} <- exec_with_retry(sprite_name, write_cmd),
-         {:ok, _} <-
-           exec_with_retry(
-             sprite_name,
-             "cd #{work_dir} && ANTHROPIC_API_KEY=#{anthropic_api_key()} timeout #{div(timeout, 1000)} claude -p \"$(cat /tmp/implement_prompt.txt)\" --output-format text 2>&1"
-           ) do
-      :ok
-    else
-      {:error, _} = err -> err
+    with {:ok, _} <- exec_with_retry(sprite_name, write_cmd) do
+      claude_cmd =
+        "cd #{work_dir} && ANTHROPIC_API_KEY=#{anthropic_api_key()} claude -p \"$(cat /tmp/implement_prompt.txt)\" --output-format text 2>&1"
+
+      case run_streaming_exec(sprite_name, claude_cmd) do
+        {:ok, %{exit_code: 0}} ->
+          :ok
+
+        {:ok, %{exit_code: code, output: output}} ->
+          Logger.warning(
+            "SpriteDelegate: claude exited with code #{code}: #{String.slice(output, -500, 500)}"
+          )
+
+          # Still try to commit — claude might have made partial changes
+          :ok
+
+        {:error, _} = err ->
+          err
+      end
     end
   end
 
@@ -201,17 +210,14 @@ defmodule Lattice.Ambient.SpriteDelegate do
     #{event[:body]}
 
     Instructions:
-    - Read CLAUDE.md and PHILOSOPHY.md first to understand project conventions
-    - Implement the requested changes following existing patterns in the codebase
-    - Write tests for any new functionality
+    - Read CLAUDE.md first to understand project conventions
+    - Start by understanding the issue: read the title, description, and any thread context above
+    - Search the codebase for relevant code (grep for keywords from the issue title/description)
+    - Implement the requested changes following existing patterns
     - Run `mix format` before finishing
     - Do NOT create a PR, push to remote, or run git operations — only modify files
     - Focus on a clean, minimal implementation that solves what was asked
     """
-  end
-
-  defp implementation_timeout_ms do
-    config(:implementation_timeout_ms, 300_000)
   end
 
   defp github_app_token do
@@ -265,33 +271,29 @@ defmodule Lattice.Ambient.SpriteDelegate do
   defp run_claude_code(sprite_name, event, thread_context) do
     prompt = build_prompt(event, thread_context)
     work_dir = work_dir()
-    timeout = delegation_timeout_ms()
 
     # Write prompt to a temp file on the sprite to avoid shell escaping issues
     write_cmd =
       "cat > /tmp/ambient_prompt.txt << 'LATTICE_PROMPT_EOF'\n#{prompt}\nLATTICE_PROMPT_EOF"
 
-    with {:ok, _} <- exec_with_retry(sprite_name, write_cmd),
-         {:ok, result} <-
-           exec_with_retry(
-             sprite_name,
-             "cd #{work_dir} && ANTHROPIC_API_KEY=#{anthropic_api_key()} timeout #{div(timeout, 1000)} claude -p \"$(cat /tmp/ambient_prompt.txt)\" --output-format text 2>&1"
-           ) do
-      output = result[:output] || result.output || ""
+    with {:ok, _} <- exec_with_retry(sprite_name, write_cmd) do
+      claude_cmd =
+        "cd #{work_dir} && ANTHROPIC_API_KEY=#{anthropic_api_key()} claude -p \"$(cat /tmp/ambient_prompt.txt)\" --output-format text 2>&1"
 
-      Logger.info(
-        "SpriteDelegate: claude returned #{byte_size(output)} bytes, exit_code=#{result[:exit_code]}"
-      )
+      case run_streaming_exec(sprite_name, claude_cmd) do
+        {:ok, %{output: output}} ->
+          Logger.info("SpriteDelegate: claude returned #{byte_size(output)} bytes")
 
-      if String.trim(output) == "" do
-        {:error, :empty_response}
-      else
-        {:ok, String.trim(output)}
+          if String.trim(output) == "" do
+            {:error, :empty_response}
+          else
+            {:ok, String.trim(output)}
+          end
+
+        {:error, reason} = err ->
+          Logger.error("SpriteDelegate: claude execution failed: #{inspect(reason)}")
+          err
       end
-    else
-      {:error, reason} = err ->
-        Logger.error("SpriteDelegate: claude execution failed: #{inspect(reason)}")
-        err
     end
   end
 
@@ -325,6 +327,67 @@ defmodule Lattice.Ambient.SpriteDelegate do
   defp retryable?(:timeout), do: true
   defp retryable?(:rate_limited), do: true
   defp retryable?(_), do: false
+
+  # ── Private: Streaming Exec ─────────────────────────────────────
+
+  defp run_streaming_exec(sprite_name, command) do
+    idle_timeout = config(:exec_idle_timeout_ms, 1_800_000)
+
+    case Sprites.exec_ws(sprite_name, command, idle_timeout: idle_timeout) do
+      {:ok, session_pid} ->
+        collect_streaming_output(session_pid)
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp collect_streaming_output(session_pid) do
+    ref = Process.monitor(session_pid)
+    {:ok, session_state} = Lattice.Sprites.ExecSession.get_state(session_pid)
+    session_id = session_state.session_id
+    topic = Lattice.Sprites.ExecSession.exec_topic(session_id)
+
+    Phoenix.PubSub.subscribe(Lattice.PubSub, topic)
+    result = collect_loop(ref, [])
+    Phoenix.PubSub.unsubscribe(Lattice.PubSub, topic)
+    Process.demonitor(ref, [:flush])
+    result
+  end
+
+  defp collect_loop(ref, chunks) do
+    idle_timeout = config(:exec_idle_timeout_ms, 1_800_000)
+
+    receive do
+      {:exec_output, %{stream: :exit, chunk: chunk}} ->
+        exit_code = parse_exit_code(chunk)
+        output = chunks |> Enum.reverse() |> Enum.join()
+        {:ok, %{output: output, exit_code: exit_code}}
+
+      {:exec_output, %{stream: stream, chunk: chunk}} when stream in [:stdout, :stderr] ->
+        Logger.debug("SpriteDelegate: claude output chunk (#{byte_size(to_string(chunk))} bytes)")
+        collect_loop(ref, [to_string(chunk) | chunks])
+
+      {:exec_output, _other} ->
+        collect_loop(ref, chunks)
+
+      {:DOWN, ^ref, :process, _pid, _reason} ->
+        output = chunks |> Enum.reverse() |> Enum.join()
+        {:ok, %{output: output, exit_code: 0}}
+    after
+      idle_timeout ->
+        {:error, :idle_timeout}
+    end
+  end
+
+  defp parse_exit_code(chunk) when is_binary(chunk) do
+    case Regex.run(~r/code (\d+)/, chunk) do
+      [_, code_str] -> String.to_integer(code_str)
+      _ -> 1
+    end
+  end
+
+  defp parse_exit_code(_), do: 1
 
   # ── Private: Prompt ──────────────────────────────────────────────
 
@@ -397,10 +460,6 @@ defmodule Lattice.Ambient.SpriteDelegate do
 
   defp work_dir do
     config(:work_dir, "/workspace/repo")
-  end
-
-  defp delegation_timeout_ms do
-    config(:delegation_timeout_ms, 120_000)
   end
 
   defp anthropic_api_key do

--- a/lib/lattice/capabilities/github.ex
+++ b/lib/lattice/capabilities/github.ex
@@ -140,6 +140,15 @@ defmodule Lattice.Capabilities.GitHub do
   @callback create_review_comment_reaction(integer(), String.t()) ::
               {:ok, map()} | {:error, term()}
 
+  @doc "Delete a reaction from an issue comment."
+  @callback delete_comment_reaction(integer(), integer()) :: :ok | {:error, term()}
+
+  @doc "Delete a reaction from an issue or PR (top-level body)."
+  @callback delete_issue_reaction(issue_number(), integer()) :: :ok | {:error, term()}
+
+  @doc "Delete a reaction from a pull request review comment."
+  @callback delete_review_comment_reaction(integer(), integer()) :: :ok | {:error, term()}
+
   @doc "List comments on an issue or PR."
   @callback list_comments(issue_number()) :: {:ok, [comment()]} | {:error, term()}
 
@@ -234,6 +243,18 @@ defmodule Lattice.Capabilities.GitHub do
   @doc "Add a reaction to a pull request review comment."
   def create_review_comment_reaction(comment_id, reaction),
     do: impl().create_review_comment_reaction(comment_id, reaction)
+
+  @doc "Delete a reaction from an issue comment."
+  def delete_comment_reaction(comment_id, reaction_id),
+    do: impl().delete_comment_reaction(comment_id, reaction_id)
+
+  @doc "Delete a reaction from an issue or PR (top-level body)."
+  def delete_issue_reaction(number, reaction_id),
+    do: impl().delete_issue_reaction(number, reaction_id)
+
+  @doc "Delete a reaction from a pull request review comment."
+  def delete_review_comment_reaction(comment_id, reaction_id),
+    do: impl().delete_review_comment_reaction(comment_id, reaction_id)
 
   @doc "List comments on an issue or PR."
   def list_comments(number), do: impl().list_comments(number)

--- a/lib/lattice/capabilities/github/http.ex
+++ b/lib/lattice/capabilities/github/http.ex
@@ -593,6 +593,50 @@ defmodule Lattice.Capabilities.GitHub.Http do
     end)
   end
 
+  # ── Delete Reactions ─────────────────────────────────────────────
+
+  @impl true
+  def delete_comment_reaction(comment_id, reaction_id) do
+    timed(:delete_comment_reaction, fn ->
+      case api_delete("/repos/#{repo()}/issues/comments/#{comment_id}/reactions/#{reaction_id}") do
+        {:ok, _} -> {:ok, :ok}
+        {:error, _} = err -> err
+      end
+    end)
+    |> case do
+      {:ok, :ok} -> :ok
+      {:error, _} = err -> err
+    end
+  end
+
+  @impl true
+  def delete_issue_reaction(number, reaction_id) do
+    timed(:delete_issue_reaction, fn ->
+      case api_delete("/repos/#{repo()}/issues/#{number}/reactions/#{reaction_id}") do
+        {:ok, _} -> {:ok, :ok}
+        {:error, _} = err -> err
+      end
+    end)
+    |> case do
+      {:ok, :ok} -> :ok
+      {:error, _} = err -> err
+    end
+  end
+
+  @impl true
+  def delete_review_comment_reaction(comment_id, reaction_id) do
+    timed(:delete_review_comment_reaction, fn ->
+      case api_delete("/repos/#{repo()}/pulls/comments/#{comment_id}/reactions/#{reaction_id}") do
+        {:ok, _} -> {:ok, :ok}
+        {:error, _} = err -> err
+      end
+    end)
+    |> case do
+      {:ok, :ok} -> :ok
+      {:error, _} = err -> err
+    end
+  end
+
   # ── Comments (list) ─────────────────────────────────────────────
 
   @impl true

--- a/lib/lattice/capabilities/github/live.ex
+++ b/lib/lattice/capabilities/github/live.ex
@@ -417,6 +417,60 @@ defmodule Lattice.Capabilities.GitHub.Live do
   end
 
   @impl true
+  def delete_comment_reaction(comment_id, reaction_id) do
+    args = [
+      "api",
+      "-X",
+      "DELETE",
+      "repos/{owner}/{repo}/issues/comments/#{comment_id}/reactions/#{reaction_id}"
+    ]
+
+    timed_cmd(:delete_comment_reaction, args, fn _output ->
+      {:ok, :ok}
+    end)
+    |> case do
+      {:ok, :ok} -> :ok
+      {:error, _} = err -> err
+    end
+  end
+
+  @impl true
+  def delete_issue_reaction(number, reaction_id) do
+    args = [
+      "api",
+      "-X",
+      "DELETE",
+      "repos/{owner}/{repo}/issues/#{number}/reactions/#{reaction_id}"
+    ]
+
+    timed_cmd(:delete_issue_reaction, args, fn _output ->
+      {:ok, :ok}
+    end)
+    |> case do
+      {:ok, :ok} -> :ok
+      {:error, _} = err -> err
+    end
+  end
+
+  @impl true
+  def delete_review_comment_reaction(comment_id, reaction_id) do
+    args = [
+      "api",
+      "-X",
+      "DELETE",
+      "repos/{owner}/{repo}/pulls/comments/#{comment_id}/reactions/#{reaction_id}"
+    ]
+
+    timed_cmd(:delete_review_comment_reaction, args, fn _output ->
+      {:ok, :ok}
+    end)
+    |> case do
+      {:ok, :ok} -> :ok
+      {:error, _} = err -> err
+    end
+  end
+
+  @impl true
   def list_comments(number) do
     args = ["api", "repos/{owner}/{repo}/issues/#{number}/comments"]
 

--- a/lib/lattice/events.ex
+++ b/lib/lattice/events.ex
@@ -399,7 +399,7 @@ defmodule Lattice.Events do
       %{event_type: event[:type], surface: event[:surface]}
     )
 
-    Phoenix.PubSub.broadcast(pubsub(), ambient_topic(), {:ambient_event, event})
+    Phoenix.PubSub.local_broadcast(pubsub(), ambient_topic(), {:ambient_event, event})
   end
 
   @doc "Broadcast a log line to a sprite's logs topic."


### PR DESCRIPTION
## Summary
- **Local broadcast**: Use `local_broadcast` for ambient events to prevent both Fly machines from processing the same webhook
- **Streaming exec**: Replace sync `exec` + shell `timeout` with `exec_ws` for Claude Code, removing arbitrary time limits and letting the Elixir process babysit until completion
- **Better prompt**: Improve implementation prompt with explicit codebase search instructions
- **Rocket reaction**: Add 🚀 as in-progress indicator (shown on start, removed on completion), with new `delete_*_reaction` GitHub API callbacks

## Test plan
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format --check-formatted` — clean
- [x] `mix test test/lattice/ambient/` — 32 tests, 0 failures
- [ ] Deploy to Fly and test "implement this" on a simple issue
- [ ] Verify only one machine processes each webhook (check logs)
- [ ] Verify 🚀 appears during processing and is removed after

🤖 Generated with [Claude Code](https://claude.com/claude-code)