### PR TITLE
Implement Lattice ↔ Sprite protocol v1

### DIFF
--- a/lib/lattice/capabilities/sprites.ex
+++ b/lib/lattice/capabilities/sprites.ex
@@ -55,6 +55,10 @@ defmodule Lattice.Capabilities.Sprites do
   @callback exec_ws(sprite_id(), command(), opts :: keyword()) ::
               {:ok, pid()} | {:error, term()}
 
+  @doc "Restore a Sprite from a checkpoint. Returns streamed messages."
+  @callback restore_checkpoint(sprite_id(), checkpoint_id :: String.t()) ::
+              {:ok, term()} | {:error, term()}
+
   @doc "List all Sprites visible to this Lattice instance."
   def list_sprites, do: impl().list_sprites()
 
@@ -81,6 +85,10 @@ defmodule Lattice.Capabilities.Sprites do
 
   @doc "Start a WebSocket exec session on a Sprite."
   def exec_ws(sprite_id, command, opts \\ []), do: impl().exec_ws(sprite_id, command, opts)
+
+  @doc "Restore a Sprite from a checkpoint."
+  def restore_checkpoint(sprite_id, checkpoint_id),
+    do: impl().restore_checkpoint(sprite_id, checkpoint_id)
 
   defp impl, do: Application.get_env(:lattice, :capabilities)[:sprites]
 end

--- a/lib/lattice/capabilities/sprites/live.ex
+++ b/lib/lattice/capabilities/sprites/live.ex
@@ -131,6 +131,24 @@ defmodule Lattice.Capabilities.Sprites.Live do
   end
 
   @impl true
+  def restore_checkpoint(id, checkpoint_id) do
+    sprite = build_sprite(id)
+
+    case Sprites.restore_checkpoint(sprite, checkpoint_id) do
+      {:ok, messages} ->
+        # Consume the streaming response to completion
+        result = Enum.to_list(messages)
+        Logger.info("Sprites API: restored checkpoint #{checkpoint_id} on #{id}")
+        {:ok, result}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  rescue
+    e -> {:error, normalize_error(e)}
+  end
+
+  @impl true
   def fetch_logs(id, opts) do
     # The SDK doesn't wrap the services endpoint, so use Req directly
     query = build_log_query(opts)

--- a/lib/lattice/protocol/event.ex
+++ b/lib/lattice/protocol/event.ex
@@ -1,23 +1,54 @@
 defmodule Lattice.Protocol.Event do
   @moduledoc """
   Envelope for structured events emitted by sprites via the LATTICE_EVENT protocol.
+
+  ## Protocol v1 Envelope
+
+  Every event carries:
+  - `protocol_version` — always `"v1"` for now
+  - `event_type` — protocol-defined type (INFO, WAITING, COMPLETED, etc.)
+  - `sprite_id` — which sprite emitted this event
+  - `work_item_id` — external work reference (issue, PR, task)
+  - `timestamp` — when the event was emitted
+  - `data` — parsed, typed payload
+
+  For backward compatibility, `type` aliases `event_type` and `run_id` aliases
+  `work_item_id` when constructing events from pre-v1 sources.
   """
 
   @type t :: %__MODULE__{
+          protocol_version: String.t(),
+          event_type: String.t(),
           type: String.t(),
-          timestamp: DateTime.t(),
+          sprite_id: String.t() | nil,
+          work_item_id: String.t() | nil,
           run_id: String.t() | nil,
+          timestamp: DateTime.t(),
           data: struct() | map()
         }
 
-  @enforce_keys [:type, :timestamp, :data]
-  defstruct [:type, :timestamp, :run_id, :data]
+  @enforce_keys [:event_type, :timestamp, :data]
+  defstruct [
+    :event_type,
+    :type,
+    :sprite_id,
+    :work_item_id,
+    :run_id,
+    :timestamp,
+    :data,
+    protocol_version: "v1"
+  ]
 
-  def new(type, data, opts \\ []) do
+  @doc "Create a new Event. Accepts either v1 field names or legacy names."
+  def new(event_type, data, opts \\ []) do
     %__MODULE__{
-      type: type,
+      protocol_version: Keyword.get(opts, :protocol_version, "v1"),
+      event_type: event_type,
+      type: event_type,
+      sprite_id: Keyword.get(opts, :sprite_id),
+      work_item_id: Keyword.get(opts, :work_item_id) || Keyword.get(opts, :run_id),
+      run_id: Keyword.get(opts, :run_id) || Keyword.get(opts, :work_item_id),
       timestamp: Keyword.get(opts, :timestamp, DateTime.utc_now()),
-      run_id: Keyword.get(opts, :run_id),
       data: data
     }
   end

--- a/lib/lattice/protocol/event_handler.ex
+++ b/lib/lattice/protocol/event_handler.ex
@@ -2,8 +2,8 @@ defmodule Lattice.Protocol.EventHandler do
   @moduledoc """
   Wires protocol events from ExecSession into Run state updates.
 
-  Subscribes to exec session event topics and routes events to the
-  appropriate handlers (artifact storage, run state transitions, etc.).
+  Handles both protocol v1 events and legacy event types. Routes events to
+  the appropriate handlers (artifact storage, run state transitions, etc.).
   """
 
   require Logger
@@ -11,18 +11,32 @@ defmodule Lattice.Protocol.EventHandler do
   alias Lattice.Capabilities.GitHub.ArtifactLink
   alias Lattice.Capabilities.GitHub.ArtifactRegistry
   alias Lattice.Protocol.Event
+
+  # Legacy event structs
   alias Lattice.Protocol.Events.Artifact
   alias Lattice.Protocol.Events.Assumption
   alias Lattice.Protocol.Events.Blocked
   alias Lattice.Protocol.Events.Question
+
+  # Protocol v1 event structs
+  alias Lattice.Protocol.Events.ActionRequest
+  alias Lattice.Protocol.Events.Completed
+  alias Lattice.Protocol.Events.EnvironmentProposal
+  alias Lattice.Protocol.Events.Error, as: ErrorEvent
+  alias Lattice.Protocol.Events.Waiting
+
   alias Lattice.Runs.Run
 
   @doc """
   Handle a protocol event in the context of a run.
   Returns {:ok, updated_run} or {:error, reason}.
   """
+
+  # ── Protocol v1: ARTIFACT (same struct as legacy, uppercase type) ────
+
   @spec handle_event(Event.t(), Run.t()) :: {:ok, Run.t()} | {:error, term()}
-  def handle_event(%Event{type: "artifact", data: %Artifact{} = artifact_data}, %Run{} = run) do
+  def handle_event(%Event{event_type: type, data: %Artifact{} = artifact_data}, %Run{} = run)
+      when type in ["artifact", "ARTIFACT"] do
     artifact = %{
       kind: artifact_data.kind,
       url: artifact_data.url,
@@ -48,7 +62,9 @@ defmodule Lattice.Protocol.EventHandler do
     {:ok, updated_run}
   end
 
-  def handle_event(%Event{type: "assumption", data: %Assumption{} = a}, %Run{} = run) do
+  # ── Legacy: assumption ───────────────────────────────────────────────
+
+  def handle_event(%Event{event_type: "assumption", data: %Assumption{} = a}, %Run{} = run) do
     updated =
       Enum.reduce(a.files, run, fn file, acc ->
         assumption = %{
@@ -76,7 +92,9 @@ defmodule Lattice.Protocol.EventHandler do
     {:ok, updated}
   end
 
-  def handle_event(%Event{type: "question", data: %Question{} = q}, %Run{} = run) do
+  # ── Legacy: question → blocked_waiting_for_user ──────────────────────
+
+  def handle_event(%Event{event_type: "question", data: %Question{} = q}, %Run{} = run) do
     question_data = %{prompt: q.prompt, choices: q.choices, default: q.default}
 
     case Run.block_for_input(run, question_data) do
@@ -95,7 +113,9 @@ defmodule Lattice.Protocol.EventHandler do
     end
   end
 
-  def handle_event(%Event{type: "blocked", data: %Blocked{} = b}, %Run{} = run) do
+  # ── Legacy: blocked ──────────────────────────────────────────────────
+
+  def handle_event(%Event{event_type: "blocked", data: %Blocked{} = b}, %Run{} = run) do
     case Run.block(run, b.reason) do
       {:ok, updated} ->
         :telemetry.execute(
@@ -112,12 +132,201 @@ defmodule Lattice.Protocol.EventHandler do
     end
   end
 
-  def handle_event(%Event{}, %Run{} = run) do
-    # Other event types handled by their respective modules
+  # ── Protocol v1: WAITING → :waiting with checkpoint ──────────────────
+
+  def handle_event(%Event{event_type: "WAITING", data: %Waiting{} = w}, %Run{} = run) do
+    case Run.wait(run, w.reason, w.checkpoint_id, w.expected_inputs) do
+      {:ok, updated} ->
+        :telemetry.execute(
+          [:lattice, :run, :waiting],
+          %{count: 1},
+          %{
+            run_id: run.id,
+            reason: w.reason,
+            checkpoint_id: w.checkpoint_id
+          }
+        )
+
+        Phoenix.PubSub.broadcast(Lattice.PubSub, "runs", {:run_waiting, updated})
+        {:ok, updated}
+
+      error ->
+        error
+    end
+  end
+
+  # ── Protocol v1: COMPLETED → succeed or fail ─────────────────────────
+
+  def handle_event(%Event{event_type: "COMPLETED", data: %Completed{} = c}, %Run{} = run) do
+    case c.status do
+      "success" ->
+        case Run.complete(run) do
+          {:ok, updated} ->
+            :telemetry.execute(
+              [:lattice, :run, :completed],
+              %{count: 1},
+              %{run_id: run.id, status: "success"}
+            )
+
+            Phoenix.PubSub.broadcast(Lattice.PubSub, "runs", {:run_completed, updated})
+            {:ok, updated}
+
+          error ->
+            error
+        end
+
+      "failure" ->
+        case Run.fail(run, %{error: c.summary}) do
+          {:ok, updated} ->
+            :telemetry.execute(
+              [:lattice, :run, :completed],
+              %{count: 1},
+              %{run_id: run.id, status: "failure"}
+            )
+
+            Phoenix.PubSub.broadcast(Lattice.PubSub, "runs", {:run_failed, updated})
+            {:ok, updated}
+
+          error ->
+            error
+        end
+
+      _other ->
+        {:ok, run}
+    end
+  end
+
+  # ── Protocol v1: ERROR → fail ────────────────────────────────────────
+
+  def handle_event(%Event{event_type: "ERROR", data: %ErrorEvent{} = e}, %Run{} = run) do
+    case Run.fail(run, %{error: e.message}) do
+      {:ok, updated} ->
+        :telemetry.execute(
+          [:lattice, :run, :error],
+          %{count: 1},
+          %{run_id: run.id, message: e.message}
+        )
+
+        Phoenix.PubSub.broadcast(Lattice.PubSub, "runs", {:run_failed, updated})
+        {:ok, updated}
+
+      error ->
+        error
+    end
+  end
+
+  # ── Protocol v1: ACTION_REQUEST → dispatch ───────────────────────────
+
+  def handle_event(%Event{event_type: "ACTION_REQUEST", data: %ActionRequest{} = a}, %Run{} = run) do
+    :telemetry.execute(
+      [:lattice, :run, :action_requested],
+      %{count: 1},
+      %{run_id: run.id, action: a.action, blocking: a.blocking}
+    )
+
+    Phoenix.PubSub.broadcast(
+      Lattice.PubSub,
+      "runs",
+      {:action_requested, run, a}
+    )
+
+    # Non-blocking: run continues. Blocking: sprite will emit WAITING next.
     {:ok, run}
   end
 
-  # ── Private: GitHub Artifact Registration ────────────────────────
+  # ── Protocol v1: PHASE_STARTED / PHASE_FINISHED → telemetry ─────────
+
+  def handle_event(%Event{event_type: "PHASE_STARTED", data: data}, %Run{} = run) do
+    phase = Map.get(data, :phase) || Map.get(data, "phase")
+
+    :telemetry.execute(
+      [:lattice, :run, :phase_started],
+      %{count: 1},
+      %{run_id: run.id, phase: phase}
+    )
+
+    Phoenix.PubSub.broadcast(
+      Lattice.PubSub,
+      "runs",
+      {:phase_started, run, phase}
+    )
+
+    {:ok, run}
+  end
+
+  def handle_event(%Event{event_type: "PHASE_FINISHED", data: data}, %Run{} = run) do
+    phase = Map.get(data, :phase) || Map.get(data, "phase")
+    success = Map.get(data, :success) || Map.get(data, "success", true)
+
+    :telemetry.execute(
+      [:lattice, :run, :phase_finished],
+      %{count: 1},
+      %{run_id: run.id, phase: phase, success: success}
+    )
+
+    Phoenix.PubSub.broadcast(
+      Lattice.PubSub,
+      "runs",
+      {:phase_finished, run, phase, success}
+    )
+
+    {:ok, run}
+  end
+
+  # ── Protocol v1: INFO → telemetry (no state change) ─────────────────
+
+  def handle_event(%Event{event_type: "INFO", data: data}, %Run{} = run) do
+    message = Map.get(data, :message) || Map.get(data, "message")
+    kind = Map.get(data, :kind) || Map.get(data, "kind")
+
+    :telemetry.execute(
+      [:lattice, :run, :info],
+      %{count: 1},
+      %{run_id: run.id, kind: kind}
+    )
+
+    Phoenix.PubSub.broadcast(
+      Lattice.PubSub,
+      "runs",
+      {:run_info, run, %{message: message, kind: kind, data: data}}
+    )
+
+    {:ok, run}
+  end
+
+  # ── Protocol v1: ENVIRONMENT_PROPOSAL → broadcast for handling ───────
+
+  def handle_event(
+        %Event{event_type: "ENVIRONMENT_PROPOSAL", data: %EnvironmentProposal{} = p},
+        %Run{} = run
+      ) do
+    :telemetry.execute(
+      [:lattice, :run, :environment_proposal],
+      %{count: 1},
+      %{
+        run_id: run.id,
+        adjustment_type: get_in_map(p.suggested_adjustment, "type"),
+        scope: p.scope,
+        confidence: p.confidence
+      }
+    )
+
+    Phoenix.PubSub.broadcast(
+      Lattice.PubSub,
+      "environment_proposals",
+      {:environment_proposal, run, p}
+    )
+
+    {:ok, run}
+  end
+
+  # ── Catch-all: unknown events pass through ───────────────────────────
+
+  def handle_event(%Event{}, %Run{} = run) do
+    {:ok, run}
+  end
+
+  # ── Private: GitHub Artifact Registration ────────────────────────────
 
   @github_artifact_kinds %{
     "pr_url" => :pull_request,
@@ -173,4 +382,7 @@ defmodule Lattice.Protocol.EventHandler do
       _ -> url
     end
   end
+
+  defp get_in_map(map, key) when is_map(map), do: Map.get(map, key)
+  defp get_in_map(_, _), do: nil
 end

--- a/lib/lattice/protocol/events/action_request.ex
+++ b/lib/lattice/protocol/events/action_request.ex
@@ -1,0 +1,19 @@
+defmodule Lattice.Protocol.Events.ActionRequest do
+  @moduledoc """
+  Protocol v1 ACTION_REQUEST event. Sprite requests Lattice perform an
+  external action on its behalf.
+
+  When `blocking` is true, the sprite will emit a WAITING event immediately
+  after and expects the action result in the resume payload.
+  """
+
+  defstruct [:action, parameters: %{}, blocking: false]
+
+  def from_map(map) do
+    %__MODULE__{
+      action: Map.get(map, "action"),
+      parameters: Map.get(map, "parameters", %{}),
+      blocking: Map.get(map, "blocking", false)
+    }
+  end
+end

--- a/lib/lattice/protocol/events/completed.ex
+++ b/lib/lattice/protocol/events/completed.ex
@@ -1,0 +1,15 @@
+defmodule Lattice.Protocol.Events.Completed do
+  @moduledoc """
+  Protocol v1 COMPLETED event. Sprite has finished all work on the
+  current work item.
+  """
+
+  defstruct [:status, :summary]
+
+  def from_map(map) do
+    %__MODULE__{
+      status: Map.get(map, "status"),
+      summary: Map.get(map, "summary")
+    }
+  end
+end

--- a/lib/lattice/protocol/events/environment_proposal.ex
+++ b/lib/lattice/protocol/events/environment_proposal.ex
@@ -1,0 +1,36 @@
+defmodule Lattice.Protocol.Events.EnvironmentProposal do
+  @moduledoc """
+  Protocol v1 ENVIRONMENT_PROPOSAL event. Sprite proposes an improvement
+  to its environment or setup.
+
+  Fire-and-forget — sprites never receive acceptance feedback in the
+  same session. Accepted changes apply only to future runs.
+  """
+
+  @valid_adjustment_types ~w(
+    runtime_install
+    runtime_version_adjust
+    dependency_manager_switch
+    add_preinstall_step
+    adjust_smoke_command
+    add_system_package
+    enable_network_access
+    escalate_to_human
+  )
+
+  defstruct [:observed_failure, :suggested_adjustment, :confidence, :scope, evidence: []]
+
+  def from_map(map) do
+    %__MODULE__{
+      observed_failure: Map.get(map, "observed_failure", %{}),
+      suggested_adjustment: Map.get(map, "suggested_adjustment", %{}),
+      confidence: Map.get(map, "confidence", 0.0),
+      evidence: Map.get(map, "evidence", []),
+      scope: Map.get(map, "scope")
+    }
+  end
+
+  def valid_adjustment_types, do: @valid_adjustment_types
+
+  def valid_adjustment_type?(type), do: type in @valid_adjustment_types
+end

--- a/lib/lattice/protocol/events/error.ex
+++ b/lib/lattice/protocol/events/error.ex
@@ -1,0 +1,14 @@
+defmodule Lattice.Protocol.Events.Error do
+  @moduledoc """
+  Protocol v1 ERROR event. Unrecoverable failure.
+  """
+
+  defstruct [:message, details: %{}]
+
+  def from_map(map) do
+    %__MODULE__{
+      message: Map.get(map, "message"),
+      details: Map.get(map, "details", %{})
+    }
+  end
+end

--- a/lib/lattice/protocol/events/info.ex
+++ b/lib/lattice/protocol/events/info.ex
@@ -1,0 +1,18 @@
+defmodule Lattice.Protocol.Events.Info do
+  @moduledoc """
+  Protocol v1 INFO event. Non-blocking informational message.
+
+  Supports optional `kind` and `metadata` for machine-actionable rendering
+  while `message` provides a human-readable fallback.
+  """
+
+  defstruct [:message, :kind, metadata: %{}]
+
+  def from_map(map) do
+    %__MODULE__{
+      message: Map.get(map, "message"),
+      kind: Map.get(map, "kind"),
+      metadata: Map.get(map, "metadata", %{})
+    }
+  end
+end

--- a/lib/lattice/protocol/events/phase_finished.ex
+++ b/lib/lattice/protocol/events/phase_finished.ex
@@ -1,0 +1,14 @@
+defmodule Lattice.Protocol.Events.PhaseFinished do
+  @moduledoc """
+  Protocol v1 PHASE_FINISHED event. Sprite completed a logical phase.
+  """
+
+  defstruct [:phase, success: true]
+
+  def from_map(map) do
+    %__MODULE__{
+      phase: Map.get(map, "phase"),
+      success: Map.get(map, "success", true)
+    }
+  end
+end

--- a/lib/lattice/protocol/events/phase_started.ex
+++ b/lib/lattice/protocol/events/phase_started.ex
@@ -1,0 +1,11 @@
+defmodule Lattice.Protocol.Events.PhaseStarted do
+  @moduledoc """
+  Protocol v1 PHASE_STARTED event. Sprite entered a logical phase of work.
+  """
+
+  defstruct [:phase]
+
+  def from_map(map) do
+    %__MODULE__{phase: Map.get(map, "phase")}
+  end
+end

--- a/lib/lattice/protocol/events/waiting.ex
+++ b/lib/lattice/protocol/events/waiting.ex
@@ -1,0 +1,20 @@
+defmodule Lattice.Protocol.Events.Waiting do
+  @moduledoc """
+  Protocol v1 WAITING event. Sprite has reached a blocking point and
+  cannot proceed without external input.
+
+  The sprite MUST create a checkpoint before emitting this event and
+  include the checkpoint_id. After emitting WAITING, the sprite stops work.
+  Lattice owns continuation via checkpoint restore + exec.
+  """
+
+  defstruct [:reason, :checkpoint_id, expected_inputs: %{}]
+
+  def from_map(map) do
+    %__MODULE__{
+      reason: Map.get(map, "reason"),
+      checkpoint_id: Map.get(map, "checkpoint_id"),
+      expected_inputs: Map.get(map, "expected_inputs", %{})
+    }
+  end
+end

--- a/lib/lattice/protocol/parser.ex
+++ b/lib/lattice/protocol/parser.ex
@@ -2,13 +2,15 @@ defmodule Lattice.Protocol.Parser do
   @moduledoc """
   Parses stdout lines for LATTICE_EVENT structured events.
 
-  Pure function module — no GenServer, no state. Transforms lines.
+  Supports both protocol v1 events (using `event_type` field) and legacy
+  events (using `type` field). Pure function module — no GenServer, no state.
   """
 
   require Logger
 
   alias Lattice.Protocol.Event
 
+  # Legacy event structs (pre-v1, still supported)
   alias Lattice.Protocol.Events.{
     Artifact,
     Assumption,
@@ -18,6 +20,18 @@ defmodule Lattice.Protocol.Parser do
     Progress,
     Question,
     Warning
+  }
+
+  # Protocol v1 event structs
+  alias Lattice.Protocol.Events.{
+    ActionRequest,
+    Completed,
+    EnvironmentProposal,
+    Error,
+    Info,
+    PhaseFinished,
+    PhaseStarted,
+    Waiting
   }
 
   @prefix "LATTICE_EVENT "
@@ -40,20 +54,48 @@ defmodule Lattice.Protocol.Parser do
 
   defp parse_event_json(json_str, original_line) do
     case Jason.decode(json_str) do
-      {:ok, %{"type" => type} = map} ->
-        data = build_typed_data(type, map)
-        event = Event.new(type, data)
-        {:event, event}
+      {:ok, map} ->
+        # Support both v1 envelope (event_type) and legacy (type)
+        event_type = Map.get(map, "event_type") || Map.get(map, "type")
 
-      {:ok, _map} ->
-        Logger.warning("LATTICE_EVENT missing 'type' field: #{json_str}")
-        {:text, original_line}
+        if event_type do
+          data = build_typed_data(event_type, map)
+
+          event =
+            Event.new(event_type, data,
+              protocol_version: Map.get(map, "protocol_version", "v1"),
+              sprite_id: Map.get(map, "sprite_id"),
+              work_item_id: Map.get(map, "work_item_id"),
+              run_id: Map.get(map, "work_item_id")
+            )
+
+          {:event, event}
+        else
+          Logger.warning("LATTICE_EVENT missing 'event_type'/'type' field: #{json_str}")
+          {:text, original_line}
+        end
 
       {:error, reason} ->
         Logger.warning("LATTICE_EVENT malformed JSON: #{inspect(reason)}")
         {:text, original_line}
     end
   end
+
+  # ── Protocol v1 event types ──────────────────────────────────────────
+
+  defp build_typed_data("INFO", map), do: Info.from_map(payload_or_root(map))
+  defp build_typed_data("PHASE_STARTED", map), do: PhaseStarted.from_map(payload_or_root(map))
+  defp build_typed_data("PHASE_FINISHED", map), do: PhaseFinished.from_map(payload_or_root(map))
+  defp build_typed_data("ACTION_REQUEST", map), do: ActionRequest.from_map(payload_or_root(map))
+  defp build_typed_data("ARTIFACT", map), do: Artifact.from_map(payload_or_root(map))
+  defp build_typed_data("WAITING", map), do: Waiting.from_map(payload_or_root(map))
+  defp build_typed_data("COMPLETED", map), do: Completed.from_map(payload_or_root(map))
+  defp build_typed_data("ERROR", map), do: Error.from_map(payload_or_root(map))
+
+  defp build_typed_data("ENVIRONMENT_PROPOSAL", map),
+    do: EnvironmentProposal.from_map(payload_or_root(map))
+
+  # ── Legacy event types (backward compatibility) ──────────────────────
 
   defp build_typed_data("artifact", map), do: Artifact.from_map(map)
   defp build_typed_data("question", map), do: Question.from_map(map)
@@ -63,5 +105,17 @@ defmodule Lattice.Protocol.Parser do
   defp build_typed_data("completion", map), do: Completion.from_map(map)
   defp build_typed_data("warning", map), do: Warning.from_map(map)
   defp build_typed_data("checkpoint", map), do: Checkpoint.from_map(map)
+
+  # ── Unknown types ────────────────────────────────────────────────────
+
   defp build_typed_data(_unknown_type, map), do: map
+
+  # V1 events nest data in "payload", legacy events put it at the root
+  defp payload_or_root(map) do
+    case Map.get(map, "payload") do
+      nil -> map
+      payload when is_map(payload) -> payload
+      _other -> map
+    end
+  end
 end

--- a/lib/lattice/protocol/resume.ex
+++ b/lib/lattice/protocol/resume.ex
@@ -1,0 +1,106 @@
+defmodule Lattice.Protocol.Resume do
+  @moduledoc """
+  Implements the protocol v1 resume flow: checkpoint restore → write context → exec.
+
+  When a sprite emits a WAITING event with a checkpoint_id, it pauses. Lattice
+  owns continuation. This module handles restoring the sprite to its checkpoint
+  state, writing the resume payload, and executing the continuation command.
+
+  ## Flow
+
+  1. Restore checkpoint via Sprites API (sub-second)
+  2. Write resume context to `/workspace/.lattice/resume.json`
+  3. Exec the continuation command on the sprite
+  """
+
+  require Logger
+
+  alias Lattice.Capabilities.Sprites
+  alias Lattice.Sprites.FileWriter
+
+  @resume_path "/workspace/.lattice/resume.json"
+
+  @doc """
+  Resume a sprite from a checkpoint with the given inputs.
+
+  Returns `{:ok, session_pid}` for WebSocket-streamed execution, or
+  `{:error, reason}` if any step fails.
+
+  ## Options
+
+  - `:command` — override the continuation command (default: uses the protocol skill)
+  - `:work_item_id` — external work reference
+  - `:context` — additional context map passed to the sprite
+  """
+  @spec resume(String.t(), String.t(), map(), keyword()) ::
+          {:ok, pid()} | {:error, term()}
+  def resume(sprite_name, checkpoint_id, inputs, opts \\ []) do
+    work_item_id = Keyword.get(opts, :work_item_id)
+    context = Keyword.get(opts, :context, %{})
+
+    command =
+      Keyword.get(
+        opts,
+        :command,
+        "claude -p 'Read /workspace/.lattice/resume.json and continue the workflow from the checkpoint.'"
+      )
+
+    Logger.info(
+      "Resuming sprite #{sprite_name} from checkpoint #{checkpoint_id}"
+    )
+
+    with {:restore, {:ok, _}} <- {:restore, restore_checkpoint(sprite_name, checkpoint_id)},
+         {:write, {:ok, _}} <-
+           {:write, write_resume_context(sprite_name, checkpoint_id, inputs, work_item_id, context)},
+         {:exec, {:ok, pid}} <- {:exec, Sprites.exec_ws(sprite_name, command)} do
+      Logger.info("Sprite #{sprite_name} resumed, exec session started")
+      {:ok, pid}
+    else
+      {:restore, {:error, reason}} ->
+        Logger.error("Failed to restore checkpoint #{checkpoint_id}: #{inspect(reason)}")
+        {:error, {:restore_failed, reason}}
+
+      {:write, {:error, reason}} ->
+        Logger.error("Failed to write resume context: #{inspect(reason)}")
+        {:error, {:write_failed, reason}}
+
+      {:exec, {:error, reason}} ->
+        Logger.error("Failed to exec on #{sprite_name}: #{inspect(reason)}")
+        {:error, {:exec_failed, reason}}
+    end
+  end
+
+  @doc """
+  Build the resume payload that gets written to the sprite filesystem.
+  """
+  @spec build_payload(String.t(), map(), String.t() | nil, map()) :: map()
+  def build_payload(checkpoint_id, inputs, work_item_id, context \\ %{}) do
+    %{
+      work_item_id: work_item_id,
+      checkpoint_id: checkpoint_id,
+      inputs: inputs,
+      context: context,
+      resumed_at: DateTime.utc_now() |> DateTime.to_iso8601()
+    }
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp restore_checkpoint(sprite_name, checkpoint_id) do
+    Sprites.restore_checkpoint(sprite_name, checkpoint_id)
+  end
+
+  defp write_resume_context(sprite_name, checkpoint_id, inputs, work_item_id, context) do
+    payload = build_payload(checkpoint_id, inputs, work_item_id, context)
+
+    case Jason.encode(payload) do
+      {:ok, json} ->
+        # Ensure directory exists, then write
+        Sprites.exec(sprite_name, "mkdir -p /workspace/.lattice")
+        FileWriter.write_file(sprite_name, json, @resume_path)
+
+      {:error, reason} ->
+        {:error, {:json_encode_failed, reason}}
+    end
+  end
+end

--- a/priv/sprite_skills/protocol/SKILL.md
+++ b/priv/sprite_skills/protocol/SKILL.md
@@ -1,0 +1,412 @@
+# Lattice Communication Protocol (v1)
+
+You are running inside a Lattice-managed sprite. This document teaches you how
+to communicate with Lattice -- how to report progress, request actions, pause
+for input, and signal completion. Follow these rules exactly.
+
+## Emitting Events
+
+You communicate with Lattice by emitting structured JSON events in two ways:
+
+1. **stdout** -- Print each event as a single line prefixed with `LATTICE_EVENT `:
+   ```
+   LATTICE_EVENT {"protocol_version":"v1","event_type":"INFO","sprite_id":"sprite-42","work_item_id":"issue-17","timestamp":"2026-01-15T10:30:00Z","payload":{"message":"Starting implementation"}}
+   ```
+
+2. **Outbox file** -- Append the raw JSON (no prefix) as a new line to:
+   ```
+   /workspace/.lattice/outbox.jsonl
+   ```
+
+You MUST do both for every event. The stdout line gives Lattice real-time
+visibility during your session. The outbox file guarantees durability -- if
+your session crashes or the connection drops, Lattice recovers events from
+the outbox.
+
+Ensure `/workspace/.lattice/` exists before writing. Create it if it does not.
+
+## Event Envelope
+
+Every event MUST use this exact structure:
+
+```json
+{
+  "protocol_version": "v1",
+  "event_type": "<TYPE>",
+  "sprite_id": "<your sprite id>",
+  "work_item_id": "<issue number, PR number, or task id>",
+  "timestamp": "<ISO-8601 UTC>",
+  "payload": {}
+}
+```
+
+| Field              | Description                                              |
+|--------------------|----------------------------------------------------------|
+| `protocol_version` | Always `"v1"`.                                           |
+| `event_type`       | One of the types defined below.                          |
+| `sprite_id`        | Your sprite identifier (provided in your exec context).  |
+| `work_item_id`     | The external work reference you are working on.          |
+| `timestamp`        | Current time in ISO-8601 format (e.g. `2026-01-15T10:30:00Z`). |
+| `payload`          | Event-specific data. Structure depends on `event_type`.  |
+
+Events are append-only. You MUST NOT retract or overwrite previous events.
+
+## Event Types
+
+### INFO
+
+Use freely for progress updates, observations, assumptions, and status notes.
+Be chatty -- more observability is always better.
+
+```json
+{
+  "protocol_version": "v1",
+  "event_type": "INFO",
+  "sprite_id": "sprite-42",
+  "work_item_id": "issue-17",
+  "timestamp": "2026-01-15T10:30:00Z",
+  "payload": {
+    "message": "Running test suite (75% complete)",
+    "kind": "progress",
+    "metadata": {"percent": 75, "phase": "test"}
+  }
+}
+```
+
+- `message` (required): Human-readable text.
+- `kind` (optional): One of `progress`, `observation`, `assumption`, `note`, or any free-form string.
+- `metadata` (optional): Structured data relevant to the kind.
+
+### PHASE_STARTED
+
+Emit when you begin a logical phase of work.
+
+```json
+{
+  "protocol_version": "v1",
+  "event_type": "PHASE_STARTED",
+  "sprite_id": "sprite-42",
+  "work_item_id": "issue-17",
+  "timestamp": "2026-01-15T10:31:00Z",
+  "payload": {
+    "phase": "implement"
+  }
+}
+```
+
+Common phase names: `bootstrap`, `implement`, `test`, `polish`, `review`. Use
+whatever name fits your current work.
+
+### PHASE_FINISHED
+
+Emit when you complete a logical phase.
+
+```json
+{
+  "protocol_version": "v1",
+  "event_type": "PHASE_FINISHED",
+  "sprite_id": "sprite-42",
+  "work_item_id": "issue-17",
+  "timestamp": "2026-01-15T10:45:00Z",
+  "payload": {
+    "phase": "implement",
+    "success": true
+  }
+}
+```
+
+### ACTION_REQUEST
+
+Emit when you need Lattice to perform an external action on your behalf.
+You MUST NOT perform these actions yourself.
+
+**Non-blocking action** (fire-and-forget):
+
+```json
+{
+  "protocol_version": "v1",
+  "event_type": "ACTION_REQUEST",
+  "sprite_id": "sprite-42",
+  "work_item_id": "issue-17",
+  "timestamp": "2026-01-15T10:46:00Z",
+  "payload": {
+    "action": "POST_COMMENT",
+    "parameters": {
+      "body": "Implementation complete, tests passing."
+    },
+    "blocking": false
+  }
+}
+```
+
+**Blocking action** (you need the result to continue):
+
+```json
+{
+  "protocol_version": "v1",
+  "event_type": "ACTION_REQUEST",
+  "sprite_id": "sprite-42",
+  "work_item_id": "issue-17",
+  "timestamp": "2026-01-15T10:46:00Z",
+  "payload": {
+    "action": "OPEN_PR",
+    "parameters": {
+      "title": "Fix cache invalidation",
+      "body": "Resolves #17",
+      "base": "main",
+      "head": "sprite/fix-cache"
+    },
+    "blocking": true
+  }
+}
+```
+
+When `blocking` is `true`, you MUST immediately follow with the WAITING flow
+(see Checkpoint Discipline below).
+
+**Known actions:**
+
+| Action             | What it does               | Typically blocking? |
+|--------------------|----------------------------|---------------------|
+| `OPEN_PR`          | Create a pull request      | yes                 |
+| `POST_COMMENT`     | Post a GitHub comment      | no                  |
+| `LABEL_ISSUE`      | Add labels to an issue     | no                  |
+| `NOTIFY_USER`      | Send a notification        | no                  |
+| `FETCH_CREDENTIAL` | Retrieve a secret or token | yes                 |
+
+### ARTIFACT
+
+Emit to declare a work product. This is purely declarative -- it records what
+you produced but does not trigger any action.
+
+```json
+{
+  "protocol_version": "v1",
+  "event_type": "ARTIFACT",
+  "sprite_id": "sprite-42",
+  "work_item_id": "issue-17",
+  "timestamp": "2026-01-15T10:47:00Z",
+  "payload": {
+    "kind": "branch",
+    "ref": "sprite/fix-cache",
+    "url": null,
+    "metadata": {}
+  }
+}
+```
+
+- `kind` (required): `branch`, `commit`, `file`, `pr_url`, `issue_url`, etc.
+- `ref` (optional): Branch name, SHA, file path, or PR number.
+- `url` (optional): URL if applicable.
+- `metadata` (optional): Additional context.
+
+### WAITING
+
+Emit when you cannot proceed without external input. This is the pause
+primitive -- it tells Lattice you are blocked and ready to be suspended.
+
+```json
+{
+  "protocol_version": "v1",
+  "event_type": "WAITING",
+  "sprite_id": "sprite-42",
+  "work_item_id": "issue-17",
+  "timestamp": "2026-01-15T10:48:00Z",
+  "payload": {
+    "reason": "PR_REVIEW",
+    "checkpoint_id": "chk_abc123",
+    "expected_inputs": {
+      "approved": "boolean",
+      "comments": "array<string>"
+    }
+  }
+}
+```
+
+- `reason` (required): Why you are waiting. Be descriptive.
+- `checkpoint_id` (required): The ID of the checkpoint you created before pausing.
+- `expected_inputs` (optional): Schema of what you need on resume. Type vocabulary: `string`, `integer`, `boolean`, `map`, `array<T>`.
+
+See Checkpoint Discipline below for the mandatory sequence.
+
+### COMPLETED
+
+Emit when you have finished all work on the current work item.
+
+```json
+{
+  "protocol_version": "v1",
+  "event_type": "COMPLETED",
+  "sprite_id": "sprite-42",
+  "work_item_id": "issue-17",
+  "timestamp": "2026-01-15T11:00:00Z",
+  "payload": {
+    "status": "success",
+    "summary": "Implemented cache invalidation. All tests passing."
+  }
+}
+```
+
+- `status` (required): `"success"` or `"failure"`.
+- `summary` (optional): Human-readable description of what was accomplished or why it failed.
+
+### ERROR
+
+Emit when you hit an unrecoverable failure and cannot continue.
+
+```json
+{
+  "protocol_version": "v1",
+  "event_type": "ERROR",
+  "sprite_id": "sprite-42",
+  "work_item_id": "issue-17",
+  "timestamp": "2026-01-15T11:01:00Z",
+  "payload": {
+    "message": "Build failed with exit code 1 after 3 retries",
+    "details": {
+      "phase": "test",
+      "exit_code": 1,
+      "attempts": 3
+    }
+  }
+}
+```
+
+Create a checkpoint before emitting ERROR when possible. This enables
+post-mortem inspection.
+
+### ENVIRONMENT_PROPOSAL
+
+Emit when you observe a fixable environment problem. You MUST NOT apply the
+fix yourself -- propose it and Lattice decides.
+
+```json
+{
+  "protocol_version": "v1",
+  "event_type": "ENVIRONMENT_PROPOSAL",
+  "sprite_id": "sprite-42",
+  "work_item_id": "issue-17",
+  "timestamp": "2026-01-15T11:02:00Z",
+  "payload": {
+    "observed_failure": {
+      "phase": "bootstrap",
+      "exit_code": 127,
+      "stderr_hint": "bash: node: command not found"
+    },
+    "suggested_adjustment": {
+      "type": "runtime_install",
+      "details": {
+        "runtime": "node",
+        "version": "20"
+      }
+    },
+    "confidence": 0.85,
+    "evidence": ["package.json present", "no .nvmrc found"],
+    "scope": "repo_specific"
+  }
+}
+```
+
+All fields are required. `confidence` is a float from 0.0 to 1.0. `scope` is
+either `"repo_specific"` or `"global_candidate"`.
+
+Allowed adjustment types: `runtime_install`, `runtime_version_adjust`,
+`dependency_manager_switch`, `add_preinstall_step`, `adjust_smoke_command`,
+`add_system_package`, `enable_network_access`, `escalate_to_human`.
+
+This is fire-and-forget. You will not receive a response in this session.
+Accepted changes apply only to future runs.
+
+## Checkpoint Discipline
+
+Checkpoints freeze your filesystem state. They are instant (~300ms,
+copy-on-write) and cheap. Use them liberally.
+
+**When you MUST checkpoint:**
+
+- Before emitting `WAITING` (mandatory -- include the checkpoint ID in the event)
+- Before emitting `ERROR` (strongly recommended)
+- At phase boundaries (recommended)
+- Before any risky operation (recommended)
+
+**The WAITING flow** (follow this exact sequence):
+
+1. Finish your current work to a stable point
+2. Create a checkpoint
+3. Emit the `WAITING` event with the `checkpoint_id`
+4. Stop doing meaningful work
+5. Exit or let the session end
+
+Lattice owns what happens next. It will restore your checkpoint and resume you
+when the external input is available.
+
+**For blocking ACTION_REQUESTs:**
+
+1. Emit `ACTION_REQUEST` with `"blocking": true`
+2. Create a checkpoint
+3. Emit `WAITING` with `expected_inputs` describing the result you need
+4. Stop and exit
+
+Lattice fulfills the action, then resumes you with the result.
+
+## The Outbox
+
+You MUST append every event as raw JSON (one line, no prefix) to:
+
+```
+/workspace/.lattice/outbox.jsonl
+```
+
+This file is your durable event log. If the stdout stream breaks, Lattice
+recovers from the outbox. Write to it for every event, without exception.
+
+Create the directory and file if they do not exist:
+
+```bash
+mkdir -p /workspace/.lattice
+touch /workspace/.lattice/outbox.jsonl
+```
+
+## Resume
+
+When Lattice resumes you from a checkpoint, it writes a file at:
+
+```
+/workspace/.lattice/resume.json
+```
+
+On resume, you MUST:
+
+1. Read `/workspace/.lattice/resume.json`
+2. Emit an `INFO` event acknowledging the resume
+3. Continue your workflow using the provided inputs
+
+**Resume payload format:**
+
+```json
+{
+  "work_item_id": "issue-17",
+  "checkpoint_id": "chk_abc123",
+  "inputs": {
+    "approved": true,
+    "comments": ["Looks good, minor nit on line 42"]
+  },
+  "context": {}
+}
+```
+
+**Idempotency:** Resume MUST be safe to replay. If you have already processed
+a resume for the same checkpoint and payload, treat it as a no-op. Use a marker
+file like `/workspace/.lattice/resumed` to detect duplicate resumes.
+
+## Hard Rules
+
+You MUST NOT:
+
+- **Push to git.** Never run `git push`. Lattice handles all remote git operations.
+- **Call GitHub APIs.** Never use `gh`, `curl` to api.github.com, or any GitHub client. Use `ACTION_REQUEST` instead.
+- **Apply environment changes.** Never install runtimes, system packages, or change configurations that ENVIRONMENT_PROPOSAL covers. Propose them and let Lattice decide.
+- **Edit git remotes.** Never run `git remote add/set-url/remove`.
+- **Expose secrets.** Never log or print tokens, keys, or credentials.
+- **Mutate or delete previous events.** Events are append-only.
+- **Continue working after emitting WAITING.** Once you emit WAITING, stop.

--- a/test/lattice/protocol/event_handler_v1_test.exs
+++ b/test/lattice/protocol/event_handler_v1_test.exs
@@ -1,0 +1,221 @@
+defmodule Lattice.Protocol.EventHandlerV1Test do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Protocol.Event
+  alias Lattice.Protocol.EventHandler
+  alias Lattice.Protocol.Events.ActionRequest
+  alias Lattice.Protocol.Events.Completed
+  alias Lattice.Protocol.Events.EnvironmentProposal
+  alias Lattice.Protocol.Events.Error, as: ErrorEvent
+  alias Lattice.Protocol.Events.Info
+  alias Lattice.Protocol.Events.PhaseFinished
+  alias Lattice.Protocol.Events.PhaseStarted
+  alias Lattice.Protocol.Events.Waiting
+  alias Lattice.Runs.Run
+
+  setup do
+    {:ok, run} = Run.new(sprite_name: "sprite-42", mode: :exec_ws)
+    {:ok, running} = Run.start(run)
+    {:ok, run: running}
+  end
+
+  defp v1_event(type, data, opts \\ []) do
+    Event.new(type, data,
+      sprite_id: "sprite-42",
+      work_item_id: Keyword.get(opts, :work_item_id, "issue-17")
+    )
+  end
+
+  describe "WAITING" do
+    test "transitions run to :waiting with checkpoint info", %{run: run} do
+      waiting = %Waiting{
+        reason: "PR_REVIEW",
+        checkpoint_id: "chk_abc123",
+        expected_inputs: %{"approved" => "boolean"}
+      }
+
+      event = v1_event("WAITING", waiting)
+      assert {:ok, updated} = EventHandler.handle_event(event, run)
+      assert updated.status == :waiting
+      assert updated.checkpoint_id == "chk_abc123"
+      assert updated.expected_inputs == %{"approved" => "boolean"}
+      assert updated.blocked_reason == "PR_REVIEW"
+    end
+
+    test "emits telemetry", %{run: run} do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:lattice, :run, :waiting]])
+
+      waiting = %Waiting{
+        reason: "PR_REVIEW",
+        checkpoint_id: "chk_abc123",
+        expected_inputs: %{}
+      }
+
+      event = v1_event("WAITING", waiting)
+      {:ok, _} = EventHandler.handle_event(event, run)
+
+      assert_received {[:lattice, :run, :waiting], ^ref, %{count: 1},
+                       %{run_id: _, checkpoint_id: "chk_abc123"}}
+    end
+  end
+
+  describe "COMPLETED" do
+    test "success transitions to :succeeded", %{run: run} do
+      completed = %Completed{status: "success", summary: "All done"}
+      event = v1_event("COMPLETED", completed)
+
+      assert {:ok, updated} = EventHandler.handle_event(event, run)
+      assert updated.status == :succeeded
+    end
+
+    test "failure transitions to :failed", %{run: run} do
+      completed = %Completed{status: "failure", summary: "Tests broken"}
+      event = v1_event("COMPLETED", completed)
+
+      assert {:ok, updated} = EventHandler.handle_event(event, run)
+      assert updated.status == :failed
+      assert updated.error == "Tests broken"
+    end
+  end
+
+  describe "ERROR" do
+    test "transitions to :failed with error message", %{run: run} do
+      error = %ErrorEvent{message: "Build exploded", details: %{"exit_code" => 1}}
+      event = v1_event("ERROR", error)
+
+      assert {:ok, updated} = EventHandler.handle_event(event, run)
+      assert updated.status == :failed
+      assert updated.error == "Build exploded"
+    end
+  end
+
+  describe "ACTION_REQUEST" do
+    test "non-blocking does not change run state", %{run: run} do
+      action = %ActionRequest{
+        action: "POST_COMMENT",
+        parameters: %{"body" => "Done!"},
+        blocking: false
+      }
+
+      event = v1_event("ACTION_REQUEST", action)
+      assert {:ok, updated} = EventHandler.handle_event(event, run)
+      assert updated.status == :running
+    end
+
+    test "emits telemetry with action info", %{run: run} do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:lattice, :run, :action_requested]])
+
+      action = %ActionRequest{action: "OPEN_PR", parameters: %{}, blocking: true}
+      event = v1_event("ACTION_REQUEST", action)
+      {:ok, _} = EventHandler.handle_event(event, run)
+
+      assert_received {[:lattice, :run, :action_requested], ^ref, %{count: 1},
+                       %{action: "OPEN_PR", blocking: true}}
+    end
+  end
+
+  describe "PHASE_STARTED / PHASE_FINISHED" do
+    test "PHASE_STARTED does not change run state", %{run: run} do
+      phase = %PhaseStarted{phase: "implement"}
+      event = v1_event("PHASE_STARTED", phase)
+
+      assert {:ok, updated} = EventHandler.handle_event(event, run)
+      assert updated.status == :running
+    end
+
+    test "PHASE_FINISHED does not change run state", %{run: run} do
+      phase = %PhaseFinished{phase: "test", success: true}
+      event = v1_event("PHASE_FINISHED", phase)
+
+      assert {:ok, updated} = EventHandler.handle_event(event, run)
+      assert updated.status == :running
+    end
+
+    test "PHASE_STARTED emits telemetry", %{run: run} do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:lattice, :run, :phase_started]])
+
+      phase = %PhaseStarted{phase: "test"}
+      event = v1_event("PHASE_STARTED", phase)
+      {:ok, _} = EventHandler.handle_event(event, run)
+
+      assert_received {[:lattice, :run, :phase_started], ^ref, %{count: 1}, %{phase: "test"}}
+    end
+  end
+
+  describe "INFO" do
+    test "does not change run state", %{run: run} do
+      info = %Info{message: "Hello", kind: "note", metadata: %{}}
+      event = v1_event("INFO", info)
+
+      assert {:ok, updated} = EventHandler.handle_event(event, run)
+      assert updated.status == :running
+    end
+  end
+
+  describe "ENVIRONMENT_PROPOSAL" do
+    test "does not change run state", %{run: run} do
+      proposal = %EnvironmentProposal{
+        observed_failure: %{"phase" => "bootstrap", "exit_code" => 127},
+        suggested_adjustment: %{"type" => "runtime_install"},
+        confidence: 0.85,
+        evidence: ["package.json present"],
+        scope: "repo_specific"
+      }
+
+      event = v1_event("ENVIRONMENT_PROPOSAL", proposal)
+      assert {:ok, updated} = EventHandler.handle_event(event, run)
+      assert updated.status == :running
+    end
+
+    test "emits telemetry", %{run: run} do
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [[:lattice, :run, :environment_proposal]])
+
+      proposal = %EnvironmentProposal{
+        observed_failure: %{},
+        suggested_adjustment: %{"type" => "add_system_package"},
+        confidence: 0.7,
+        evidence: [],
+        scope: "global_candidate"
+      }
+
+      event = v1_event("ENVIRONMENT_PROPOSAL", proposal)
+      {:ok, _} = EventHandler.handle_event(event, run)
+
+      assert_received {[:lattice, :run, :environment_proposal], ^ref, %{count: 1},
+                       %{scope: "global_candidate", confidence: 0.7}}
+    end
+  end
+
+  describe "Run :waiting lifecycle" do
+    test "waiting run can be resumed", %{run: run} do
+      waiting = %Waiting{reason: "test", checkpoint_id: "chk_1", expected_inputs: %{}}
+      event = v1_event("WAITING", waiting)
+      {:ok, waiting_run} = EventHandler.handle_event(event, run)
+
+      assert waiting_run.status == :waiting
+      assert {:ok, resumed} = Run.resume(waiting_run, %{"answer" => "yes"})
+      assert resumed.status == :running
+    end
+
+    test "waiting run can be failed", %{run: run} do
+      waiting = %Waiting{reason: "test", checkpoint_id: "chk_1", expected_inputs: %{}}
+      event = v1_event("WAITING", waiting)
+      {:ok, waiting_run} = EventHandler.handle_event(event, run)
+
+      assert {:ok, failed} = Run.fail(waiting_run, %{error: "timed out"})
+      assert failed.status == :failed
+    end
+
+    test "waiting run can be canceled", %{run: run} do
+      waiting = %Waiting{reason: "test", checkpoint_id: "chk_1", expected_inputs: %{}}
+      event = v1_event("WAITING", waiting)
+      {:ok, waiting_run} = EventHandler.handle_event(event, run)
+
+      assert {:ok, canceled} = Run.cancel(waiting_run)
+      assert canceled.status == :canceled
+    end
+  end
+end

--- a/test/lattice/protocol/parser_v1_test.exs
+++ b/test/lattice/protocol/parser_v1_test.exs
@@ -1,0 +1,241 @@
+defmodule Lattice.Protocol.ParserV1Test do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.Protocol.Event
+  alias Lattice.Protocol.Parser
+
+  alias Lattice.Protocol.Events.{
+    ActionRequest,
+    Artifact,
+    Completed,
+    EnvironmentProposal,
+    Error,
+    Info,
+    PhaseFinished,
+    PhaseStarted,
+    Waiting
+  }
+
+  defp v1_line(event_type, payload) do
+    json =
+      Jason.encode!(%{
+        "protocol_version" => "v1",
+        "event_type" => event_type,
+        "sprite_id" => "sprite-42",
+        "work_item_id" => "issue-17",
+        "timestamp" => "2026-01-15T10:30:00Z",
+        "payload" => payload
+      })
+
+    "LATTICE_EVENT #{json}"
+  end
+
+  describe "v1 INFO" do
+    test "parses with kind and metadata" do
+      line =
+        v1_line("INFO", %{
+          "message" => "Running tests (75%)",
+          "kind" => "progress",
+          "metadata" => %{"percent" => 75, "phase" => "test"}
+        })
+
+      assert {:event, %Event{event_type: "INFO", data: %Info{} = data}} = Parser.parse_line(line)
+      assert data.message == "Running tests (75%)"
+      assert data.kind == "progress"
+      assert data.metadata == %{"percent" => 75, "phase" => "test"}
+    end
+
+    test "parses minimal INFO (message only)" do
+      line = v1_line("INFO", %{"message" => "Hello"})
+
+      assert {:event, %Event{data: %Info{} = data}} = Parser.parse_line(line)
+      assert data.message == "Hello"
+      assert data.kind == nil
+      assert data.metadata == %{}
+    end
+  end
+
+  describe "v1 PHASE_STARTED / PHASE_FINISHED" do
+    test "parses PHASE_STARTED" do
+      line = v1_line("PHASE_STARTED", %{"phase" => "implement"})
+
+      assert {:event, %Event{event_type: "PHASE_STARTED", data: %PhaseStarted{} = data}} =
+               Parser.parse_line(line)
+
+      assert data.phase == "implement"
+    end
+
+    test "parses PHASE_FINISHED with success" do
+      line = v1_line("PHASE_FINISHED", %{"phase" => "test", "success" => true})
+
+      assert {:event, %Event{event_type: "PHASE_FINISHED", data: %PhaseFinished{} = data}} =
+               Parser.parse_line(line)
+
+      assert data.phase == "test"
+      assert data.success == true
+    end
+
+    test "parses PHASE_FINISHED with failure" do
+      line = v1_line("PHASE_FINISHED", %{"phase" => "test", "success" => false})
+
+      assert {:event, %Event{data: %PhaseFinished{} = data}} = Parser.parse_line(line)
+      assert data.success == false
+    end
+  end
+
+  describe "v1 ACTION_REQUEST" do
+    test "parses non-blocking action" do
+      line =
+        v1_line("ACTION_REQUEST", %{
+          "action" => "POST_COMMENT",
+          "parameters" => %{"body" => "Done!"},
+          "blocking" => false
+        })
+
+      assert {:event, %Event{data: %ActionRequest{} = data}} = Parser.parse_line(line)
+      assert data.action == "POST_COMMENT"
+      assert data.parameters == %{"body" => "Done!"}
+      assert data.blocking == false
+    end
+
+    test "parses blocking action" do
+      line =
+        v1_line("ACTION_REQUEST", %{
+          "action" => "OPEN_PR",
+          "parameters" => %{"title" => "Fix bug", "base" => "main"},
+          "blocking" => true
+        })
+
+      assert {:event, %Event{data: %ActionRequest{} = data}} = Parser.parse_line(line)
+      assert data.action == "OPEN_PR"
+      assert data.blocking == true
+    end
+  end
+
+  describe "v1 ARTIFACT" do
+    test "parses artifact declaration" do
+      line =
+        v1_line("ARTIFACT", %{
+          "kind" => "branch",
+          "ref" => "sprite/fix-cache",
+          "url" => nil,
+          "metadata" => %{}
+        })
+
+      assert {:event, %Event{event_type: "ARTIFACT", data: %Artifact{} = data}} =
+               Parser.parse_line(line)
+
+      assert data.kind == "branch"
+    end
+  end
+
+  describe "v1 WAITING" do
+    test "parses with checkpoint and expected inputs" do
+      line =
+        v1_line("WAITING", %{
+          "reason" => "PR_REVIEW",
+          "checkpoint_id" => "chk_abc123",
+          "expected_inputs" => %{"approved" => "boolean"}
+        })
+
+      assert {:event, %Event{data: %Waiting{} = data}} = Parser.parse_line(line)
+      assert data.reason == "PR_REVIEW"
+      assert data.checkpoint_id == "chk_abc123"
+      assert data.expected_inputs == %{"approved" => "boolean"}
+    end
+  end
+
+  describe "v1 COMPLETED" do
+    test "parses success" do
+      line = v1_line("COMPLETED", %{"status" => "success", "summary" => "All done"})
+
+      assert {:event, %Event{data: %Completed{} = data}} = Parser.parse_line(line)
+      assert data.status == "success"
+      assert data.summary == "All done"
+    end
+
+    test "parses failure" do
+      line = v1_line("COMPLETED", %{"status" => "failure", "summary" => "Tests failed"})
+
+      assert {:event, %Event{data: %Completed{} = data}} = Parser.parse_line(line)
+      assert data.status == "failure"
+    end
+  end
+
+  describe "v1 ERROR" do
+    test "parses error with details" do
+      line =
+        v1_line("ERROR", %{
+          "message" => "Build failed",
+          "details" => %{"exit_code" => 1, "phase" => "test"}
+        })
+
+      assert {:event, %Event{data: %Error{} = data}} = Parser.parse_line(line)
+      assert data.message == "Build failed"
+      assert data.details == %{"exit_code" => 1, "phase" => "test"}
+    end
+  end
+
+  describe "v1 ENVIRONMENT_PROPOSAL" do
+    test "parses full proposal" do
+      line =
+        v1_line("ENVIRONMENT_PROPOSAL", %{
+          "observed_failure" => %{
+            "phase" => "bootstrap",
+            "exit_code" => 127,
+            "stderr_hint" => "bash: node: command not found"
+          },
+          "suggested_adjustment" => %{
+            "type" => "runtime_install",
+            "details" => %{"runtime" => "node", "version" => "20"}
+          },
+          "confidence" => 0.85,
+          "evidence" => ["package.json present"],
+          "scope" => "repo_specific"
+        })
+
+      assert {:event, %Event{data: %EnvironmentProposal{} = data}} = Parser.parse_line(line)
+      assert data.observed_failure["phase"] == "bootstrap"
+      assert data.suggested_adjustment["type"] == "runtime_install"
+      assert data.confidence == 0.85
+      assert data.evidence == ["package.json present"]
+      assert data.scope == "repo_specific"
+    end
+  end
+
+  describe "v1 envelope fields" do
+    test "extracts sprite_id and work_item_id" do
+      line = v1_line("INFO", %{"message" => "Hello"})
+
+      assert {:event, %Event{} = event} = Parser.parse_line(line)
+      assert event.sprite_id == "sprite-42"
+      assert event.work_item_id == "issue-17"
+      assert event.protocol_version == "v1"
+    end
+
+    test "run_id aliases work_item_id for backward compat" do
+      line = v1_line("INFO", %{"message" => "Hello"})
+
+      assert {:event, %Event{} = event} = Parser.parse_line(line)
+      assert event.run_id == event.work_item_id
+    end
+  end
+
+  describe "backward compatibility" do
+    test "legacy artifact events still parse" do
+      json = Jason.encode!(%{"type" => "artifact", "kind" => "pr", "url" => "https://example.com"})
+      line = "LATTICE_EVENT #{json}"
+
+      assert {:event, %Event{event_type: "artifact", data: %Artifact{}}} = Parser.parse_line(line)
+    end
+
+    test "legacy question events still parse" do
+      json = Jason.encode!(%{"type" => "question", "prompt" => "Which?"})
+      line = "LATTICE_EVENT #{json}"
+
+      assert {:event, %Event{event_type: "question"}} = Parser.parse_line(line)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Full implementation of the protocol v1 spec (`spec/protocol-v1.md`)
- 9 event types: `INFO`, `PHASE_STARTED`, `PHASE_FINISHED`, `ACTION_REQUEST`, `ARTIFACT`, `WAITING`, `COMPLETED`, `ERROR`, `ENVIRONMENT_PROPOSAL`
- Updated `Event` envelope with `protocol_version`, `sprite_id`, `work_item_id`
- `Run` state machine gains `:waiting` state with `checkpoint_id` and `expected_inputs`
- `Resume` module: checkpoint restore → write `resume.json` → exec continuation
- Protocol skill (`SKILL.md`) synced to sprites as the client SDK
- Backward compatible with all legacy event types

## Changes
| Area | Files |
|---|---|
| Event envelope | `protocol/event.ex` |
| New event structs | `protocol/events/{info,phase_started,phase_finished,action_request,waiting,completed,error,environment_proposal}.ex` |
| Parser | `protocol/parser.ex` — handles v1 + legacy formats |
| Event handler | `protocol/event_handler.ex` — routes all v1 events |
| Run state machine | `runs/run.ex` — adds `:waiting` state |
| Resume flow | `protocol/resume.ex` — checkpoint → resume.json → exec |
| Sprites capability | `capabilities/sprites.ex` + `live.ex` — `restore_checkpoint/2` |
| Protocol skill | `priv/sprite_skills/protocol/SKILL.md` |

## Test plan
- [x] 208 protocol/run tests pass (33 new v1 tests)
- [x] All legacy event types still parse and route correctly
- [x] Strict compilation (`--warnings-as-errors`) clean
- [ ] Integration test: sync skill to sprite, verify event emission (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)