### PR TITLE
Close issue when implementation finds no changes needed

### DIFF
--- a/test/lattice/ambient/responder_test.exs
+++ b/test/lattice/ambient/responder_test.exs
@@ -314,13 +314,16 @@ defmodule Lattice.Ambient.ResponderTest do
       Process.sleep(100)
     end
 
-    test "posts helpful comment when no changes produced" do
+    test "closes issue when no changes produced" do
       Lattice.Capabilities.MockGitHub
       |> expect(:delete_comment_reaction, fn 600, 42 -> :ok end)
       |> expect(:create_comment, fn 99, body ->
-        assert body =~ "couldn't produce any code changes"
+        assert body =~ "already resolved"
         assert body =~ "lattice:ambient:implement"
         {:ok, %{id: 1}}
+      end)
+      |> expect(:update_issue, fn 99, %{state: "closed"} ->
+        {:ok, %{number: 99}}
       end)
 
       ref = make_ref()
@@ -481,11 +484,11 @@ defmodule Lattice.Ambient.ResponderTest do
       Process.sleep(100)
     end
 
-    test "posts error comment on PR surface for implementation failures" do
+    test "posts comment on PR surface when no changes produced" do
       Lattice.Capabilities.MockGitHub
       |> expect(:delete_comment_reaction, fn 600, 42 -> :ok end)
       |> expect(:create_comment, fn 203, body ->
-        assert body =~ "couldn't produce any code changes"
+        assert body =~ "already resolved"
         assert body =~ "lattice:ambient:implement"
         {:ok, %{id: 1}}
       end)


### PR DESCRIPTION
## Summary
- When the sprite reports `no_changes`, the bot now comments "already resolved" and closes the issue
- For non-issue surfaces (PR comments), it posts the comment without closing
- Fixes the unhelpful "couldn't produce any code changes" message from [#223](https://github.com/plattegruber/lattice/issues/223#issuecomment-3963633795)

## Context
The DIL created issue #223 (add `@moduledoc` to `repo.ex`) but PR #222 had already merged that fix. When the user said "implement it", the sprite correctly found nothing to do, but the bot's response was vague and left the issue open.

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix credo --strict` passes
- [x] All 18 responder tests pass (updated for new behavior)
- [x] `mix format --check-formatted` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)