### PR TITLE
Implement context gathering v1 and fix Fly autostop

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -18,7 +18,7 @@ kill_signal = 'SIGTERM'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
   [http_service.concurrency]

--- a/lib/lattice/capabilities/github.ex
+++ b/lib/lattice/capabilities/github.ex
@@ -152,6 +152,9 @@ defmodule Lattice.Capabilities.GitHub do
   @doc "List comments on an issue or PR."
   @callback list_comments(issue_number()) :: {:ok, [comment()]} | {:error, term()}
 
+  @doc "List files changed in a pull request."
+  @callback list_pr_files(pr_number()) :: {:ok, [map()]} | {:error, term()}
+
   @doc "Create a new GitHub issue with the given attributes."
   def create_issue(title, attrs), do: impl().create_issue(title, attrs)
 
@@ -258,6 +261,9 @@ defmodule Lattice.Capabilities.GitHub do
 
   @doc "List comments on an issue or PR."
   def list_comments(number), do: impl().list_comments(number)
+
+  @doc "List files changed in a pull request."
+  def list_pr_files(pr_number), do: impl().list_pr_files(pr_number)
 
   defp impl, do: Application.get_env(:lattice, :capabilities)[:github]
 end

--- a/lib/lattice/capabilities/github/http.ex
+++ b/lib/lattice/capabilities/github/http.ex
@@ -633,6 +633,32 @@ defmodule Lattice.Capabilities.GitHub.Http do
     end
   end
 
+  # ── PR Files ──────────────────────────────────────────────────────
+
+  @impl true
+  def list_pr_files(pr_number) do
+    timed(:list_pr_files, fn ->
+      case api_get("/repos/#{repo()}/pulls/#{pr_number}/files", per_page: 100) do
+        {:ok, files} when is_list(files) ->
+          {:ok, Enum.map(files, &parse_pr_file/1)}
+
+        error ->
+          error
+      end
+    end)
+  end
+
+  defp parse_pr_file(data) when is_map(data) do
+    %{
+      filename: data["filename"],
+      status: data["status"],
+      additions: data["additions"] || 0,
+      deletions: data["deletions"] || 0,
+      changes: data["changes"] || 0,
+      patch: data["patch"]
+    }
+  end
+
   # ── Comments (list) ─────────────────────────────────────────────
 
   @impl true

--- a/lib/lattice/capabilities/github/live.ex
+++ b/lib/lattice/capabilities/github/live.ex
@@ -357,6 +357,36 @@ defmodule Lattice.Capabilities.GitHub.Live do
     end)
   end
 
+  # ── PR Files ────────────────────────────────────────────────────────────
+
+  @impl true
+  def list_pr_files(pr_number) do
+    args = ["api", "repos/{owner}/{repo}/pulls/#{pr_number}/files"]
+
+    timed_cmd(:list_pr_files, args, fn json ->
+      case Jason.decode(json) do
+        {:ok, files} when is_list(files) ->
+          {:ok,
+           Enum.map(files, fn f ->
+             %{
+               filename: f["filename"],
+               status: f["status"],
+               additions: f["additions"] || 0,
+               deletions: f["deletions"] || 0,
+               changes: f["changes"] || 0,
+               patch: f["patch"]
+             }
+           end)}
+
+        {:ok, _} ->
+          {:ok, []}
+
+        {:error, _} ->
+          {:error, {:invalid_json, json}}
+      end
+    end)
+  end
+
   # ── Reactions & Comments (list) ────────────────────────────────────────
 
   @impl true

--- a/lib/lattice/context/bundle.ex
+++ b/lib/lattice/context/bundle.ex
@@ -1,0 +1,134 @@
+defmodule Lattice.Context.Bundle do
+  @moduledoc """
+  Output struct from context gathering.
+
+  Contains the manifest metadata, a list of file entries (path + content + kind),
+  linked item references, expansion budget tracking, and any warnings.
+  """
+
+  @type file_entry :: %{path: String.t(), content: String.t(), kind: String.t()}
+
+  @type linked_item :: %{type: String.t(), number: pos_integer(), title: String.t()}
+
+  @type t :: %__MODULE__{
+          trigger_type: :issue | :pull_request,
+          trigger_number: pos_integer(),
+          repo: String.t(),
+          title: String.t(),
+          gathered_at: DateTime.t(),
+          files: [file_entry()],
+          linked_items: [linked_item()],
+          expansion_budget: %{used: non_neg_integer(), max: non_neg_integer()},
+          warnings: [String.t()]
+        }
+
+  @enforce_keys [:trigger_type, :trigger_number, :repo, :title, :gathered_at]
+  defstruct [
+    :trigger_type,
+    :trigger_number,
+    :repo,
+    :title,
+    :gathered_at,
+    files: [],
+    linked_items: [],
+    expansion_budget: %{used: 0, max: 5},
+    warnings: []
+  ]
+
+  @doc """
+  Create a new Bundle from a `Trigger`.
+  """
+  @spec new(Lattice.Context.Trigger.t(), keyword()) :: t()
+  def new(%Lattice.Context.Trigger{} = trigger, opts \\ []) do
+    max_expansions = Keyword.get(opts, :max_expansions, 5)
+
+    %__MODULE__{
+      trigger_type: trigger.type,
+      trigger_number: trigger.number,
+      repo: trigger.repo,
+      title: trigger.title,
+      gathered_at: DateTime.utc_now(),
+      expansion_budget: %{used: 0, max: max_expansions}
+    }
+  end
+
+  @doc """
+  Add a file entry to the bundle.
+  """
+  @spec add_file(t(), String.t(), String.t(), String.t()) :: t()
+  def add_file(%__MODULE__{} = bundle, path, content, kind) do
+    entry = %{path: path, content: content, kind: kind}
+    %{bundle | files: bundle.files ++ [entry]}
+  end
+
+  @doc """
+  Add a linked item reference to the bundle and increment the expansion budget.
+  """
+  @spec add_linked_item(t(), String.t(), pos_integer(), String.t()) :: t()
+  def add_linked_item(%__MODULE__{} = bundle, type, number, title) do
+    item = %{type: type, number: number, title: title}
+    budget = %{bundle.expansion_budget | used: bundle.expansion_budget.used + 1}
+    %{bundle | linked_items: bundle.linked_items ++ [item], expansion_budget: budget}
+  end
+
+  @doc """
+  Add a warning message to the bundle.
+  """
+  @spec add_warning(t(), String.t()) :: t()
+  def add_warning(%__MODULE__{} = bundle, message) do
+    %{bundle | warnings: bundle.warnings ++ [message]}
+  end
+
+  @doc """
+  Check if the expansion budget has remaining capacity.
+  """
+  @spec budget_remaining?(t()) :: boolean()
+  def budget_remaining?(%__MODULE__{expansion_budget: %{used: used, max: max}}) do
+    used < max
+  end
+
+  @doc """
+  Total byte size of all file contents in the bundle.
+  """
+  @spec total_size(t()) :: non_neg_integer()
+  def total_size(%__MODULE__{files: files}) do
+    Enum.reduce(files, 0, fn %{content: content}, acc ->
+      acc + byte_size(content)
+    end)
+  end
+
+  @doc """
+  Convert the bundle to a JSON-encodable manifest map.
+  """
+  @spec to_manifest(t()) :: map()
+  def to_manifest(%__MODULE__{} = bundle) do
+    %{
+      version: "v1",
+      trigger_type: to_string(bundle.trigger_type),
+      trigger_number: bundle.trigger_number,
+      repo: bundle.repo,
+      title: bundle.title,
+      gathered_at: DateTime.to_iso8601(bundle.gathered_at),
+      files:
+        Enum.map(bundle.files, fn %{path: path, kind: kind} ->
+          %{path: path, kind: kind}
+        end),
+      linked_items:
+        Enum.map(bundle.linked_items, fn item ->
+          %{type: item.type, number: item.number, title: item.title}
+        end),
+      expansion_budget: bundle.expansion_budget,
+      warnings: bundle.warnings
+    }
+  end
+
+  @doc """
+  Convert the bundle to a pretty-printed JSON manifest string.
+  """
+  @spec to_manifest_json(t()) :: String.t()
+  def to_manifest_json(%__MODULE__{} = bundle) do
+    bundle
+    |> to_manifest()
+    |> Jason.encode!(pretty: true)
+  end
+end

--- a/lib/lattice/context/delivery.ex
+++ b/lib/lattice/context/delivery.ex
@@ -1,0 +1,100 @@
+defmodule Lattice.Context.Delivery do
+  @moduledoc """
+  Writes a context Bundle to a sprite's filesystem.
+
+  Follows the SkillSync pattern: clear → create → write → verify.
+  Uses `FileWriter` for chunked base64 file transfer.
+  """
+
+  require Logger
+
+  alias Lattice.Capabilities.Sprites
+  alias Lattice.Context.Bundle
+  alias Lattice.Sprites.FileWriter
+
+  @context_dir "/workspace/.lattice/context"
+
+  @doc """
+  Deliver a Bundle to the named sprite.
+
+  Clears the context directory, writes `manifest.json` and all file entries,
+  then verifies the directory listing.
+  """
+  @spec deliver(String.t(), Bundle.t()) :: :ok | {:error, term()}
+  def deliver(sprite_name, %Bundle{} = bundle) do
+    with :ok <- clear_context_dir(sprite_name),
+         :ok <- create_context_dirs(sprite_name, bundle),
+         :ok <- write_manifest(sprite_name, bundle),
+         :ok <- write_files(sprite_name, bundle),
+         :ok <- verify_delivery(sprite_name) do
+      Logger.info("Context: delivered #{length(bundle.files)} file(s) to #{sprite_name}")
+
+      :ok
+    else
+      {:error, reason} = err ->
+        Logger.warning("Context: delivery to #{sprite_name} failed: #{inspect(reason)}")
+        err
+    end
+  end
+
+  # ── Private ──────────────────────────────────────────────────────
+
+  defp clear_context_dir(sprite_name) do
+    case Sprites.exec(sprite_name, "rm -rf #{@context_dir} && mkdir -p #{@context_dir}") do
+      {:ok, _} -> :ok
+      {:error, _} = err -> err
+    end
+  end
+
+  defp create_context_dirs(sprite_name, bundle) do
+    dirs =
+      bundle.files
+      |> Enum.map(fn %{path: path} -> Path.dirname(path) end)
+      |> Enum.reject(&(&1 == "."))
+      |> Enum.uniq()
+
+    if dirs == [] do
+      :ok
+    else
+      mkdir_cmd =
+        dirs
+        |> Enum.map(fn dir -> "#{@context_dir}/#{dir}" end)
+        |> Enum.join(" ")
+
+      case Sprites.exec(sprite_name, "mkdir -p #{mkdir_cmd}") do
+        {:ok, _} -> :ok
+        {:error, _} = err -> err
+      end
+    end
+  end
+
+  defp write_manifest(sprite_name, bundle) do
+    manifest_json = Bundle.to_manifest_json(bundle)
+    FileWriter.write_file(sprite_name, manifest_json, "#{@context_dir}/manifest.json")
+  end
+
+  defp write_files(sprite_name, bundle) do
+    Enum.reduce_while(bundle.files, :ok, fn %{path: path, content: content}, :ok ->
+      remote_path = "#{@context_dir}/#{path}"
+
+      case FileWriter.write_file(sprite_name, content, remote_path) do
+        :ok -> {:cont, :ok}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp verify_delivery(sprite_name) do
+    case Sprites.exec(sprite_name, "ls -la #{@context_dir}/") do
+      {:ok, %{output: output}} ->
+        Logger.info("Context: #{sprite_name} — verified: #{String.trim(output)}")
+        :ok
+
+      {:ok, _} ->
+        :ok
+
+      {:error, _} = err ->
+        err
+    end
+  end
+end

--- a/lib/lattice/context/gatherer.ex
+++ b/lib/lattice/context/gatherer.ex
@@ -1,0 +1,201 @@
+defmodule Lattice.Context.Gatherer do
+  @moduledoc """
+  Assembles a context Bundle by fetching GitHub data and rendering markdown.
+
+  Stateless module — calls the GitHub capability, uses Renderer for markdown,
+  and produces a `%Bundle{}`.
+  """
+
+  require Logger
+
+  alias Lattice.Capabilities.GitHub
+  alias Lattice.Context.Bundle
+  alias Lattice.Context.Renderer
+  alias Lattice.Context.Trigger
+
+  @default_max_expansions 5
+
+  @doc """
+  Gather context for the given trigger.
+
+  ## Options
+
+    * `:max_expansions` - maximum `#NNN` references to expand (default: 5)
+  """
+  @spec gather(Trigger.t(), keyword()) :: {:ok, Bundle.t()} | {:error, term()}
+  def gather(%Trigger{} = trigger, opts \\ []) do
+    max_expansions = Keyword.get(opts, :max_expansions, @default_max_expansions)
+    bundle = Bundle.new(trigger, max_expansions: max_expansions)
+
+    case trigger.type do
+      :issue -> gather_issue(trigger, bundle)
+      :pull_request -> gather_pull_request(trigger, bundle)
+    end
+  end
+
+  # ── Issue Gathering ──────────────────────────────────────────────
+
+  defp gather_issue(trigger, bundle) do
+    with {:ok, issue} <- GitHub.get_issue(trigger.number),
+         {:ok, comments} <- fetch_comments(trigger) do
+      bundle =
+        bundle
+        |> add_trigger_file(Renderer.render_issue(issue, comments))
+        |> add_thread_file(comments)
+        |> expand_references(trigger.body, comments)
+
+      {:ok, bundle}
+    end
+  end
+
+  # ── Pull Request Gathering ──────────────────────────────────────
+
+  defp gather_pull_request(trigger, bundle) do
+    with {:ok, pr} <- GitHub.get_pull_request(trigger.number),
+         {:ok, comments} <- fetch_comments(trigger),
+         {:ok, pr_files} <- fetch_pr_files(trigger.number),
+         {:ok, reviews} <- fetch_reviews(trigger.number),
+         {:ok, review_comments} <- fetch_review_comments(trigger.number) do
+      trigger_md =
+        Renderer.render_pull_request(pr,
+          diff_stats: pr_files,
+          reviews: reviews,
+          review_comments: review_comments
+        )
+
+      bundle =
+        bundle
+        |> add_trigger_file(trigger_md)
+        |> add_thread_file(comments)
+        |> add_diff_stats_file(pr_files)
+        |> add_reviews_file(reviews, review_comments)
+        |> expand_references(trigger.body, comments)
+
+      {:ok, bundle}
+    end
+  end
+
+  # ── File Addition ───────────────────────────────────────────────
+
+  defp add_trigger_file(bundle, content) do
+    Bundle.add_file(bundle, "trigger.md", content, "trigger")
+  end
+
+  defp add_thread_file(bundle, comments) do
+    content = Renderer.render_thread(comments)
+    Bundle.add_file(bundle, "thread.md", content, "thread")
+  end
+
+  defp add_diff_stats_file(bundle, []), do: bundle
+
+  defp add_diff_stats_file(bundle, files) do
+    content = Renderer.render_diff_stats(files)
+    Bundle.add_file(bundle, "diff_stats.md", content, "diff_stats")
+  end
+
+  defp add_reviews_file(bundle, [], []), do: bundle
+
+  defp add_reviews_file(bundle, reviews, review_comments) do
+    content = Renderer.render_reviews(reviews, review_comments)
+    Bundle.add_file(bundle, "reviews.md", content, "reviews")
+  end
+
+  # ── Reference Expansion ─────────────────────────────────────────
+
+  defp expand_references(bundle, body, comments) do
+    text = collect_text(body, comments)
+    refs = extract_issue_refs(text)
+
+    Enum.reduce(refs, bundle, fn ref_number, acc ->
+      if Bundle.budget_remaining?(acc) do
+        expand_single_ref(acc, ref_number)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp collect_text(body, comments) do
+    comment_text =
+      comments
+      |> Enum.map(fn c -> c[:body] || c["body"] || "" end)
+      |> Enum.join("\n")
+
+    (body || "") <> "\n" <> comment_text
+  end
+
+  @doc false
+  @spec extract_issue_refs(String.t()) :: [pos_integer()]
+  def extract_issue_refs(text) do
+    # Remove code blocks first to avoid matching refs inside code
+    cleaned = Regex.replace(~r/```[\s\S]*?```/, text, "")
+    cleaned = Regex.replace(~r/`[^`]+`/, cleaned, "")
+
+    ~r/(?<!\w)#(\d+)/
+    |> Regex.scan(cleaned)
+    |> Enum.map(fn [_, num] -> String.to_integer(num) end)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp expand_single_ref(bundle, ref_number) do
+    case GitHub.get_issue(ref_number) do
+      {:ok, issue} ->
+        title = issue[:title] || issue["title"] || ""
+        content = Renderer.render_issue(issue)
+        path = "linked/issue_#{ref_number}.md"
+        type = if issue[:pull_request], do: "linked_pr", else: "linked_issue"
+
+        bundle
+        |> Bundle.add_file(path, content, type)
+        |> Bundle.add_linked_item("issue", ref_number, title)
+
+      {:error, reason} ->
+        Logger.warning("Context: failed to expand ##{ref_number}: #{inspect(reason)}")
+        Bundle.add_warning(bundle, "Failed to expand ##{ref_number}: #{inspect(reason)}")
+    end
+  end
+
+  # ── Data Fetching ───────────────────────────────────────────────
+
+  defp fetch_comments(%Trigger{thread_context: ctx}) when is_list(ctx) do
+    {:ok, ctx}
+  end
+
+  defp fetch_comments(%Trigger{number: number}) do
+    GitHub.list_comments(number)
+  end
+
+  defp fetch_pr_files(pr_number) do
+    case GitHub.list_pr_files(pr_number) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, reason} ->
+        Logger.warning("Context: failed to fetch PR files: #{inspect(reason)}")
+        {:ok, []}
+    end
+  end
+
+  defp fetch_reviews(pr_number) do
+    case GitHub.list_reviews(pr_number) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, reason} ->
+        Logger.warning("Context: failed to fetch reviews: #{inspect(reason)}")
+        {:ok, []}
+    end
+  end
+
+  defp fetch_review_comments(pr_number) do
+    case GitHub.list_review_comments(pr_number) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, reason} ->
+        Logger.warning("Context: failed to fetch review comments: #{inspect(reason)}")
+        {:ok, []}
+    end
+  end
+end

--- a/lib/lattice/context/renderer.ex
+++ b/lib/lattice/context/renderer.ex
@@ -1,0 +1,264 @@
+defmodule Lattice.Context.Renderer do
+  @moduledoc """
+  Pure functions that render GitHub data into markdown files.
+
+  No side effects, no GitHub API calls. Takes structured data in,
+  returns markdown strings out.
+  """
+
+  alias Lattice.Capabilities.GitHub.Review
+  alias Lattice.Capabilities.GitHub.ReviewComment
+
+  # ── Issue Rendering ──────────────────────────────────────────────
+
+  @doc """
+  Render an issue as markdown.
+
+  Includes title, metadata block, labels, and body.
+  """
+  @spec render_issue(map(), [map()]) :: String.t()
+  def render_issue(issue, comments \\ []) do
+    number = issue[:number] || issue["number"]
+    title = issue[:title] || issue["title"] || ""
+    body = issue[:body] || issue["body"] || ""
+    author = extract_author(issue)
+    labels = extract_labels(issue)
+    state = issue[:state] || issue["state"] || "open"
+
+    lines = [
+      "# Issue ##{number}: #{title}",
+      "",
+      "| Field | Value |",
+      "|-------|-------|",
+      "| Author | #{author} |",
+      "| State | #{state} |",
+      "| Labels | #{format_labels(labels)} |",
+      ""
+    ]
+
+    lines =
+      if body != "" do
+        lines ++ ["## Description", "", body, ""]
+      else
+        lines ++ ["## Description", "", "_No description provided._", ""]
+      end
+
+    lines =
+      if comments != [] do
+        lines ++ ["## Comments", "", render_thread(comments)]
+      else
+        lines
+      end
+
+    Enum.join(lines, "\n") |> String.trim_trailing()
+  end
+
+  # ── Pull Request Rendering ──────────────────────────────────────
+
+  @doc """
+  Render a pull request as markdown.
+
+  Includes title, metadata, branch info, body, and optionally
+  diff stats and reviews.
+
+  ## Options
+
+    * `:diff_stats` - list of PR file maps (from `list_pr_files/1`)
+    * `:reviews` - list of `%Review{}` structs
+    * `:review_comments` - list of `%ReviewComment{}` structs
+  """
+  @spec render_pull_request(map(), keyword()) :: String.t()
+  def render_pull_request(pr, opts \\ []) do
+    number = pr[:number] || pr["number"]
+    title = pr[:title] || pr["title"] || ""
+    body = pr[:body] || pr["body"] || ""
+    author = extract_author(pr)
+    labels = extract_labels(pr)
+    state = pr[:state] || pr["state"] || "open"
+    head = pr[:head] || pr["head"] || pr["headRefName"] || ""
+    base = pr[:base] || pr["base"] || pr["baseRefName"] || ""
+
+    lines = [
+      "# PR ##{number}: #{title}",
+      "",
+      "| Field | Value |",
+      "|-------|-------|",
+      "| Author | #{author} |",
+      "| State | #{state} |",
+      "| Labels | #{format_labels(labels)} |",
+      "| Head | `#{head}` |",
+      "| Base | `#{base}` |",
+      ""
+    ]
+
+    lines =
+      if body != "" do
+        lines ++ ["## Description", "", body, ""]
+      else
+        lines ++ ["## Description", "", "_No description provided._", ""]
+      end
+
+    diff_stats = Keyword.get(opts, :diff_stats)
+
+    lines =
+      if diff_stats && diff_stats != [] do
+        lines ++ ["## Changed Files", "", render_diff_stats(diff_stats), ""]
+      else
+        lines
+      end
+
+    reviews = Keyword.get(opts, :reviews)
+    review_comments = Keyword.get(opts, :review_comments)
+
+    lines =
+      if reviews && reviews != [] do
+        lines ++ ["## Reviews", "", render_reviews(reviews, review_comments || []), ""]
+      else
+        lines
+      end
+
+    Enum.join(lines, "\n") |> String.trim_trailing()
+  end
+
+  # ── Diff Stats ──────────────────────────────────────────────────
+
+  @doc """
+  Render PR file changes as a markdown table.
+
+  Expects the list of maps from `GitHub.list_pr_files/1`, each with
+  `:filename`, `:status`, `:additions`, `:deletions`.
+  """
+  @spec render_diff_stats([map()]) :: String.t()
+  def render_diff_stats(files) when is_list(files) do
+    header = [
+      "| File | Status | Additions | Deletions |",
+      "|------|--------|-----------|-----------|"
+    ]
+
+    rows =
+      Enum.map(files, fn file ->
+        filename = file[:filename] || file["filename"] || ""
+        status = file[:status] || file["status"] || ""
+        additions = file[:additions] || file["additions"] || 0
+        deletions = file[:deletions] || file["deletions"] || 0
+        "| `#{filename}` | #{status} | +#{additions} | -#{deletions} |"
+      end)
+
+    total_add =
+      Enum.reduce(files, 0, fn f, acc -> acc + (f[:additions] || f["additions"] || 0) end)
+
+    total_del =
+      Enum.reduce(files, 0, fn f, acc -> acc + (f[:deletions] || f["deletions"] || 0) end)
+
+    summary = ["", "**Total:** #{length(files)} files, +#{total_add}, -#{total_del}"]
+
+    (header ++ rows ++ summary)
+    |> Enum.join("\n")
+  end
+
+  # ── Thread Rendering ────────────────────────────────────────────
+
+  @doc """
+  Render a chronological comment thread as markdown.
+
+  Each comment should have `:user` (or `:author`) and `:body` keys.
+  """
+  @spec render_thread([map()]) :: String.t()
+  def render_thread(comments) when is_list(comments) do
+    if comments == [] do
+      "_No comments._"
+    else
+      comments
+      |> Enum.with_index(1)
+      |> Enum.map(fn {comment, idx} ->
+        user =
+          comment[:user] || comment[:author] || comment["user"] || comment["author"] || "unknown"
+
+        body = comment[:body] || comment["body"] || ""
+        timestamp = comment[:created_at] || comment["created_at"] || ""
+
+        time_str = if timestamp != "", do: " (#{timestamp})", else: ""
+        "### Comment #{idx} — @#{user}#{time_str}\n\n#{body}"
+      end)
+      |> Enum.join("\n\n---\n\n")
+    end
+  end
+
+  # ── Review Rendering ────────────────────────────────────────────
+
+  @doc """
+  Render PR reviews and inline review comments as markdown.
+  """
+  @spec render_reviews([Review.t()], [ReviewComment.t()]) :: String.t()
+  def render_reviews(reviews, review_comments \\ [])
+
+  def render_reviews([], []), do: "_No reviews._"
+
+  def render_reviews(reviews, review_comments) do
+    review_section =
+      reviews
+      |> Enum.map(fn review ->
+        state_badge = review_state_badge(review.state)
+        body_str = if review.body != "", do: "\n\n#{review.body}", else: ""
+        time_str = if review.submitted_at, do: " (#{review.submitted_at})", else: ""
+
+        "### @#{review.author} — #{state_badge}#{time_str}#{body_str}"
+      end)
+      |> Enum.join("\n\n---\n\n")
+
+    inline_section =
+      if review_comments != [] do
+        grouped = Enum.group_by(review_comments, & &1.path)
+
+        inline_lines =
+          grouped
+          |> Enum.sort_by(fn {path, _} -> path end)
+          |> Enum.map(fn {path, comments} ->
+            comment_lines =
+              comments
+              |> Enum.sort_by(& &1.line)
+              |> Enum.map(fn rc ->
+                line_str = if rc.line, do: "L#{rc.line}", else: ""
+                "  - **@#{rc.author}** #{line_str}: #{rc.body}"
+              end)
+              |> Enum.join("\n")
+
+            "- `#{path}`\n#{comment_lines}"
+          end)
+          |> Enum.join("\n\n")
+
+        "\n\n### Inline Comments\n\n#{inline_lines}"
+      else
+        ""
+      end
+
+    review_section <> inline_section
+  end
+
+  # ── Private ──────────────────────────────────────────────────────
+
+  defp extract_author(data) do
+    data[:author] || data["author"] ||
+      get_in(data, [:user, :login]) ||
+      get_in(data, ["user", "login"]) ||
+      "unknown"
+  end
+
+  defp extract_labels(data) do
+    labels = data[:labels] || data["labels"] || []
+
+    Enum.map(labels, fn
+      %{"name" => name} -> name
+      name when is_binary(name) -> name
+      _ -> ""
+    end)
+  end
+
+  defp format_labels([]), do: "_none_"
+  defp format_labels(labels), do: Enum.map_join(labels, ", ", &"`#{&1}`")
+
+  defp review_state_badge(:approved), do: "APPROVED"
+  defp review_state_badge(:changes_requested), do: "CHANGES REQUESTED"
+  defp review_state_badge(:commented), do: "COMMENTED"
+  defp review_state_badge(other), do: to_string(other)
+end

--- a/lib/lattice/context/trigger.ex
+++ b/lib/lattice/context/trigger.ex
@@ -1,0 +1,122 @@
+defmodule Lattice.Context.Trigger do
+  @moduledoc """
+  Input struct describing what triggered context gathering.
+
+  A trigger captures the GitHub issue or PR that initiated the work,
+  along with enough metadata to drive gathering without re-fetching.
+  """
+
+  @type t :: %__MODULE__{
+          type: :issue | :pull_request,
+          number: pos_integer(),
+          repo: String.t(),
+          raw_event: map() | nil,
+          title: String.t(),
+          body: String.t(),
+          author: String.t(),
+          labels: [String.t()],
+          head_branch: String.t() | nil,
+          base_branch: String.t() | nil,
+          thread_context: [map()] | nil
+        }
+
+  @enforce_keys [:type, :number, :repo]
+  defstruct [
+    :type,
+    :number,
+    :repo,
+    :raw_event,
+    :head_branch,
+    :base_branch,
+    :thread_context,
+    title: "",
+    body: "",
+    author: "unknown",
+    labels: []
+  ]
+
+  @doc """
+  Build a Trigger from a GitHub API issue map.
+
+  Expects the map shape returned by `GitHub.get_issue/1`.
+  """
+  @spec from_issue(map(), String.t()) :: t()
+  def from_issue(issue, repo) when is_map(issue) and is_binary(repo) do
+    %__MODULE__{
+      type: :issue,
+      number: issue[:number] || issue["number"],
+      repo: repo,
+      title: issue[:title] || issue["title"] || "",
+      body: issue[:body] || issue["body"] || "",
+      author: extract_author(issue),
+      labels: extract_labels(issue),
+      raw_event: issue
+    }
+  end
+
+  @doc """
+  Build a Trigger from a GitHub API pull request map.
+
+  Expects the map shape returned by `GitHub.get_pull_request/1`.
+  """
+  @spec from_pull_request(map(), String.t()) :: t()
+  def from_pull_request(pr, repo) when is_map(pr) and is_binary(repo) do
+    %__MODULE__{
+      type: :pull_request,
+      number: pr[:number] || pr["number"],
+      repo: repo,
+      title: pr[:title] || pr["title"] || "",
+      body: pr[:body] || pr["body"] || "",
+      author: extract_author(pr),
+      labels: extract_labels(pr),
+      head_branch: pr[:head] || pr["head"] || pr["headRefName"],
+      base_branch: pr[:base] || pr["base"] || pr["baseRefName"],
+      raw_event: pr
+    }
+  end
+
+  @doc """
+  Build a Trigger from an ambient responder event map.
+
+  Infers type from the event's `:surface` field.
+  """
+  @spec from_ambient_event(map()) :: t()
+  def from_ambient_event(event) when is_map(event) do
+    type =
+      case event[:surface] do
+        :pr_review -> :pull_request
+        :pr_review_comment -> :pull_request
+        _ -> :issue
+      end
+
+    %__MODULE__{
+      type: type,
+      number: event[:number],
+      repo: event[:repo] || Lattice.Instance.resource(:github_repo),
+      title: event[:title] || "",
+      body: event[:context_body] || "",
+      author: event[:author] || "unknown",
+      labels: event[:labels] || [],
+      raw_event: event
+    }
+  end
+
+  # ── Private ──────────────────────────────────────────────────────
+
+  defp extract_author(data) do
+    data[:author] || data["author"] ||
+      get_in(data, [:user, :login]) ||
+      get_in(data, ["user", "login"]) ||
+      "unknown"
+  end
+
+  defp extract_labels(data) do
+    labels = data[:labels] || data["labels"] || []
+
+    Enum.map(labels, fn
+      %{"name" => name} -> name
+      name when is_binary(name) -> name
+      _ -> ""
+    end)
+  end
+end

--- a/priv/sprite_skills/context/SKILL.md
+++ b/priv/sprite_skills/context/SKILL.md
@@ -1,0 +1,105 @@
+# Lattice Context Bundle
+
+You are running inside a Lattice-managed sprite. Before you start working,
+Lattice has gathered context about the issue or pull request that triggered
+your task. This document teaches you how to read and use that context.
+
+## Where Context Lives
+
+```
+/workspace/.lattice/context/
+├── manifest.json          # Bundle metadata + file index
+├── trigger.md             # The issue or PR that triggered this work
+├── thread.md              # Comment thread (chronological)
+├── diff_stats.md          # Files changed in the PR (PRs only)
+├── reviews.md             # Review verdicts + inline comments (PRs only)
+└── linked/
+    └── issue_NNN.md       # Expanded cross-references
+```
+
+Not all files are always present. Check `manifest.json` to see what was gathered.
+
+## Step 1: Read the Manifest
+
+Start by reading `/workspace/.lattice/context/manifest.json`:
+
+```json
+{
+  "version": "v1",
+  "trigger_type": "issue",
+  "trigger_number": 42,
+  "repo": "owner/name",
+  "title": "The issue title",
+  "gathered_at": "2026-02-23T12:00:00Z",
+  "files": [
+    {"path": "trigger.md", "kind": "trigger"},
+    {"path": "thread.md", "kind": "thread"},
+    {"path": "linked/issue_10.md", "kind": "linked_issue"}
+  ],
+  "linked_items": [
+    {"type": "issue", "number": 10, "title": "Related issue"}
+  ],
+  "expansion_budget": {"used": 1, "max": 5},
+  "warnings": []
+}
+```
+
+The manifest tells you:
+- **trigger_type**: Whether this is an `issue` or `pull_request`
+- **files**: Which context files are available
+- **linked_items**: Cross-referenced issues that were expanded
+- **warnings**: Any issues during context gathering
+
+## Step 2: Read the Trigger
+
+`trigger.md` contains the primary issue or PR:
+- Title and metadata (author, state, labels)
+- The full description/body
+- For PRs: branch information, changed files summary, and reviews
+
+This is the most important file. Start here to understand what you need to do.
+
+## Step 3: Read the Thread
+
+`thread.md` contains the comment thread in chronological order.
+Each comment shows the author, timestamp, and body.
+Read this to understand the full conversation and any clarifications.
+
+## Step 4: Read PR-Specific Files (if present)
+
+For pull request triggers:
+
+- **diff_stats.md** — Table of files changed with additions/deletions counts.
+  Use this to understand the scope of changes.
+- **reviews.md** — Review verdicts (APPROVED, CHANGES REQUESTED, COMMENTED)
+  and inline review comments grouped by file. Use this to understand what
+  reviewers want changed.
+
+## Step 5: Check Linked Items
+
+The `linked/` directory contains expanded cross-references (`#NNN`) found in
+the trigger body and comments. Each is rendered as a standalone issue/PR document.
+
+Not all references are expanded — check the manifest's `expansion_budget` to see
+how many were expanded vs. the maximum. If you need context from a reference that
+wasn't expanded, you can fetch it directly using `gh`.
+
+## Using Context Effectively
+
+1. **Read trigger.md first** — understand the task
+2. **Read thread.md** — catch any clarifications or follow-up discussion
+3. **Check linked items** — understand related context
+4. **For PRs: read reviews.md** — understand what reviewers want
+5. **For PRs: read diff_stats.md** — understand scope of changes
+
+## Hard Rules
+
+You MUST:
+- Read `manifest.json` before accessing context files
+- Check which files exist before trying to read them
+- Use context to inform your work, not as the sole source of truth
+
+You MUST NOT:
+- Modify files in `/workspace/.lattice/context/` — they are read-only reference
+- Assume all files are present — check the manifest
+- Ignore warnings in the manifest

--- a/spec/context-gathering-v1.md
+++ b/spec/context-gathering-v1.md
@@ -1,0 +1,159 @@
+# Lattice Context Gathering Specification (v1)
+
+> **Status:** Stable v1
+
+This specification defines how Lattice assembles GitHub context into a structured
+file bundle on a Sprite's filesystem. It governs what context is gathered, how it
+is rendered, and where it is delivered.
+
+It explicitly **does not** define:
+
+- Sprite ↔ Lattice communication (see Protocol v1)
+- How sprites consume context (see Context Skill)
+- On-demand context refresh (future work)
+
+---
+
+## Design Principles
+
+1. **Context is pre-gathered.** Lattice fetches and renders context before the sprite starts working, so the sprite has immediate access without API calls.
+2. **Context is structured files.** Each piece of context (trigger, thread, diff stats, reviews, linked items) is a separate markdown file with a JSON manifest.
+3. **Expansion is bounded.** Cross-references (`#NNN`) are expanded to depth=1 with a configurable budget (default 5) to prevent unbounded API calls.
+4. **Rendering is pure.** Markdown rendering functions have no side effects and no GitHub API calls. Gathering and rendering are cleanly separated.
+5. **Delivery follows SkillSync patterns.** Context is written to sprites using the same FileWriter infrastructure as skill sync.
+
+---
+
+## Inputs
+
+Context gathering is triggered by a `Trigger` struct containing:
+
+| Field | Required | Description |
+|---|---|---|
+| `type` | yes | `:issue` or `:pull_request` |
+| `number` | yes | GitHub issue/PR number |
+| `repo` | yes | Repository in `"owner/name"` format |
+| `title` | no | Issue/PR title |
+| `body` | no | Issue/PR body text |
+| `author` | no | Author login |
+| `labels` | no | List of label names |
+| `head_branch` | no | PR head branch (PRs only) |
+| `base_branch` | no | PR base branch (PRs only) |
+| `thread_context` | no | Pre-fetched comments (avoids re-fetch) |
+
+---
+
+## Filesystem Contract
+
+Context is delivered to:
+
+```
+/workspace/.lattice/context/
+├── manifest.json          # Bundle metadata + file index
+├── trigger.md             # Primary issue/PR with body and metadata
+├── thread.md              # Chronological comment thread
+├── diff_stats.md          # PR file changes table (PRs only)
+├── reviews.md             # Review verdicts + inline comments (PRs only)
+└── linked/
+    ├── issue_42.md        # Expanded cross-reference
+    └── issue_108.md       # Expanded cross-reference
+```
+
+### manifest.json
+
+```json
+{
+  "version": "v1",
+  "trigger_type": "pull_request",
+  "trigger_number": 123,
+  "repo": "owner/name",
+  "title": "Add context gathering",
+  "gathered_at": "2026-02-23T12:00:00Z",
+  "files": [
+    {"path": "trigger.md", "kind": "trigger"},
+    {"path": "thread.md", "kind": "thread"},
+    {"path": "diff_stats.md", "kind": "diff_stats"},
+    {"path": "reviews.md", "kind": "reviews"},
+    {"path": "linked/issue_42.md", "kind": "linked_issue"}
+  ],
+  "linked_items": [
+    {"type": "issue", "number": 42, "title": "Original bug report"}
+  ],
+  "expansion_budget": {"used": 1, "max": 5},
+  "warnings": []
+}
+```
+
+---
+
+## Gathering Behavior
+
+### Issue Triggers
+
+For `:issue` triggers, the gatherer:
+
+1. Fetches the issue via `GitHub.get_issue/1`
+2. Fetches comments via `GitHub.list_comments/1` (skipped if `thread_context` is pre-fetched)
+3. Renders `trigger.md` — issue title, body, labels, author
+4. Renders `thread.md` — chronological comment thread
+5. Parses `#NNN` references from body + comments
+6. Expands each reference (up to budget) via `GitHub.get_issue/1`
+7. Renders each as `linked/issue_NNN.md`
+
+### Pull Request Triggers
+
+For `:pull_request` triggers, the gatherer performs all issue steps plus:
+
+1. Fetches the PR via `GitHub.get_pull_request/1`
+2. Fetches PR file list via `GitHub.list_pr_files/1`
+3. Fetches reviews via `GitHub.list_reviews/1`
+4. Fetches review comments via `GitHub.list_review_comments/1`
+5. Renders `diff_stats.md` — table of files changed with +/- counts
+6. Renders `reviews.md` — review verdicts and inline comments
+
+### Expansion Rules
+
+- References are extracted via regex: `#(\d+)` (excluding code blocks)
+- Maximum expansions per gather: configurable, default 5
+- Depth is always 1 — expanded items are NOT scanned for further references
+- Each expanded item is fetched via `GitHub.get_issue/1` (works for both issues and PRs)
+- Expansion failures are logged as warnings, not errors
+
+---
+
+## Delivery
+
+Delivery writes the bundle to a sprite's filesystem:
+
+1. Clear context directory: `rm -rf /workspace/.lattice/context/`
+2. Create directory structure: `mkdir -p /workspace/.lattice/context/linked/`
+3. Write `manifest.json` via FileWriter
+4. Write each file entry via FileWriter
+5. Verify directory listing
+
+Delivery follows the SkillSync pattern: clear → create → write → verify.
+
+---
+
+## Error Handling
+
+- GitHub API failures during gathering return `{:error, term()}`
+- Individual expansion failures are recorded as warnings, not fatal errors
+- Delivery failures on transient errors are retried (FileWriter handles retry)
+- Missing optional data (no reviews, no comments) produces empty files, not errors
+
+---
+
+## Summary
+
+| Concept | Implementation |
+|---|---|
+| Input | `Lattice.Context.Trigger` struct |
+| Output | `Lattice.Context.Bundle` struct |
+| Rendering | `Lattice.Context.Renderer` (pure functions) |
+| Gathering | `Lattice.Context.Gatherer` (calls GitHub capability) |
+| Delivery | `Lattice.Context.Delivery` (writes to sprite via FileWriter) |
+| Filesystem | `/workspace/.lattice/context/` |
+| Manifest | `manifest.json` (JSON, machine-readable) |
+| Expansion | Bounded `#NNN` expansion, depth=1, default budget=5 |
+| Skill | `priv/sprite_skills/context/SKILL.md` |

--- a/test/lattice/context/bundle_test.exs
+++ b/test/lattice/context/bundle_test.exs
@@ -1,0 +1,144 @@
+defmodule Lattice.Context.BundleTest do
+  use ExUnit.Case
+  @moduletag :unit
+
+  alias Lattice.Context.Bundle
+  alias Lattice.Context.Trigger
+
+  @trigger %Trigger{
+    type: :issue,
+    number: 42,
+    repo: "owner/repo",
+    title: "Test issue",
+    body: "Some body"
+  }
+
+  describe "new/2" do
+    test "creates a bundle from a trigger" do
+      bundle = Bundle.new(@trigger)
+
+      assert bundle.trigger_type == :issue
+      assert bundle.trigger_number == 42
+      assert bundle.repo == "owner/repo"
+      assert bundle.title == "Test issue"
+      assert bundle.files == []
+      assert bundle.linked_items == []
+      assert bundle.expansion_budget == %{used: 0, max: 5}
+      assert bundle.warnings == []
+      assert %DateTime{} = bundle.gathered_at
+    end
+
+    test "accepts custom max_expansions" do
+      bundle = Bundle.new(@trigger, max_expansions: 10)
+      assert bundle.expansion_budget == %{used: 0, max: 10}
+    end
+  end
+
+  describe "add_file/4" do
+    test "appends a file entry" do
+      bundle =
+        Bundle.new(@trigger)
+        |> Bundle.add_file("trigger.md", "# Hello", "trigger")
+
+      assert length(bundle.files) == 1
+      [file] = bundle.files
+      assert file.path == "trigger.md"
+      assert file.content == "# Hello"
+      assert file.kind == "trigger"
+    end
+
+    test "preserves order of multiple files" do
+      bundle =
+        Bundle.new(@trigger)
+        |> Bundle.add_file("a.md", "A", "first")
+        |> Bundle.add_file("b.md", "B", "second")
+
+      assert [%{path: "a.md"}, %{path: "b.md"}] = bundle.files
+    end
+  end
+
+  describe "add_linked_item/4" do
+    test "adds item and increments budget" do
+      bundle =
+        Bundle.new(@trigger)
+        |> Bundle.add_linked_item("issue", 10, "Some issue")
+
+      assert length(bundle.linked_items) == 1
+      assert hd(bundle.linked_items).number == 10
+      assert bundle.expansion_budget.used == 1
+    end
+  end
+
+  describe "add_warning/2" do
+    test "appends a warning" do
+      bundle =
+        Bundle.new(@trigger)
+        |> Bundle.add_warning("something went wrong")
+
+      assert bundle.warnings == ["something went wrong"]
+    end
+  end
+
+  describe "budget_remaining?/1" do
+    test "returns true when budget has capacity" do
+      bundle = Bundle.new(@trigger, max_expansions: 3)
+      assert Bundle.budget_remaining?(bundle)
+    end
+
+    test "returns false when budget is exhausted" do
+      bundle =
+        Bundle.new(@trigger, max_expansions: 1)
+        |> Bundle.add_linked_item("issue", 1, "x")
+
+      refute Bundle.budget_remaining?(bundle)
+    end
+  end
+
+  describe "total_size/1" do
+    test "sums byte sizes of all file contents" do
+      bundle =
+        Bundle.new(@trigger)
+        |> Bundle.add_file("a.md", "hello", "trigger")
+        |> Bundle.add_file("b.md", "world!", "thread")
+
+      assert Bundle.total_size(bundle) == byte_size("hello") + byte_size("world!")
+    end
+
+    test "returns 0 for empty bundle" do
+      assert Bundle.total_size(Bundle.new(@trigger)) == 0
+    end
+  end
+
+  describe "to_manifest/1" do
+    test "returns a JSON-encodable map" do
+      bundle =
+        Bundle.new(@trigger)
+        |> Bundle.add_file("trigger.md", "content", "trigger")
+        |> Bundle.add_linked_item("issue", 10, "Linked")
+        |> Bundle.add_warning("warn")
+
+      manifest = Bundle.to_manifest(bundle)
+
+      assert manifest.version == "v1"
+      assert manifest.trigger_type == "issue"
+      assert manifest.trigger_number == 42
+      assert manifest.repo == "owner/repo"
+      assert is_binary(manifest.gathered_at)
+      assert [%{path: "trigger.md", kind: "trigger"}] = manifest.files
+      assert [%{type: "issue", number: 10, title: "Linked"}] = manifest.linked_items
+      assert manifest.expansion_budget == %{used: 1, max: 5}
+      assert manifest.warnings == ["warn"]
+    end
+  end
+
+  describe "to_manifest_json/1" do
+    test "returns valid JSON string" do
+      bundle = Bundle.new(@trigger)
+      json = Bundle.to_manifest_json(bundle)
+
+      assert {:ok, decoded} = Jason.decode(json)
+      assert decoded["version"] == "v1"
+      assert decoded["trigger_number"] == 42
+    end
+  end
+end

--- a/test/lattice/context/delivery_test.exs
+++ b/test/lattice/context/delivery_test.exs
@@ -1,0 +1,136 @@
+defmodule Lattice.Context.DeliveryTest do
+  use ExUnit.Case
+  @moduletag :unit
+
+  import Mox
+
+  alias Lattice.Context.Bundle
+  alias Lattice.Context.Delivery
+  alias Lattice.Context.Trigger
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  @trigger %Trigger{
+    type: :issue,
+    number: 42,
+    repo: "owner/repo",
+    title: "Test issue"
+  }
+
+  defp build_bundle do
+    Bundle.new(@trigger)
+    |> Bundle.add_file("trigger.md", "# Issue #42", "trigger")
+    |> Bundle.add_file("thread.md", "_No comments._", "thread")
+  end
+
+  defp build_bundle_with_linked do
+    build_bundle()
+    |> Bundle.add_file("linked/issue_10.md", "# Issue #10", "linked_issue")
+  end
+
+  describe "deliver/2" do
+    test "clears dir, creates subdirs, writes manifest and files, verifies" do
+      bundle = build_bundle()
+
+      Lattice.Capabilities.MockSprites
+      # 1. rm -rf && mkdir -p (clear)
+      |> expect(:exec, fn "sprite-1", cmd ->
+        assert cmd =~ "rm -rf"
+        assert cmd =~ "/workspace/.lattice/context"
+        {:ok, %{output: "", exit_code: 0}}
+      end)
+      # 2. No mkdir for subdirs needed (no linked/ files)
+      # 3. FileWriter: manifest.json write first chunk
+      |> expect(:exec, fn "sprite-1", cmd ->
+        assert cmd =~ ".b64"
+        {:ok, %{output: "", exit_code: 0}}
+      end)
+      # 4. FileWriter: manifest.json decode
+      |> expect(:exec, fn "sprite-1", cmd ->
+        assert cmd =~ "base64 -d"
+        assert cmd =~ "manifest.json"
+        {:ok, %{output: "", exit_code: 0}}
+      end)
+      # 5. FileWriter: trigger.md write first chunk
+      |> expect(:exec, fn "sprite-1", cmd ->
+        assert cmd =~ ".b64"
+        {:ok, %{output: "", exit_code: 0}}
+      end)
+      # 6. FileWriter: trigger.md decode
+      |> expect(:exec, fn "sprite-1", cmd ->
+        assert cmd =~ "base64 -d"
+        assert cmd =~ "trigger.md"
+        {:ok, %{output: "", exit_code: 0}}
+      end)
+      # 7. FileWriter: thread.md write first chunk
+      |> expect(:exec, fn "sprite-1", cmd ->
+        assert cmd =~ ".b64"
+        {:ok, %{output: "", exit_code: 0}}
+      end)
+      # 8. FileWriter: thread.md decode
+      |> expect(:exec, fn "sprite-1", cmd ->
+        assert cmd =~ "base64 -d"
+        assert cmd =~ "thread.md"
+        {:ok, %{output: "", exit_code: 0}}
+      end)
+      # 9. Verify: ls -la
+      |> expect(:exec, fn "sprite-1", cmd ->
+        assert cmd =~ "ls -la"
+        {:ok, %{output: "manifest.json trigger.md thread.md", exit_code: 0}}
+      end)
+
+      assert :ok = Delivery.deliver("sprite-1", bundle)
+    end
+
+    test "creates subdirs when linked files are present" do
+      bundle = build_bundle_with_linked()
+
+      Lattice.Capabilities.MockSprites
+      # 1. clear
+      |> expect(:exec, fn "sprite-1", cmd ->
+        assert cmd =~ "rm -rf"
+        {:ok, %{output: "", exit_code: 0}}
+      end)
+      # 2. mkdir -p for linked/
+      |> expect(:exec, fn "sprite-1", cmd ->
+        assert cmd =~ "mkdir -p"
+        assert cmd =~ "linked"
+        {:ok, %{output: "", exit_code: 0}}
+      end)
+      # 3-12: manifest + 3 files = 4 * 2 (write + decode) = 8 exec calls
+      |> expect(:exec, 8, fn "sprite-1", _cmd ->
+        {:ok, %{output: "", exit_code: 0}}
+      end)
+      # 13. verify
+      |> expect(:exec, fn "sprite-1", _cmd ->
+        {:ok, %{output: "ok", exit_code: 0}}
+      end)
+
+      assert :ok = Delivery.deliver("sprite-1", bundle)
+    end
+
+    test "returns error when clear fails" do
+      bundle = build_bundle()
+
+      Lattice.Capabilities.MockSprites
+      |> expect(:exec, fn "sprite-1", _cmd ->
+        {:error, :not_found}
+      end)
+
+      assert {:error, :not_found} = Delivery.deliver("sprite-1", bundle)
+    end
+
+    test "returns error when file write fails" do
+      bundle = build_bundle()
+
+      Lattice.Capabilities.MockSprites
+      # clear succeeds
+      |> expect(:exec, fn "sprite-1", _cmd -> {:ok, %{output: "", exit_code: 0}} end)
+      # manifest write fails (non-retryable)
+      |> expect(:exec, fn "sprite-1", _cmd -> {:error, :write_failed} end)
+
+      assert {:error, :write_failed} = Delivery.deliver("sprite-1", bundle)
+    end
+  end
+end

--- a/test/lattice/context/gatherer_test.exs
+++ b/test/lattice/context/gatherer_test.exs
@@ -1,0 +1,234 @@
+defmodule Lattice.Context.GathererTest do
+  use ExUnit.Case
+  @moduletag :unit
+
+  import Mox
+
+  alias Lattice.Capabilities.GitHub.Review
+  alias Lattice.Capabilities.GitHub.ReviewComment
+  alias Lattice.Context.Bundle
+  alias Lattice.Context.Gatherer
+  alias Lattice.Context.Trigger
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  @issue_trigger %Trigger{
+    type: :issue,
+    number: 42,
+    repo: "owner/repo",
+    title: "Fix bug",
+    body: "The thing is broken. See #10 for context."
+  }
+
+  @pr_trigger %Trigger{
+    type: :pull_request,
+    number: 99,
+    repo: "owner/repo",
+    title: "Add feature",
+    body: "Implements #42."
+  }
+
+  @issue_data %{
+    number: 42,
+    title: "Fix bug",
+    body: "The thing is broken. See #10 for context.",
+    state: "open",
+    labels: ["bug"],
+    comments: []
+  }
+
+  @pr_data %{
+    number: 99,
+    title: "Add feature",
+    body: "Implements #42.",
+    state: "open",
+    labels: [],
+    head: "feature",
+    base: "main"
+  }
+
+  @linked_issue %{
+    number: 10,
+    title: "Original report",
+    body: "Something was wrong.",
+    state: "closed",
+    labels: [],
+    comments: []
+  }
+
+  describe "gather/2 with issue trigger" do
+    test "gathers issue context with trigger.md, thread.md, and expanded refs" do
+      Lattice.Capabilities.MockGitHub
+      # get_issue for trigger
+      |> expect(:get_issue, fn 42 -> {:ok, @issue_data} end)
+      # list_comments for thread
+      |> expect(:list_comments, fn 42 ->
+        {:ok, [%{user: "bob", body: "I see it too", created_at: "2026-01-01"}]}
+      end)
+      # get_issue for expansion of #10
+      |> expect(:get_issue, fn 10 -> {:ok, @linked_issue} end)
+
+      assert {:ok, %Bundle{} = bundle} = Gatherer.gather(@issue_trigger)
+
+      assert bundle.trigger_type == :issue
+      assert bundle.trigger_number == 42
+
+      # Should have trigger.md, thread.md, and linked/issue_10.md
+      paths = Enum.map(bundle.files, & &1.path)
+      assert "trigger.md" in paths
+      assert "thread.md" in paths
+      assert "linked/issue_10.md" in paths
+
+      # Linked items should include #10
+      assert [%{number: 10, title: "Original report"}] = bundle.linked_items
+      assert bundle.expansion_budget.used == 1
+    end
+
+    test "reuses pre-fetched thread_context instead of calling list_comments" do
+      trigger = %{@issue_trigger | thread_context: [%{user: "pre", body: "pre-fetched"}]}
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 42 -> {:ok, @issue_data} end)
+      # No list_comments expected — using thread_context
+
+      # #10 expansion
+      |> expect(:get_issue, fn 10 -> {:ok, @linked_issue} end)
+
+      assert {:ok, %Bundle{} = bundle} = Gatherer.gather(trigger)
+
+      thread_file = Enum.find(bundle.files, &(&1.path == "thread.md"))
+      assert thread_file.content =~ "pre-fetched"
+    end
+
+    test "respects expansion budget" do
+      trigger = %{@issue_trigger | body: "See #1, #2, #3, #4, #5, #6, #7"}
+
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 42 -> {:ok, @issue_data} end)
+      |> expect(:list_comments, fn 42 -> {:ok, []} end)
+      # Only 5 expansions (default budget), not 7
+      |> expect(:get_issue, 5, fn n ->
+        {:ok,
+         %{number: n, title: "Issue #{n}", body: "", state: "open", labels: [], comments: []}}
+      end)
+
+      assert {:ok, %Bundle{} = bundle} = Gatherer.gather(trigger)
+      assert bundle.expansion_budget.used == 5
+      assert bundle.expansion_budget.max == 5
+
+      linked_paths =
+        bundle.files
+        |> Enum.filter(&String.starts_with?(&1.path, "linked/"))
+        |> Enum.map(& &1.path)
+
+      assert length(linked_paths) == 5
+    end
+
+    test "records warning when expansion fails" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 42 -> {:ok, @issue_data} end)
+      |> expect(:list_comments, fn 42 -> {:ok, []} end)
+      |> expect(:get_issue, fn 10 -> {:error, :not_found} end)
+
+      assert {:ok, %Bundle{} = bundle} = Gatherer.gather(@issue_trigger)
+      assert length(bundle.warnings) == 1
+      assert hd(bundle.warnings) =~ "#10"
+    end
+
+    test "propagates GitHub error on get_issue failure" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_issue, fn 42 -> {:error, :rate_limited} end)
+
+      assert {:error, :rate_limited} = Gatherer.gather(@issue_trigger)
+    end
+  end
+
+  describe "gather/2 with PR trigger" do
+    test "gathers PR context with all files" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_pull_request, fn 99 -> {:ok, @pr_data} end)
+      |> expect(:list_comments, fn 99 -> {:ok, []} end)
+      |> expect(:list_pr_files, fn 99 ->
+        {:ok, [%{filename: "lib/foo.ex", status: "modified", additions: 5, deletions: 2}]}
+      end)
+      |> expect(:list_reviews, fn 99 ->
+        {:ok, [%Review{id: 1, author: "rev", state: :approved, body: "LGTM"}]}
+      end)
+      |> expect(:list_review_comments, fn 99 ->
+        {:ok,
+         [
+           %ReviewComment{
+             id: 1,
+             author: "rev",
+             body: "Nit",
+             path: "lib/foo.ex",
+             line: 10
+           }
+         ]}
+      end)
+      # expansion of #42
+      |> expect(:get_issue, fn 42 ->
+        {:ok,
+         %{number: 42, title: "Fix bug", body: "desc", state: "open", labels: [], comments: []}}
+      end)
+
+      assert {:ok, %Bundle{} = bundle} = Gatherer.gather(@pr_trigger)
+
+      assert bundle.trigger_type == :pull_request
+      paths = Enum.map(bundle.files, & &1.path)
+      assert "trigger.md" in paths
+      assert "thread.md" in paths
+      assert "diff_stats.md" in paths
+      assert "reviews.md" in paths
+      assert "linked/issue_42.md" in paths
+    end
+
+    test "gracefully handles PR files fetch failure" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:get_pull_request, fn 99 -> {:ok, @pr_data} end)
+      |> expect(:list_comments, fn 99 -> {:ok, []} end)
+      |> expect(:list_pr_files, fn 99 -> {:error, :rate_limited} end)
+      |> expect(:list_reviews, fn 99 -> {:ok, []} end)
+      |> expect(:list_review_comments, fn 99 -> {:ok, []} end)
+      |> expect(:get_issue, fn 42 ->
+        {:ok, %{number: 42, title: "Fix bug", body: "", state: "open", labels: [], comments: []}}
+      end)
+
+      # Should succeed even though list_pr_files failed (graceful fallback)
+      assert {:ok, %Bundle{}} = Gatherer.gather(@pr_trigger)
+    end
+  end
+
+  describe "extract_issue_refs/1" do
+    test "extracts issue references from text" do
+      assert Gatherer.extract_issue_refs("See #42 and #10") == [10, 42]
+    end
+
+    test "ignores refs in code blocks" do
+      text = """
+      See #42.
+
+      ```
+      # This is #99 in code
+      ```
+
+      Also `#50` in inline code.
+      """
+
+      assert Gatherer.extract_issue_refs(text) == [42]
+    end
+
+    test "deduplicates refs" do
+      assert Gatherer.extract_issue_refs("#42 and #42 again") == [42]
+    end
+
+    test "returns empty list for no refs" do
+      assert Gatherer.extract_issue_refs("No refs here") == []
+    end
+
+    test "ignores hash in words" do
+      assert Gatherer.extract_issue_refs("color#42 is not a ref") == []
+    end
+  end
+end

--- a/test/lattice/context/renderer_test.exs
+++ b/test/lattice/context/renderer_test.exs
@@ -1,0 +1,205 @@
+defmodule Lattice.Context.RendererTest do
+  use ExUnit.Case
+  @moduletag :unit
+
+  alias Lattice.Capabilities.GitHub.Review
+  alias Lattice.Capabilities.GitHub.ReviewComment
+  alias Lattice.Context.Renderer
+
+  describe "render_issue/2" do
+    test "renders issue with title, metadata, and body" do
+      issue = %{
+        number: 42,
+        title: "Fix the bug",
+        body: "Something is broken.",
+        state: "open",
+        labels: ["bug", "urgent"],
+        author: "alice"
+      }
+
+      md = Renderer.render_issue(issue)
+
+      assert md =~ "# Issue #42: Fix the bug"
+      assert md =~ "| Author | alice |"
+      assert md =~ "| State | open |"
+      assert md =~ "`bug`, `urgent`"
+      assert md =~ "Something is broken."
+    end
+
+    test "renders issue with no body" do
+      issue = %{number: 1, title: "Empty", body: "", state: "open", labels: []}
+      md = Renderer.render_issue(issue)
+      assert md =~ "_No description provided._"
+    end
+
+    test "renders issue with comments" do
+      issue = %{number: 1, title: "Test", body: "body", state: "open", labels: []}
+
+      comments = [
+        %{user: "bob", body: "Looks good", created_at: "2026-01-01T00:00:00Z"},
+        %{user: "alice", body: "Thanks!"}
+      ]
+
+      md = Renderer.render_issue(issue, comments)
+      assert md =~ "## Comments"
+      assert md =~ "@bob"
+      assert md =~ "Looks good"
+      assert md =~ "@alice"
+    end
+
+    test "handles string-keyed maps" do
+      issue = %{
+        "number" => 5,
+        "title" => "String keys",
+        "body" => "body text",
+        "state" => "closed",
+        "labels" => [%{"name" => "feature"}]
+      }
+
+      md = Renderer.render_issue(issue)
+      assert md =~ "# Issue #5: String keys"
+      assert md =~ "`feature`"
+    end
+  end
+
+  describe "render_pull_request/2" do
+    test "renders PR with metadata and branch info" do
+      pr = %{
+        number: 99,
+        title: "Add feature",
+        body: "This adds a thing.",
+        state: "open",
+        labels: ["enhancement"],
+        author: "charlie",
+        head: "feature-branch",
+        base: "main"
+      }
+
+      md = Renderer.render_pull_request(pr)
+
+      assert md =~ "# PR #99: Add feature"
+      assert md =~ "| Head | `feature-branch` |"
+      assert md =~ "| Base | `main` |"
+      assert md =~ "This adds a thing."
+    end
+
+    test "includes diff stats when provided" do
+      pr = %{number: 1, title: "T", body: "", state: "open", labels: [], head: "h", base: "b"}
+
+      files = [
+        %{filename: "lib/foo.ex", status: "modified", additions: 10, deletions: 3},
+        %{filename: "lib/bar.ex", status: "added", additions: 25, deletions: 0}
+      ]
+
+      md = Renderer.render_pull_request(pr, diff_stats: files)
+      assert md =~ "## Changed Files"
+      assert md =~ "`lib/foo.ex`"
+      assert md =~ "+10"
+    end
+
+    test "includes reviews when provided" do
+      pr = %{number: 1, title: "T", body: "", state: "open", labels: [], head: "h", base: "b"}
+
+      reviews = [
+        %Review{id: 1, author: "reviewer", state: :approved, body: "LGTM"}
+      ]
+
+      md = Renderer.render_pull_request(pr, reviews: reviews)
+      assert md =~ "## Reviews"
+      assert md =~ "@reviewer"
+      assert md =~ "APPROVED"
+    end
+  end
+
+  describe "render_diff_stats/1" do
+    test "renders a table of file changes" do
+      files = [
+        %{filename: "lib/foo.ex", status: "modified", additions: 10, deletions: 2},
+        %{filename: "test/foo_test.exs", status: "added", additions: 30, deletions: 0}
+      ]
+
+      md = Renderer.render_diff_stats(files)
+
+      assert md =~ "| File | Status | Additions | Deletions |"
+      assert md =~ "| `lib/foo.ex` | modified | +10 | -2 |"
+      assert md =~ "| `test/foo_test.exs` | added | +30 | -0 |"
+      assert md =~ "**Total:** 2 files, +40, -2"
+    end
+
+    test "handles empty file list" do
+      md = Renderer.render_diff_stats([])
+      assert md =~ "**Total:** 0 files, +0, -0"
+    end
+  end
+
+  describe "render_thread/1" do
+    test "renders chronological comments" do
+      comments = [
+        %{user: "alice", body: "First comment", created_at: "2026-01-01T00:00:00Z"},
+        %{user: "bob", body: "Second comment"}
+      ]
+
+      md = Renderer.render_thread(comments)
+
+      assert md =~ "### Comment 1 — @alice (2026-01-01T00:00:00Z)"
+      assert md =~ "First comment"
+      assert md =~ "### Comment 2 — @bob"
+      assert md =~ "Second comment"
+      assert md =~ "---"
+    end
+
+    test "returns placeholder for empty thread" do
+      assert Renderer.render_thread([]) == "_No comments._"
+    end
+
+    test "handles string-keyed comment maps" do
+      comments = [%{"user" => "eve", "body" => "Hello", "created_at" => "2026-01-01"}]
+      md = Renderer.render_thread(comments)
+      assert md =~ "@eve"
+      assert md =~ "Hello"
+    end
+  end
+
+  describe "render_reviews/2" do
+    test "renders review verdicts" do
+      reviews = [
+        %Review{id: 1, author: "reviewer1", state: :approved, body: "Ship it"},
+        %Review{
+          id: 2,
+          author: "reviewer2",
+          state: :changes_requested,
+          body: "Needs work"
+        }
+      ]
+
+      md = Renderer.render_reviews(reviews)
+
+      assert md =~ "@reviewer1 — APPROVED"
+      assert md =~ "Ship it"
+      assert md =~ "@reviewer2 — CHANGES REQUESTED"
+      assert md =~ "Needs work"
+    end
+
+    test "includes inline review comments grouped by file" do
+      reviews = [%Review{id: 1, author: "rev", state: :commented, body: ""}]
+
+      review_comments = [
+        %ReviewComment{id: 1, author: "rev", body: "Fix this", path: "lib/foo.ex", line: 10},
+        %ReviewComment{id: 2, author: "rev", body: "And this", path: "lib/foo.ex", line: 20},
+        %ReviewComment{id: 3, author: "rev", body: "Check bar", path: "lib/bar.ex", line: 5}
+      ]
+
+      md = Renderer.render_reviews(reviews, review_comments)
+
+      assert md =~ "### Inline Comments"
+      assert md =~ "`lib/bar.ex`"
+      assert md =~ "`lib/foo.ex`"
+      assert md =~ "L10"
+      assert md =~ "Fix this"
+    end
+
+    test "returns placeholder for no reviews" do
+      assert Renderer.render_reviews([], []) == "_No reviews._"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add structured GitHub context gathering system for sprites (spec, Trigger/Bundle structs, Renderer, Gatherer, Delivery, context skill) with 43 tests
- Add `list_pr_files/1` to GitHub capability (behaviour + Http + Live implementations)
- Fix Fly autostop killing in-flight delegation tasks (`min_machines_running=0` → `1`) — this caused issue #201 to get eyes + rocket but no response

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test test/lattice/context/` — 43 tests, 0 failures
- [x] `mix format --check-formatted` — clean
- [ ] Verify next ambient delegation completes without autostop interruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)