### PR TITLE
Add DIL live mode with GitHub issue creation

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -47,6 +47,17 @@ config :lattice, :resources,
   fly_app: System.get_env("FLY_APP"),
   sprites_api_base: System.get_env("SPRITES_API_BASE")
 
+# Daily Improvement Loop — enabled + mode from env vars
+if System.get_env("DIL_ENABLED") == "true" do
+  dil_mode =
+    case System.get_env("DIL_MODE", "dry_run") do
+      "live" -> :live
+      _ -> :dry_run
+    end
+
+  config :lattice, :dil, enabled: true, mode: dil_mode
+end
+
 # Capability auto-selection: use live implementations when credentials are present
 capabilities = Application.get_env(:lattice, :capabilities, [])
 

--- a/lib/lattice/safety/classifier.ex
+++ b/lib/lattice/safety/classifier.ex
@@ -84,7 +84,10 @@ defmodule Lattice.Safety.Classifier do
     {:fly, :machine_status} => :safe,
     {:fly, :deploy} => :dangerous,
     # Secret Store
-    {:secret_store, :get_secret} => :safe
+    {:secret_store, :get_secret} => :safe,
+    # DIL (Daily Improvement Loop)
+    {:dil, :gather_context} => :safe,
+    {:dil, :create_proposal} => :controlled
   }
 
   @doc """


### PR DESCRIPTION
## Summary
- Runner now supports `:live` mode: gates → context → evaluate → score → format → **create real GitHub issue**
- Audit logging via `Safety.Audit.log/6` for both context gathering (`:safe`) and proposal creation (`:controlled`)
- Safety classifier registers `{:dil, :gather_context} => :safe` and `{:dil, :create_proposal} => :controlled`
- Runtime config reads `DIL_ENABLED` and `DIL_MODE` env vars (defaults: disabled, dry_run)
- Live mode returns `issue_number` in the response summary

## Test plan
- [x] 50 unit tests pass (all DIL modules)
- [x] 49 classifier tests pass (including new DIL entries)
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [ ] CI passes
- [ ] Deploy and set `DIL_ENABLED=true`, `DIL_MODE=dry_run` to validate cron integration
- [ ] Test `POST /api/dil/run` with `skip_gates: true` to see full pipeline output

🤖 Generated with [Claude Code](https://claude.com/claude-code)