### PR TITLE
Remove ambient responder per-thread cooldown

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -66,7 +66,6 @@ config :lattice, :webhooks,
 config :lattice, Lattice.Ambient.Responder,
   enabled: false,
   bot_login: nil,
-  cooldown_ms: 60_000,
   eyes_reaction: true
 
 # Configure the endpoint

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -86,7 +86,6 @@ if System.get_env("ANTHROPIC_API_KEY") do
   config :lattice, Lattice.Ambient.Responder,
     enabled: true,
     bot_login: System.get_env("LATTICE_BOT_LOGIN"),
-    cooldown_ms: String.to_integer(System.get_env("AMBIENT_COOLDOWN_MS", "60000")),
     eyes_reaction: true
 
   config :lattice, Lattice.Ambient.Claude,

--- a/test/lattice/webhooks/github_ambient_test.exs
+++ b/test/lattice/webhooks/github_ambient_test.exs
@@ -112,7 +112,6 @@ defmodule Lattice.Webhooks.GitHubAmbientTest do
       Application.put_env(:lattice, Lattice.Ambient.Responder,
         enabled: true,
         bot_login: "lattice-operator",
-        cooldown_ms: 60_000,
         eyes_reaction: true
       )
 


### PR DESCRIPTION
## Summary

- Removes the per-thread cooldown from the Ambient Responder that was silently dropping follow-up comments arriving within 60s of a previous response
- Self-loop prevention (bot/Lattice comment filtering at the webhook layer) remains in place
- Fixes the issue where follow-up instructions on #207 were ignored

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test test/lattice/ambient/responder_test.exs` — 18 tests, 0 failures
- [x] `mix test test/lattice/webhooks/github_ambient_test.exs` — 8 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)