### PR TITLE
Route ambient classification through sprite Pro account

### DIFF
--- a/lib/lattice/ambient/claude.ex
+++ b/lib/lattice/ambient/claude.ex
@@ -25,6 +25,16 @@ defmodule Lattice.Ambient.Claude do
   @type result :: {:ok, decision(), String.t() | nil} | {:error, term()}
 
   @doc """
+  Returns whether an Anthropic API key is configured and non-empty.
+  Used to decide whether to classify via the API or via a sprite.
+  """
+  @spec api_key_configured?() :: boolean()
+  def api_key_configured? do
+    key = resolve_api_key()
+    not is_nil(key) and key != ""
+  end
+
+  @doc """
   Classify a GitHub event and optionally generate a response.
 
   Returns `{:ok, :respond, "response text"}`, `{:ok, :react, nil}`,

--- a/lib/lattice/ambient/responder.ex
+++ b/lib/lattice/ambient/responder.ex
@@ -120,8 +120,18 @@ defmodule Lattice.Ambient.Responder do
 
     # Step 2: Fetch thread context and classify
     thread_context = fetch_thread_context(event)
-    classification = Claude.classify(event, thread_context)
+    classification = classify_event(event, thread_context)
     handle_classification(classification, event, thread_context, state)
+  end
+
+  # Routes classification through the API when an API key is available,
+  # otherwise falls back to running classification on the ambient sprite.
+  defp classify_event(event, thread_context) do
+    if Claude.api_key_configured?() do
+      Claude.classify(event, thread_context)
+    else
+      SpriteDelegate.classify(event, thread_context)
+    end
   end
 
   # ── Private: Classification Dispatch ───────────────────────────


### PR DESCRIPTION
## Summary
- When no `ANTHROPIC_API_KEY` is set, ambient event classification now runs via `claude -p` on the ambient sprite using OAuth/Pro credentials
- Adds `Claude.api_key_configured?/0` to check key availability
- Adds `SpriteDelegate.classify/2` with structured JSON output parsing and regex fallback
- Responder routes through `classify_event/2` which picks API or sprite path

## Motivation
API key credits are depleted, so classification fails with "credit balance too low" and no events reach sprites. This routes all Claude usage through the Pro account.

## Test plan
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format --check-formatted` — clean
- [x] `mix test --only unit` — 1935 tests, 0 failures
- [ ] Deploy, unset `ANTHROPIC_API_KEY`, trigger ambient event, verify sprite-based classification in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)