### PR TITLE
Add DIL proposal formatting and dry-run output

### DIFF
--- a/lib/lattice/dil/proposal.ex
+++ b/lib/lattice/dil/proposal.ex
@@ -1,0 +1,154 @@
+defmodule Lattice.DIL.Proposal do
+  @moduledoc """
+  Formats a scored `%Candidate{}` into a GitHub issue body matching
+  the DIL spec template: 8 sections, `dil-proposal` label, research-backed tag.
+  """
+
+  alias Lattice.DIL.Candidate
+
+  @doc """
+  Format the issue title from a candidate.
+
+  Returns a string like `"[DIL] Improve <subsystem> via <change>"`.
+  """
+  @spec format_title(Candidate.t()) :: String.t()
+  def format_title(%Candidate{title: title}) do
+    "[DIL] #{title}"
+  end
+
+  @doc """
+  Format the full issue body with all 8 DIL spec sections.
+  """
+  @spec format_body(Candidate.t()) :: String.t()
+  def format_body(%Candidate{} = candidate) do
+    [
+      summary_section(candidate),
+      why_section(candidate),
+      evidence_section(candidate),
+      proposed_change_section(candidate),
+      alternatives_section(candidate),
+      risks_section(candidate),
+      effort_section(candidate),
+      confidence_section(candidate)
+    ]
+    |> Enum.join("\n\n---\n\n")
+  end
+
+  @doc """
+  Returns the standard DIL proposal labels.
+  """
+  @spec labels() :: [String.t()]
+  def labels, do: ["dil-proposal", "research-backed"]
+
+  # ── Section Builders ─────────────────────────────────────────────────
+
+  defp summary_section(%{summary: summary}) do
+    """
+    #### 1. Summary
+
+    #{summary}\
+    """
+  end
+
+  defp why_section(%{category: category}) do
+    mapping = %{
+      observability:
+        "Improves fleet visibility and operational awareness — core to Lattice's NOC-glass mission.",
+      context_efficiency:
+        "Reduces context window waste and prompt overhead — directly impacts sprite effectiveness.",
+      reliability:
+        "Strengthens system reliability and reduces failure modes — essential for autonomous operation.",
+      developer_ergonomics:
+        "Improves developer experience and codebase navigability — accelerates contribution velocity."
+    }
+
+    """
+    #### 2. Why This Matters
+
+    #{Map.get(mapping, category, "Aligns with Lattice's core mission.")}\
+    """
+  end
+
+  defp evidence_section(%{evidence: evidence}) do
+    items = Enum.map_join(evidence, "\n", &"- `#{&1}`")
+
+    """
+    #### 3. Evidence
+
+    #{items}\
+    """
+  end
+
+  defp proposed_change_section(%{files: files, summary: summary}) do
+    file_list = Enum.map_join(files, "\n", &"- `#{&1}`")
+
+    """
+    #### 4. Proposed Change
+
+    #{summary}
+
+    **Files to modify:**
+    #{file_list}\
+    """
+  end
+
+  defp alternatives_section(%{alternatives: alternatives}) do
+    items = Enum.map_join(alternatives, "\n", &"- #{&1}")
+
+    """
+    #### 5. Alternatives Considered
+
+    #{items}\
+    """
+  end
+
+  defp risks_section(%{risks: risks}) do
+    items = Enum.map_join(risks, "\n", &"- #{&1}")
+
+    """
+    #### 6. Risks
+
+    #{items}\
+    """
+  end
+
+  defp effort_section(%{effort: effort}) do
+    label =
+      case effort do
+        :xs -> "XS (1 hr or less)"
+        :s -> "S (1 day or less)"
+        :m -> "M (3 days or less)"
+      end
+
+    """
+    #### 7. Effort Estimate
+
+    #{label}\
+    """
+  end
+
+  defp confidence_section(%{total_score: total, scores: scores}) do
+    score_details =
+      if scores do
+        [
+          "north_star_alignment: #{scores.north_star_alignment}/5",
+          "evidence_strength: #{scores.evidence_strength}/5",
+          "scope_clarity: #{scores.scope_clarity}/5",
+          "risk_level: #{scores.risk_level}/5",
+          "implementation_confidence: #{scores.implementation_confidence}/5"
+        ]
+        |> Enum.map_join("\n", &"  - #{&1}")
+      else
+        ""
+      end
+
+    """
+    #### 8. Confidence Level
+
+    > Confidence: High (#{total}/25)
+
+    Score breakdown:
+    #{score_details}\
+    """
+  end
+end

--- a/test/lattice/dil/proposal_test.exs
+++ b/test/lattice/dil/proposal_test.exs
@@ -1,0 +1,100 @@
+defmodule Lattice.DIL.ProposalTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :unit
+
+  alias Lattice.DIL.Candidate
+  alias Lattice.DIL.Proposal
+
+  @candidate %Candidate{
+    id: "test-1",
+    title: "Add missing @moduledoc to 3 module(s)",
+    category: :developer_ergonomics,
+    summary: "3 modules lack @moduledoc. Adding documentation improves discoverability.",
+    evidence: [
+      "lib/foo.ex: missing @moduledoc",
+      "lib/bar.ex: missing @moduledoc",
+      "lib/baz.ex: missing @moduledoc"
+    ],
+    files: ["lib/foo.ex", "lib/bar.ex", "lib/baz.ex"],
+    scores: %{
+      north_star_alignment: 3,
+      evidence_strength: 4,
+      scope_clarity: 5,
+      risk_level: 5,
+      implementation_confidence: 5
+    },
+    total_score: 22,
+    alternatives: ["Add @moduledoc false for intentionally undocumented modules"],
+    risks: ["Minimal — documentation-only change"],
+    effort: :xs
+  }
+
+  describe "format_title/1" do
+    test "prefixes with [DIL]" do
+      title = Proposal.format_title(@candidate)
+      assert title == "[DIL] Add missing @moduledoc to 3 module(s)"
+    end
+  end
+
+  describe "format_body/1" do
+    setup do
+      %{body: Proposal.format_body(@candidate)}
+    end
+
+    test "contains all 8 sections", %{body: body} do
+      assert body =~ "#### 1. Summary"
+      assert body =~ "#### 2. Why This Matters"
+      assert body =~ "#### 3. Evidence"
+      assert body =~ "#### 4. Proposed Change"
+      assert body =~ "#### 5. Alternatives Considered"
+      assert body =~ "#### 6. Risks"
+      assert body =~ "#### 7. Effort Estimate"
+      assert body =~ "#### 8. Confidence Level"
+    end
+
+    test "includes summary text", %{body: body} do
+      assert body =~ "3 modules lack @moduledoc"
+    end
+
+    test "includes evidence items", %{body: body} do
+      assert body =~ "lib/foo.ex: missing @moduledoc"
+      assert body =~ "lib/bar.ex: missing @moduledoc"
+      assert body =~ "lib/baz.ex: missing @moduledoc"
+    end
+
+    test "includes files to modify", %{body: body} do
+      assert body =~ "`lib/foo.ex`"
+      assert body =~ "`lib/bar.ex`"
+      assert body =~ "`lib/baz.ex`"
+    end
+
+    test "includes alternatives", %{body: body} do
+      assert body =~ "@moduledoc false"
+    end
+
+    test "includes risks", %{body: body} do
+      assert body =~ "Minimal"
+    end
+
+    test "includes effort estimate", %{body: body} do
+      assert body =~ "XS (1 hr or less)"
+    end
+
+    test "includes confidence score", %{body: body} do
+      assert body =~ "22/25"
+    end
+
+    test "includes score breakdown", %{body: body} do
+      assert body =~ "north_star_alignment: 3/5"
+      assert body =~ "evidence_strength: 4/5"
+      assert body =~ "scope_clarity: 5/5"
+    end
+  end
+
+  describe "labels/0" do
+    test "returns dil-proposal and research-backed" do
+      assert Proposal.labels() == ["dil-proposal", "research-backed"]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Proposal module formats scored `%Candidate{}` into GitHub issue bodies with all 8 DIL spec sections
- Title format: `[DIL] <candidate title>`
- Labels: `dil-proposal`, `research-backed`
- Runner now formats proposals and logs full issue body at `:info` in dry-run mode
- Mode awareness added — runner reads `:mode` from config (default `:dry_run`)

## Test plan
- [x] 48 unit tests pass (gates + runner + context + evaluator + proposal)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)