### PR TITLE
Add DIL context gathering, evaluator, and ad-hoc endpoint

### DIFF
--- a/lib/lattice/dil/context.ex
+++ b/lib/lattice/dil/context.ex
@@ -1,0 +1,143 @@
+defmodule Lattice.DIL.Context do
+  @moduledoc """
+  Gathers signals from the repository and GitHub for DIL candidate identification.
+
+  Scans `lib/` and `test/` for code-level signals (TODOs, missing moduledocs,
+  missing typespecs, large files, test gaps) and queries GitHub for recent
+  closed issues.
+  """
+
+  alias Lattice.Capabilities.GitHub
+
+  defstruct todos: [],
+            missing_moduledocs: [],
+            missing_typespecs: [],
+            large_files: [],
+            test_gaps: [],
+            recent_issues: []
+
+  @type signal :: %{file: String.t(), line: integer() | nil, detail: String.t()}
+
+  @type t :: %__MODULE__{
+          todos: [signal()],
+          missing_moduledocs: [signal()],
+          missing_typespecs: [signal()],
+          large_files: [signal()],
+          test_gaps: [signal()],
+          recent_issues: [map()]
+        }
+
+  @large_file_threshold 300
+
+  @doc """
+  Gather all context signals. Returns a `%Context{}` struct.
+  """
+  @spec gather() :: t()
+  def gather do
+    lib_files = list_elixir_files("lib")
+    test_files = list_elixir_files("test")
+
+    %__MODULE__{
+      todos: scan_todos(lib_files),
+      missing_moduledocs: scan_missing_moduledocs(lib_files),
+      missing_typespecs: scan_missing_typespecs(lib_files),
+      large_files: scan_large_files(lib_files),
+      test_gaps: scan_test_gaps(lib_files, test_files),
+      recent_issues: fetch_recent_issues()
+    }
+  end
+
+  # ── File Scanning ────────────────────────────────────────────────────
+
+  defp list_elixir_files(dir) do
+    Path.wildcard(Path.join(dir, "**/*.ex")) ++
+      Path.wildcard(Path.join(dir, "**/*.exs"))
+  end
+
+  defp scan_todos(files) do
+    Enum.flat_map(files, fn file ->
+      file
+      |> File.read!()
+      |> String.split("\n")
+      |> Enum.with_index(1)
+      |> Enum.filter(fn {line, _} -> line =~ ~r/# TODO/i end)
+      |> Enum.map(fn {line, num} ->
+        %{file: file, line: num, detail: String.trim(line)}
+      end)
+    end)
+  end
+
+  defp scan_missing_moduledocs(files) do
+    files
+    |> Enum.filter(fn file ->
+      String.ends_with?(file, ".ex") and
+        (
+          content = File.read!(file)
+          has_defmodule?(content) and not has_moduledoc?(content)
+        )
+    end)
+    |> Enum.map(fn file ->
+      %{file: file, line: nil, detail: "missing @moduledoc"}
+    end)
+  end
+
+  defp scan_missing_typespecs(files) do
+    files
+    |> Enum.filter(&String.ends_with?(&1, ".ex"))
+    |> Enum.flat_map(fn file ->
+      content = File.read!(file)
+
+      if has_public_functions?(content) and not has_typespecs?(content) do
+        [%{file: file, line: nil, detail: "public functions without @spec"}]
+      else
+        []
+      end
+    end)
+  end
+
+  defp scan_large_files(files) do
+    Enum.flat_map(files, fn file ->
+      line_count = file |> File.read!() |> String.split("\n") |> length()
+
+      if line_count > @large_file_threshold do
+        [%{file: file, line: nil, detail: "#{line_count} lines"}]
+      else
+        []
+      end
+    end)
+  end
+
+  defp scan_test_gaps(lib_files, test_files) do
+    test_modules =
+      test_files
+      |> Enum.map(&Path.basename/1)
+      |> MapSet.new()
+
+    lib_files
+    |> Enum.filter(&String.ends_with?(&1, ".ex"))
+    |> Enum.reject(&(&1 =~ ~r/(application|router|endpoint|telemetry|gettext|error)/))
+    |> Enum.filter(fn file ->
+      expected_test = file |> Path.basename(".ex") |> Kernel.<>("_test.exs")
+      expected_test not in test_modules
+    end)
+    |> Enum.map(fn file ->
+      %{file: file, line: nil, detail: "no corresponding test file"}
+    end)
+  end
+
+  # ── GitHub Signals ───────────────────────────────────────────────────
+
+  defp fetch_recent_issues do
+    case GitHub.list_issues(state: "closed", per_page: 20) do
+      {:ok, issues} -> issues
+      {:error, _} -> []
+    end
+  end
+
+  # ── Content Helpers ──────────────────────────────────────────────────
+
+  defp has_defmodule?(content), do: content =~ ~r/defmodule\s+/
+  defp has_moduledoc?(content), do: content =~ ~r/@moduledoc/
+  defp has_public_functions?(content), do: content =~ ~r/\n\s+def\s+\w+/
+  defp has_typespecs?(content), do: content =~ ~r/@spec\s+/
+end

--- a/lib/lattice/dil/evaluator.ex
+++ b/lib/lattice/dil/evaluator.ex
@@ -1,0 +1,209 @@
+defmodule Lattice.DIL.Evaluator do
+  @moduledoc """
+  Rule-based heuristic evaluator for DIL candidates.
+
+  Maps context signals to improvement candidates in four categories
+  (observability, context_efficiency, reliability, developer_ergonomics),
+  scores each across five dimensions, and selects the top qualifying one.
+  """
+
+  alias Lattice.DIL.Candidate
+  alias Lattice.DIL.Context
+
+  @score_dimensions [
+    :north_star_alignment,
+    :evidence_strength,
+    :scope_clarity,
+    :risk_level,
+    :implementation_confidence
+  ]
+
+  @doc """
+  Identify candidate improvements from gathered context signals.
+  """
+  @spec identify_candidates(Context.t()) :: [Candidate.t()]
+  def identify_candidates(%Context{} = ctx) do
+    []
+    |> maybe_add_moduledoc_candidates(ctx)
+    |> maybe_add_typespec_candidates(ctx)
+    |> maybe_add_todo_candidates(ctx)
+    |> maybe_add_large_file_candidates(ctx)
+    |> maybe_add_test_gap_candidates(ctx)
+  end
+
+  @doc """
+  Score a candidate across all five dimensions. Returns the candidate
+  with `scores` and `total_score` populated.
+  """
+  @spec score_candidate(Candidate.t()) :: Candidate.t()
+  def score_candidate(%Candidate{} = candidate) do
+    scores = %{
+      north_star_alignment: score_north_star(candidate),
+      evidence_strength: score_evidence(candidate),
+      scope_clarity: score_scope(candidate),
+      risk_level: score_risk(candidate),
+      implementation_confidence: score_confidence(candidate)
+    }
+
+    total = scores |> Map.values() |> Enum.sum()
+    %{candidate | scores: scores, total_score: total}
+  end
+
+  @doc """
+  Select the top-scoring candidate above the configured threshold.
+  Returns `nil` if no candidate qualifies.
+  """
+  @spec select_top([Candidate.t()], keyword()) :: Candidate.t() | nil
+  def select_top(candidates, opts \\ []) do
+    threshold = opts[:threshold] || dil_config()[:score_threshold] || 18
+
+    candidates
+    |> Enum.map(&score_candidate/1)
+    |> Enum.filter(&(&1.total_score >= threshold))
+    |> Enum.sort_by(& &1.total_score, :desc)
+    |> List.first()
+  end
+
+  # ── Candidate Identification ─────────────────────────────────────────
+
+  defp maybe_add_moduledoc_candidates(acc, %{missing_moduledocs: []}), do: acc
+
+  defp maybe_add_moduledoc_candidates(acc, %{missing_moduledocs: files}) do
+    file_list = Enum.map(files, & &1.file)
+
+    candidate = %Candidate{
+      id: "moduledoc-#{:erlang.phash2(file_list)}",
+      title: "Add missing @moduledoc to #{length(files)} module(s)",
+      category: :developer_ergonomics,
+      summary:
+        "#{length(files)} module(s) lack @moduledoc. Adding documentation improves discoverability and onboarding.",
+      evidence: Enum.map(files, &"#{&1.file}: #{&1.detail}"),
+      files: file_list,
+      alternatives: ["Add @moduledoc false for intentionally undocumented modules"],
+      risks: ["Minimal — documentation-only change"],
+      effort: effort_for_count(length(files))
+    }
+
+    [candidate | acc]
+  end
+
+  defp maybe_add_typespec_candidates(acc, %{missing_typespecs: []}), do: acc
+
+  defp maybe_add_typespec_candidates(acc, %{missing_typespecs: files}) do
+    file_list = Enum.map(files, & &1.file)
+
+    candidate = %Candidate{
+      id: "typespecs-#{:erlang.phash2(file_list)}",
+      title: "Add missing @spec to #{length(files)} module(s)",
+      category: :developer_ergonomics,
+      summary:
+        "#{length(files)} module(s) have public functions without @spec. Type specs improve Dialyzer coverage and documentation.",
+      evidence: Enum.map(files, &"#{&1.file}: #{&1.detail}"),
+      files: file_list,
+      alternatives: ["Run Dialyzer to identify most impactful missing specs first"],
+      risks: ["Minimal — type annotation only, no behavior change"],
+      effort: effort_for_count(length(files))
+    }
+
+    [candidate | acc]
+  end
+
+  defp maybe_add_todo_candidates(acc, %{todos: []}), do: acc
+
+  defp maybe_add_todo_candidates(acc, %{todos: todos}) do
+    file_list = todos |> Enum.map(& &1.file) |> Enum.uniq()
+
+    candidate = %Candidate{
+      id: "todos-#{:erlang.phash2(file_list)}",
+      title: "Address #{length(todos)} TODO comment(s)",
+      category: :reliability,
+      summary:
+        "#{length(todos)} TODO(s) found across #{length(file_list)} file(s). Resolving TODOs reduces tech debt.",
+      evidence: Enum.map(todos, &"#{&1.file}:#{&1.line}: #{&1.detail}"),
+      files: file_list,
+      alternatives: ["Triage TODOs into GitHub issues for tracking"],
+      risks: ["Varies by TODO — each needs individual assessment"],
+      effort: :m
+    }
+
+    [candidate | acc]
+  end
+
+  defp maybe_add_large_file_candidates(acc, %{large_files: []}), do: acc
+
+  defp maybe_add_large_file_candidates(acc, %{large_files: files}) do
+    file_list = Enum.map(files, & &1.file)
+
+    candidate = %Candidate{
+      id: "large-files-#{:erlang.phash2(file_list)}",
+      title: "Consider splitting #{length(files)} large file(s)",
+      category: :context_efficiency,
+      summary:
+        "#{length(files)} file(s) exceed the size threshold. Large files are harder to navigate and increase context window usage.",
+      evidence: Enum.map(files, &"#{&1.file}: #{&1.detail}"),
+      files: file_list,
+      alternatives: ["Extract helper modules", "Use module attributes to reduce boilerplate"],
+      risks: ["Refactoring may affect imports and aliases across the codebase"],
+      effort: :m
+    }
+
+    [candidate | acc]
+  end
+
+  defp maybe_add_test_gap_candidates(acc, %{test_gaps: []}), do: acc
+
+  defp maybe_add_test_gap_candidates(acc, %{test_gaps: gaps}) do
+    file_list = Enum.map(gaps, & &1.file)
+
+    candidate = %Candidate{
+      id: "test-gaps-#{:erlang.phash2(file_list)}",
+      title: "Add tests for #{length(gaps)} untested module(s)",
+      category: :reliability,
+      summary:
+        "#{length(gaps)} module(s) have no corresponding test file. Test coverage improves confidence in changes.",
+      evidence: Enum.map(gaps, &"#{&1.file}: #{&1.detail}"),
+      files: file_list,
+      alternatives: ["Prioritize modules with highest change frequency"],
+      risks: ["Minimal — additive test files only"],
+      effort: effort_for_count(length(gaps))
+    }
+
+    [candidate | acc]
+  end
+
+  # ── Scoring Heuristics ──────────────────────────────────────────────
+
+  defp score_north_star(%{category: :observability}), do: 5
+  defp score_north_star(%{category: :reliability}), do: 4
+  defp score_north_star(%{category: :developer_ergonomics}), do: 3
+  defp score_north_star(%{category: :context_efficiency}), do: 4
+
+  defp score_evidence(%{evidence: [_, _, _, _, _ | _]}), do: 5
+  defp score_evidence(%{evidence: [_, _, _ | _]}), do: 4
+  defp score_evidence(%{evidence: [_ | _]}), do: 3
+  defp score_evidence(_), do: 1
+
+  defp score_scope(%{effort: :xs}), do: 5
+  defp score_scope(%{effort: :s}), do: 4
+  defp score_scope(%{effort: :m}), do: 3
+
+  defp score_risk(%{risks: risks}) do
+    if Enum.any?(risks, &(&1 =~ ~r/[Mm]inimal/)), do: 5, else: 3
+  end
+
+  defp score_confidence(%{files: files}) when length(files) <= 3, do: 5
+  defp score_confidence(%{files: files}) when length(files) <= 10, do: 4
+  defp score_confidence(_), do: 3
+
+  # ── Helpers ─────────────────────────────────────────────────────────
+
+  defp effort_for_count(n) when n <= 3, do: :xs
+  defp effort_for_count(n) when n <= 10, do: :s
+  defp effort_for_count(_), do: :m
+
+  defp dil_config, do: Application.get_env(:lattice, :dil, [])
+
+  # Suppress unused warning for @score_dimensions — used for documentation
+  # and will be referenced in future validation logic.
+  def score_dimensions, do: @score_dimensions
+end

--- a/lib/lattice/dil/runner.ex
+++ b/lib/lattice/dil/runner.ex
@@ -3,40 +3,62 @@ defmodule Lattice.DIL.Runner do
   Orchestrator for the Daily Improvement Loop.
 
   `run/1` is the single entry point called by the cron task. It checks
-  whether DIL is enabled, runs all safety gates, and returns the result.
-
-  Future PRs will extend this to gather context, evaluate candidates,
-  format proposals, and (in live mode) create GitHub issues.
+  whether DIL is enabled, runs all safety gates, gathers context, evaluates
+  candidates, and returns the result.
   """
 
   require Logger
 
+  alias Lattice.DIL.Context
+  alias Lattice.DIL.Evaluator
   alias Lattice.DIL.Gates
 
   @type result ::
           {:ok, :disabled}
-          | {:ok, :gates_passed}
           | {:ok, {:skipped, String.t()}}
+          | {:ok, {:no_candidate, map()}}
+          | {:ok, {:candidate, map()}}
           | {:error, term()}
 
   @doc """
   Run the Daily Improvement Loop.
 
+  Options:
+  - `:skip_gates` — bypass safety gates (used by ad-hoc API endpoint)
+
   Returns:
-  - `{:ok, :disabled}` — DIL feature flag is off
-  - `{:ok, :gates_passed}` — all gates passed (future: proposal created/logged)
+  - `{:ok, :disabled}` — DIL feature flag is off (only when gates not skipped)
   - `{:ok, {:skipped, reason}}` — a safety gate blocked execution
+  - `{:ok, {:no_candidate, summary}}` — gates passed, no candidate above threshold
+  - `{:ok, {:candidate, summary}}` — top candidate identified
   - `{:error, reason}` — unexpected failure
   """
   @spec run(keyword()) :: result()
   def run(opts \\ []) do
-    _ = opts
+    skip_gates = Keyword.get(opts, :skip_gates, false)
 
+    with :ok <- check_gates(skip_gates) do
+      run_pipeline()
+    end
+  rescue
+    error ->
+      Logger.error("DIL: unexpected error — #{inspect(error)}")
+      {:error, error}
+  end
+
+  # ── Private ──────────────────────────────────────────────────────────
+
+  defp check_gates(true = _skip) do
+    Logger.info("DIL: gates skipped (ad-hoc run)")
+    :ok
+  end
+
+  defp check_gates(false) do
     if Gates.enabled?() do
       case Gates.check_all() do
         {:ok, :gates_passed} ->
           Logger.info("DIL: all gates passed")
-          {:ok, :gates_passed}
+          :ok
 
         {:skip, reason} ->
           Logger.info("DIL: skipped — #{reason}")
@@ -46,9 +68,47 @@ defmodule Lattice.DIL.Runner do
       Logger.info("DIL: disabled, skipping")
       {:ok, :disabled}
     end
-  rescue
-    error ->
-      Logger.error("DIL: unexpected error — #{inspect(error)}")
-      {:error, error}
+  end
+
+  defp run_pipeline do
+    Logger.info("DIL: gathering context")
+    context = Context.gather()
+
+    signal_counts = %{
+      todos: length(context.todos),
+      missing_moduledocs: length(context.missing_moduledocs),
+      missing_typespecs: length(context.missing_typespecs),
+      large_files: length(context.large_files),
+      test_gaps: length(context.test_gaps),
+      recent_issues: length(context.recent_issues)
+    }
+
+    Logger.info("DIL: context gathered — #{inspect(signal_counts)}")
+
+    candidates = Evaluator.identify_candidates(context)
+    Logger.info("DIL: #{length(candidates)} candidate(s) identified")
+
+    case Evaluator.select_top(candidates) do
+      nil ->
+        Logger.info("DIL: no candidate above threshold")
+        {:ok, {:no_candidate, %{signal_counts: signal_counts, candidates: length(candidates)}}}
+
+      top ->
+        Logger.info(
+          "DIL: top candidate — #{top.title} (score: #{top.total_score}/25, category: #{top.category})"
+        )
+
+        {:ok,
+         {:candidate,
+          %{
+            title: top.title,
+            category: top.category,
+            total_score: top.total_score,
+            scores: top.scores,
+            evidence_count: length(top.evidence),
+            files: top.files,
+            signal_counts: signal_counts
+          }}}
+    end
   end
 end

--- a/lib/lattice_web/controllers/api/dil_controller.ex
+++ b/lib/lattice_web/controllers/api/dil_controller.ex
@@ -1,0 +1,69 @@
+defmodule LatticeWeb.Api.DilController do
+  @moduledoc """
+  API controller for ad-hoc Daily Improvement Loop runs.
+
+  Triggers the DIL pipeline on demand, bypassing the cron schedule and
+  the enabled/disabled gate. Other safety gates (open issue, cooldown,
+  rejection cooldown) are still checked unless `skip_gates` is true.
+  """
+
+  use LatticeWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Lattice.DIL.Runner
+
+  tags(["DIL"])
+  security([%{"BearerAuth" => []}])
+
+  operation(:run,
+    summary: "Trigger DIL run",
+    description:
+      "Runs the Daily Improvement Loop ad-hoc. Pass `skip_gates: true` in the body to bypass safety gates.",
+    request_body:
+      {"DIL run options", "application/json",
+       %OpenApiSpex.Schema{
+         type: :object,
+         properties: %{
+           skip_gates: %OpenApiSpex.Schema{type: :boolean, default: false}
+         }
+       }, required: false},
+    responses: [
+      ok: {"DIL result", "application/json", %OpenApiSpex.Schema{type: :object}},
+      unauthorized: {"Unauthorized", "application/json", LatticeWeb.Schemas.UnauthorizedResponse}
+    ]
+  )
+
+  @doc """
+  POST /api/dil/run — trigger an ad-hoc DIL run.
+  """
+  def run(conn, params) do
+    skip_gates = params["skip_gates"] == true
+
+    case Runner.run(skip_gates: skip_gates) do
+      {:ok, :disabled} ->
+        conn
+        |> put_status(200)
+        |> json(%{data: %{status: "disabled"}, timestamp: DateTime.utc_now()})
+
+      {:ok, {:skipped, reason}} ->
+        conn
+        |> put_status(200)
+        |> json(%{data: %{status: "skipped", reason: reason}, timestamp: DateTime.utc_now()})
+
+      {:ok, {:no_candidate, summary}} ->
+        conn
+        |> put_status(200)
+        |> json(%{data: Map.put(summary, :status, "no_candidate"), timestamp: DateTime.utc_now()})
+
+      {:ok, {:candidate, summary}} ->
+        conn
+        |> put_status(200)
+        |> json(%{data: Map.put(summary, :status, "candidate"), timestamp: DateTime.utc_now()})
+
+      {:error, reason} ->
+        conn
+        |> put_status(500)
+        |> json(%{error: "DIL run failed: #{inspect(reason)}", code: "DIL_ERROR"})
+    end
+  end
+end

--- a/lib/lattice_web/router.ex
+++ b/lib/lattice_web/router.ex
@@ -145,6 +145,8 @@ defmodule LatticeWeb.Router do
     delete "/projects/:id", ProjectController, :delete
 
     get "/search", SearchController, :index
+
+    post "/dil/run", DilController, :run
   end
 
   # Authenticated LiveView routes

--- a/test/lattice/dil/context_test.exs
+++ b/test/lattice/dil/context_test.exs
@@ -1,0 +1,74 @@
+defmodule Lattice.DIL.ContextTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :unit
+
+  import Mox
+
+  alias Lattice.DIL.Context
+
+  setup :verify_on_exit!
+
+  describe "gather/0" do
+    test "returns a Context struct with signals from the repo" do
+      # Mock GitHub for recent issues
+      Lattice.Capabilities.MockGitHub
+      |> expect(:list_issues, fn opts ->
+        assert opts[:state] == "closed"
+        {:ok, [%{"number" => 1, "title" => "Fix something"}]}
+      end)
+
+      ctx = Context.gather()
+
+      assert %Context{} = ctx
+      assert is_list(ctx.todos)
+      assert is_list(ctx.missing_moduledocs)
+      assert is_list(ctx.missing_typespecs)
+      assert is_list(ctx.large_files)
+      assert is_list(ctx.test_gaps)
+      assert [%{"number" => 1}] = ctx.recent_issues
+    end
+
+    test "handles GitHub errors gracefully" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:list_issues, fn _opts -> {:error, :api_error} end)
+
+      ctx = Context.gather()
+
+      assert ctx.recent_issues == []
+    end
+
+    test "detects TODOs in lib/ files" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:list_issues, fn _opts -> {:ok, []} end)
+
+      ctx = Context.gather()
+
+      # Our codebase may or may not have TODOs — just verify the structure
+      Enum.each(ctx.todos, fn todo ->
+        assert Map.has_key?(todo, :file)
+        assert Map.has_key?(todo, :line)
+        assert Map.has_key?(todo, :detail)
+      end)
+    end
+
+    test "signals have expected shape" do
+      Lattice.Capabilities.MockGitHub
+      |> expect(:list_issues, fn _opts -> {:ok, []} end)
+
+      ctx = Context.gather()
+
+      for signal_list <- [
+            ctx.missing_moduledocs,
+            ctx.missing_typespecs,
+            ctx.large_files,
+            ctx.test_gaps
+          ] do
+        Enum.each(signal_list, fn signal ->
+          assert Map.has_key?(signal, :file)
+          assert Map.has_key?(signal, :detail)
+        end)
+      end
+    end
+  end
+end

--- a/test/lattice/dil/evaluator_test.exs
+++ b/test/lattice/dil/evaluator_test.exs
@@ -1,0 +1,192 @@
+defmodule Lattice.DIL.EvaluatorTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.DIL.Candidate
+  alias Lattice.DIL.Context
+  alias Lattice.DIL.Evaluator
+
+  describe "identify_candidates/1" do
+    test "returns empty list for empty context" do
+      ctx = %Context{}
+      assert Evaluator.identify_candidates(ctx) == []
+    end
+
+    test "identifies moduledoc candidates" do
+      ctx = %Context{
+        missing_moduledocs: [
+          %{file: "lib/foo.ex", line: nil, detail: "missing @moduledoc"}
+        ]
+      }
+
+      candidates = Evaluator.identify_candidates(ctx)
+      assert length(candidates) == 1
+      assert hd(candidates).category == :developer_ergonomics
+      assert hd(candidates).title =~ "moduledoc"
+    end
+
+    test "identifies typespec candidates" do
+      ctx = %Context{
+        missing_typespecs: [
+          %{file: "lib/bar.ex", line: nil, detail: "public functions without @spec"}
+        ]
+      }
+
+      candidates = Evaluator.identify_candidates(ctx)
+      assert length(candidates) == 1
+      assert hd(candidates).category == :developer_ergonomics
+      assert hd(candidates).title =~ "@spec"
+    end
+
+    test "identifies TODO candidates" do
+      ctx = %Context{
+        todos: [
+          %{file: "lib/baz.ex", line: 42, detail: "# TODO: fix this"}
+        ]
+      }
+
+      candidates = Evaluator.identify_candidates(ctx)
+      assert length(candidates) == 1
+      assert hd(candidates).category == :reliability
+    end
+
+    test "identifies large file candidates" do
+      ctx = %Context{
+        large_files: [
+          %{file: "lib/big.ex", line: nil, detail: "500 lines"}
+        ]
+      }
+
+      candidates = Evaluator.identify_candidates(ctx)
+      assert length(candidates) == 1
+      assert hd(candidates).category == :context_efficiency
+    end
+
+    test "identifies test gap candidates" do
+      ctx = %Context{
+        test_gaps: [
+          %{file: "lib/untested.ex", line: nil, detail: "no corresponding test file"}
+        ]
+      }
+
+      candidates = Evaluator.identify_candidates(ctx)
+      assert length(candidates) == 1
+      assert hd(candidates).category == :reliability
+    end
+
+    test "identifies multiple candidate types from rich context" do
+      ctx = %Context{
+        missing_moduledocs: [%{file: "lib/a.ex", line: nil, detail: "missing @moduledoc"}],
+        todos: [%{file: "lib/b.ex", line: 1, detail: "# TODO: fix"}],
+        test_gaps: [%{file: "lib/c.ex", line: nil, detail: "no corresponding test file"}]
+      }
+
+      candidates = Evaluator.identify_candidates(ctx)
+      assert length(candidates) == 3
+    end
+  end
+
+  describe "score_candidate/1" do
+    test "scores a candidate with all five dimensions" do
+      candidate = %Candidate{
+        id: "test-1",
+        title: "Add missing @moduledoc",
+        category: :developer_ergonomics,
+        summary: "Test candidate",
+        evidence: [
+          "file.ex: missing @moduledoc",
+          "other.ex: missing @moduledoc",
+          "third.ex: missing @moduledoc"
+        ],
+        files: ["lib/file.ex", "lib/other.ex"],
+        risks: ["Minimal — documentation-only change"],
+        effort: :xs
+      }
+
+      scored = Evaluator.score_candidate(candidate)
+
+      assert is_map(scored.scores)
+      assert Map.has_key?(scored.scores, :north_star_alignment)
+      assert Map.has_key?(scored.scores, :evidence_strength)
+      assert Map.has_key?(scored.scores, :scope_clarity)
+      assert Map.has_key?(scored.scores, :risk_level)
+      assert Map.has_key?(scored.scores, :implementation_confidence)
+      assert scored.total_score > 0
+      assert scored.total_score == Enum.sum(Map.values(scored.scores))
+    end
+
+    test "higher evidence count yields higher evidence score" do
+      low_evidence = %Candidate{
+        id: "low",
+        title: "Low",
+        category: :reliability,
+        summary: "s",
+        evidence: ["one"],
+        risks: ["Minimal"]
+      }
+
+      high_evidence = %Candidate{
+        id: "high",
+        title: "High",
+        category: :reliability,
+        summary: "s",
+        evidence: ["one", "two", "three", "four", "five"],
+        risks: ["Minimal"]
+      }
+
+      low_scored = Evaluator.score_candidate(low_evidence)
+      high_scored = Evaluator.score_candidate(high_evidence)
+
+      assert high_scored.scores.evidence_strength >= low_scored.scores.evidence_strength
+    end
+  end
+
+  describe "select_top/2" do
+    test "returns nil when no candidates" do
+      assert Evaluator.select_top([]) == nil
+    end
+
+    test "returns nil when no candidate above threshold" do
+      candidate = %Candidate{
+        id: "weak",
+        title: "Weak candidate",
+        category: :developer_ergonomics,
+        summary: "s",
+        evidence: ["one"],
+        files: Enum.map(1..20, &"lib/file#{&1}.ex"),
+        risks: ["High risk of breakage"],
+        effort: :m
+      }
+
+      assert Evaluator.select_top([candidate], threshold: 25) == nil
+    end
+
+    test "returns highest-scoring candidate above threshold" do
+      strong = %Candidate{
+        id: "strong",
+        title: "Strong candidate",
+        category: :observability,
+        summary: "s",
+        evidence: Enum.map(1..5, &"evidence #{&1}"),
+        files: ["lib/one.ex"],
+        risks: ["Minimal"],
+        effort: :xs
+      }
+
+      weak = %Candidate{
+        id: "weak",
+        title: "Weak candidate",
+        category: :developer_ergonomics,
+        summary: "s",
+        evidence: ["one"],
+        files: Enum.map(1..20, &"lib/file#{&1}.ex"),
+        risks: ["Significant refactoring required"],
+        effort: :m
+      }
+
+      result = Evaluator.select_top([weak, strong], threshold: 15)
+      assert result.id == "strong"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Context module scans `lib/` and `test/` for code signals: TODOs, missing `@moduledoc`, missing `@spec`, large files, test gaps
- Evaluator maps signals to scored candidates in 4 categories (observability, context_efficiency, reliability, developer_ergonomics)
- Five-dimension scoring (north_star_alignment, evidence_strength, scope_clarity, risk_level, implementation_confidence) with configurable threshold (default 18/25)
- Runner now executes full pipeline: gates → context → evaluate → select top candidate
- **New: `POST /api/dil/run`** endpoint for ad-hoc triggering with optional `skip_gates` parameter

## Test plan
- [x] 37 unit tests pass (gates + runner + context + evaluator)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [ ] CI passes
- [ ] Deploy and test `POST /api/dil/run` with `skip_gates: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)