### PR TITLE
Remove unsupported --max-tokens flag from classification

### DIFF
--- a/lib/lattice/ambient/sprite_delegate.ex
+++ b/lib/lattice/ambient/sprite_delegate.ex
@@ -751,7 +751,7 @@ defmodule Lattice.Ambient.SpriteDelegate do
     case FileWriter.write_file(sprite_name, prompt, "/tmp/classify_prompt.txt") do
       :ok ->
         claude_cmd =
-          "#{claude_env_prefix()}claude -p \"$(cat /tmp/classify_prompt.txt)\" --model claude-sonnet-4-20250514 --output-format json --max-tokens 200 2>&1"
+          "#{claude_env_prefix()}claude -p \"$(cat /tmp/classify_prompt.txt)\" --model claude-sonnet-4-20250514 --output-format json 2>&1"
 
         case exec_with_retry(sprite_name, claude_cmd) do
           {:ok, %{output: output, exit_code: 0}} ->


### PR DESCRIPTION
## Summary
- The `claude` CLI doesn't support `--max-tokens`, causing every sprite-based classification to fail with `error: unknown option '--max-tokens'` and default to `:ignore`
- Removes the flag so classification actually runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)